### PR TITLE
feat: add copy suggestions to clipboard button #3

### DIFF
--- a/resume-frontend/src/App.tsx
+++ b/resume-frontend/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
   const [score, setScore] = useState<number | null>(null);
   const [skills, setSkills] = useState<string[]>([]);
   const [suggestions, setSuggestions] = useState<string[]>([]);
-
+  const [copied, setCopied] = useState(false);
 
   const uploadResume = async () => {
 
@@ -43,6 +43,24 @@ function App() {
     }
 
   };
+  const copySuggestionsToClipboard = () => {
+  if (suggestions.length === 0) return;
+
+  // Formats the suggestions array cleanly with bullet points
+  const plainTextSuggestions = suggestions
+    .map((s) => `• ${s}`)
+    .join("\n");
+
+  navigator.clipboard.writeText(plainTextSuggestions)
+    .then(() => {
+      setCopied(true);
+      // Acceptance Criteria: Brief "Copied!" confirmation shown after click
+      setTimeout(() => setCopied(false), 2000); 
+    })
+    .catch((err) => {
+      console.error("Failed to copy text: ", err);
+    });
+};
 
   return (
 
@@ -116,19 +134,37 @@ function App() {
 
             </div>
 
-            {/* SUGGESTIONS */}
+          {/* SUGGESTIONS */}
+<div className="suggestion-box" style={{ position: "relative" }}>
+  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" }}>
+    <h4 style={{ margin: 0 }}>💡 Suggestions</h4>
+    
+    {suggestions.length > 0 && (
+      <button
+        onClick={copySuggestionsToClipboard}
+        style={{
+          backgroundColor: copied ? "#22c55e" : "#3b82f6",
+          color: "white",
+          border: "none",
+          padding: "6px 12px",
+          borderRadius: "6px",
+          fontSize: "12px",
+          fontWeight: "6px",
+          cursor: "pointer",
+          transition: "background-color 0.2s ease"
+        }}
+      >
+        {copied ? "✅ Copied!" : "📋 Copy Suggestions"}
+      </button>
+    )}
+  </div>
 
-            <div className="suggestion-box">
-
-              <h4>💡 Suggestions</h4>
-
-              {suggestions.map((s, i) => (
-                <div key={i} className="suggestion-item">
-                  📌 {s}
-                </div>
-              ))}
-
-            </div>
+  {suggestions.map((s, i) => (
+    <div key={i} className="suggestion-item">
+      📌 {s}
+    </div>
+  ))}
+</div> 
 
           </>
 

--- a/resume-frontend/src/App.tsx
+++ b/resume-frontend/src/App.tsx
@@ -3,23 +3,22 @@ import axios from "axios";
 import "./index.css";
 
 function App() {
-
   const [loading, setLoading] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [score, setScore] = useState<number | null>(null);
   const [skills, setSkills] = useState<string[]>([]);
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  
+  // Issue #3: Clipboard copy state tracking
   const [copied, setCopied] = useState(false);
 
   const uploadResume = async () => {
-
     if (!file) {
       alert("Please upload resume");
       return;
     }
 
     try {
-
       setLoading(true);   
 
       const formData = new FormData();
@@ -33,44 +32,34 @@ function App() {
       setScore(res.data.score);
       setSkills(res.data.skills_found);
       setSuggestions(res.data.suggestions);
-
       setLoading(false);   
-
     } catch (error) {
       console.error(error);
       alert("Upload failed");
       setLoading(false);   
     }
-
   };
+
+  // Issue #3: Format list items to plain text clipboard list
   const copySuggestionsToClipboard = () => {
-  if (suggestions.length === 0) return;
-
-  // Formats the suggestions array cleanly with bullet points
-  const plainTextSuggestions = suggestions
-    .map((s) => `• ${s}`)
-    .join("\n");
-
-  navigator.clipboard.writeText(plainTextSuggestions)
-    .then(() => {
-      setCopied(true);
-      // Acceptance Criteria: Brief "Copied!" confirmation shown after click
-      setTimeout(() => setCopied(false), 2000); 
-    })
-    .catch((err) => {
-      console.error("Failed to copy text: ", err);
-    });
-};
+    if (suggestions.length === 0) return;
+    const plainTextSuggestions = suggestions.map((s) => `• ${s}`).join("\n");
+    navigator.clipboard.writeText(plainTextSuggestions)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch((err) => {
+        console.error("Failed to copy text: ", err);
+      });
+  };
 
   return (
-
     <div className="container mt-5">
-
       <div className="main-card text-center">
-
         <h1 className="mb-4">🚀 AI Resume Analyzer</h1>
+        
         <div className="upload-box mb-3">
-
           <input
             type="file"
             id="fileUpload"
@@ -81,97 +70,75 @@ function App() {
               }
             }}
           />
-
           <label htmlFor="fileUpload" className="upload-label">
             📄 {file ? file.name : "Drag & Drop Resume or Click to Upload"}
           </label>
-
         </div>
 
-        <button
-          className="analyze-btn"
-          onClick={uploadResume}
-        >
+        <button className="analyze-btn" onClick={uploadResume}>
           {loading ? "⏳ Analyzing..." : "🚀 Analyze Resume"}
         </button>
 
         {score !== null && (
-
           <>
-
             {/* SCORE METER */}
-
             <div className="score-section">
-
               <div
                 className="score-circle mb-3"
                 style={{ "--score": `${score * 3.6}deg` } as React.CSSProperties}
               >
                 {score}%
               </div>
-
               <h3>ATS Resume Score</h3>
-
               <h5 className="analysis-done">
                 ✅ Resume Analysis Complete
               </h5>
-
             </div>
 
             {/* SKILLS */}
-
             <div className="mt-4">
-
               <h4>Skills Found</h4>
-
               {skills.length === 0 && <p>No skills detected</p>}
-
               {skills.map((skill: string, i: number) => (
                 <span key={i} className="skill-badge">
                   {skill}
                 </span>
               ))}
-
             </div>
 
-          {/* SUGGESTIONS */}
-<div className="suggestion-box" style={{ position: "relative" }}>
-  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" }}>
-    <h4 style={{ margin: 0 }}>💡 Suggestions</h4>
-    
-    {suggestions.length > 0 && (
-      <button
-        onClick={copySuggestionsToClipboard}
-        style={{
-          backgroundColor: copied ? "#22c55e" : "#3b82f6",
-          color: "white",
-          border: "none",
-          padding: "6px 12px",
-          borderRadius: "6px",
-          fontSize: "12px",
-          fontWeight: "6px",
-          cursor: "pointer",
-          transition: "background-color 0.2s ease"
-        }}
-      >
-        {copied ? "✅ Copied!" : "📋 Copy Suggestions"}
-      </button>
-    )}
-  </div>
+            {/* SUGGESTIONS WITH COPY BUTTON */}
+            <div className="suggestion-box">
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" }}>
+                <h4 style={{ margin: 0 }}>💡 Suggestions</h4>
+                {suggestions.length > 0 && (
+                  <button
+                    onClick={copySuggestionsToClipboard}
+                    style={{
+                      backgroundColor: copied ? "#22c55e" : "#3b82f6",
+                      color: "white",
+                      border: "none",
+                      padding: "6px 12px",
+                      borderRadius: "6px",
+                      fontSize: "12px",
+                      fontWeight: "600",
+                      cursor: "pointer",
+                      transition: "background-color 0.2s ease"
+                    }}
+                  >
+                    {copied ? "✅ Copied!" : "📋 Copy Suggestions"}
+                  </button>
+                )}
+              </div>
 
-  {suggestions.map((s, i) => (
-    <div key={i} className="suggestion-item">
-      📌 {s}
-    </div>
-  ))}
-</div> 
-
+              {suggestions.map((s, i) => (
+                <div key={i} className="suggestion-item">
+                  📌 {s}
+                </div>
+              ))}
+            </div>
           </>
-
         )}
-
       </div>
-
     </div>
   );
 }


### PR DESCRIPTION
### Description
This PR addresses Issue #3 by adding a "Copy Suggestions" button to the results dashboard screen, allowing users to quickly copy plain text improvement recommendations to their clipboard in one click.

### Changes Implemented
* **Clipboard API Integration:** Added a handler using `navigator.clipboard.writeText` to extract and format the array of improvement items into a clean plain-text bulleted list.
* **UX Confirmation State:** Added a temporary state switch that dynamically changes the button label to "✅ Copied!" for 2 seconds upon a successful clipboard operation.
* **UI Polish:** Positioned the button alongside the header using standard flexbox space distribution to maintain a balanced layout.

Closes #3

### Screenshots or Screen-Recordings 

https://github.com/user-attachments/assets/1a87a736-c777-4b13-a0f4-4b18af9598ac




