### PR TITLE
feat: add target job role skill-gap comparison dashboard #5

### DIFF
--- a/resume-frontend/src/App.tsx
+++ b/resume-frontend/src/App.tsx
@@ -3,27 +3,31 @@ import axios from "axios";
 import "./index.css";
 
 function App() {
-
   const [loading, setLoading] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [score, setScore] = useState<number | null>(null);
   const [skills, setSkills] = useState<string[]>([]);
   const [suggestions, setSuggestions] = useState<string[]>([]);
 
+  // --- ISSUE #5 SKILL GAP STATE VARIABLES ---
+  const [selectedRole, setSelectedRole] = useState<string>("Frontend Developer");
+  const [matchedSkills, setMatchedSkills] = useState<string[]>([]);
+  const [missingSkills, setMissingSkills] = useState<string[]>([]);
+  const [analysisPerformedFor, setAnalysisPerformedFor] = useState<string | null>(null);
 
   const uploadResume = async () => {
-
     if (!file) {
       alert("Please upload resume");
       return;
     }
 
     try {
-
       setLoading(true);   
 
       const formData = new FormData();
       formData.append("file", file);
+      // Issue #5: Send the selected role to the backend
+      formData.append("role", selectedRole);
 
       const res = await axios.post(
         "http://127.0.0.1:8000/api/upload/",
@@ -33,26 +37,26 @@ function App() {
       setScore(res.data.score);
       setSkills(res.data.skills_found);
       setSuggestions(res.data.suggestions);
+      
+      // Issue #5: Save comparison lists from backend response
+      setMatchedSkills(res.data.matched_skills || []);
+      setMissingSkills(res.data.missing_skills || []);
+      setAnalysisPerformedFor(res.data.target_role || selectedRole);
 
       setLoading(false);   
-
     } catch (error) {
       console.error(error);
       alert("Upload failed");
       setLoading(false);   
     }
-
   };
 
   return (
-
     <div className="container mt-5">
-
       <div className="main-card text-center">
-
         <h1 className="mb-4">🚀 AI Resume Analyzer</h1>
+        
         <div className="upload-box mb-3">
-
           <input
             type="file"
             id="fileUpload"
@@ -63,79 +67,113 @@ function App() {
               }
             }}
           />
-
           <label htmlFor="fileUpload" className="upload-label">
             📄 {file ? file.name : "Drag & Drop Resume or Click to Upload"}
           </label>
-
         </div>
 
-        <button
-          className="analyze-btn"
-          onClick={uploadResume}
-        >
+        {/* Issue #5: Dropdown UI to pick a role before analysis */}
+        <div className="mb-4" style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "10px" }}>
+          <label htmlFor="roleSelect" style={{ fontWeight: "600", color: "#fff" }}>Target Job Role:</label>
+          <select
+            id="roleSelect"
+            value={selectedRole}
+            onChange={(e) => setSelectedRole(e.target.value)}
+            style={{
+              padding: "8px 12px",
+              borderRadius: "6px",
+              border: "1px solid #cbd5e1",
+              backgroundColor: "#fff",
+              color: "#334155",
+              fontSize: "14px",
+              fontWeight: "500",
+              cursor: "pointer"
+            }}
+          >
+            <option value="Frontend Developer">Frontend Developer</option>
+            <option value="Backend Developer">Backend Developer</option>
+            <option value="Data Analyst">Data Analyst</option>
+          </select>
+        </div>
+
+        <button className="analyze-btn" onClick={uploadResume}>
           {loading ? "⏳ Analyzing..." : "🚀 Analyze Resume"}
         </button>
 
         {score !== null && (
-
           <>
-
-            {/* SCORE METER */}
-
+            {/* SCORE METER - Restored perfectly to your original version */}
             <div className="score-section">
-
               <div
                 className="score-circle mb-3"
                 style={{ "--score": `${score * 3.6}deg` } as React.CSSProperties}
               >
                 {score}%
               </div>
-
               <h3>ATS Resume Score</h3>
-
               <h5 className="analysis-done">
                 ✅ Resume Analysis Complete
               </h5>
-
             </div>
 
             {/* SKILLS */}
-
             <div className="mt-4">
-
               <h4>Skills Found</h4>
-
               {skills.length === 0 && <p>No skills detected</p>}
-
               {skills.map((skill: string, i: number) => (
                 <span key={i} className="skill-badge">
                   {skill}
                 </span>
               ))}
-
             </div>
 
+            {/* Issue #5: Display Comparison Panels */}
+            {analysisPerformedFor && (
+              <div className="mt-4" style={{ backgroundColor: "rgba(255, 255, 255, 0.1)", padding: "20px", borderRadius: "8px", textAlign: "left" }}>
+                <h4 style={{ marginTop: 0, borderBottom: "1px solid rgba(255,255,255,0.2)", paddingBottom: "8px", color: "#fff" }}>
+                  🎯 Target Role Match Analysis: {analysisPerformedFor}
+                </h4>
+                
+                <div style={{ marginBottom: "14px" }}>
+                  <strong style={{ color: "#4ade80", fontSize: "15px" }}>✅ Matched Skills:</strong>
+                  <div style={{ marginTop: "8px", display: "flex", flexWrap: "wrap", gap: "8px" }}>
+                    {matchedSkills.length === 0 ? <em style={{ fontSize: "13px", color: "#cbd5e1" }}>None matched yet</em> : 
+                      matchedSkills.map((s, i) => (
+                        <span key={i} style={{ backgroundColor: "#22c55e", color: "white", padding: "5px 10px", borderRadius: "4px", fontSize: "12px", fontWeight: "500" }}>
+                          {s}
+                        </span>
+                      ))
+                    }
+                  </div>
+                </div>
+
+                <div>
+                  <strong style={{ color: "#f87171", fontSize: "15px" }}>❌ Missing Skills:</strong>
+                  <div style={{ marginTop: "8px", display: "flex", flexWrap: "wrap", gap: "8px" }}>
+                    {missingSkills.length === 0 ? <em style={{ fontSize: "13px", color: "#cbd5e1" }}>Perfect Match! No gaps found.</em> : 
+                      missingSkills.map((s, i) => (
+                        <span key={i} style={{ backgroundColor: "#ef4444", color: "white", padding: "5px 10px", borderRadius: "4px", fontSize: "12px", fontWeight: "500" }}>
+                          {s}
+                        </span>
+                      ))
+                    }
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* SUGGESTIONS */}
-
             <div className="suggestion-box">
-
               <h4>💡 Suggestions</h4>
-
               {suggestions.map((s, i) => (
                 <div key={i} className="suggestion-item">
                   📌 {s}
                 </div>
               ))}
-
             </div>
-
           </>
-
         )}
-
       </div>
-
     </div>
   );
 }

--- a/resume_analyzer/analyzer/views.py
+++ b/resume_analyzer/analyzer/views.py
@@ -3,7 +3,6 @@ from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.response import Response
 import pdfplumber
 
-
 skills_list = [
     "python","django","react","javascript","sql",
     "html","css","git","github","flask",
@@ -12,15 +11,21 @@ skills_list = [
     "c","c++","java"
 ]
 
+# Acceptance Criteria: Predefined skill sets for at least 3 roles
+ROLE_SKILL_MATRICES = {
+    "Frontend Developer": ["html", "css", "javascript", "react", "git", "github"],
+    "Backend Developer": ["python", "django", "flask", "sql", "git", "github"],
+    "Data Analyst": ["python", "excel", "sql", "data analysis", "machine learning"]
+}
 
 @api_view(["POST"])
 @parser_classes([MultiPartParser, FormParser])
 def upload_resume(request):
-
     file = request.FILES.get("file")
+    # Acceptance Criteria: Endpoint accepts a target role parameter
+    target_role = request.data.get("role", None)
 
     text = ""
-
     with pdfplumber.open(file) as pdf:
         for page in pdf.pages:
             page_text = page.extract_text()
@@ -28,33 +33,43 @@ def upload_resume(request):
                 text += page_text
 
     text = text.lower()
-
     print(text)   # debug
 
     detected_skills = []
-
     for skill in skills_list:
         if skill.lower() in text:
             detected_skills.append(skill)
 
     score = len(detected_skills) * 10
-
     if score > 100:
         score = 100
 
     suggestions = []
-
     if "python" not in detected_skills:
         suggestions.append("Add Python projects")
-
     if "django" not in detected_skills:
         suggestions.append("Mention Django experience")
-
     if "react" not in detected_skills:
         suggestions.append("Add frontend skills like React")
+
+    # --- NEW SKILL GAP ANALYSIS LOGIC ---
+    matched_skills = []
+    missing_skills = []
+
+    if target_role in ROLE_SKILL_MATRICES:
+        required_skills = ROLE_SKILL_MATRICES[target_role]
+        for skill in required_skills:
+            if skill in detected_skills:
+                matched_skills.append(skill)
+            else:
+                missing_skills.append(skill)
 
     return Response({
         "score": score,
         "skills_found": detected_skills,
-        "suggestions": suggestions
+        "suggestions": suggestions,
+        "target_role": target_role,
+        "matched_skills": matched_skills,
+        "missing_skills": missing_skills
     })
+    


### PR DESCRIPTION
### Description
This PR resolves Issue #5 by implementing a skill-gap comparison engine. Users can select a target career track prior to analysis, comparing extracted resume competencies against a predefined skill matrix to see what they match and what they are missing.

### Changes Implemented
* **Predefined Target Matrices (Backend):** Expanded `views.py` with a benchmark skillset matrix for 3 distinct roles: Frontend Developer, Backend Developer, and Data Analyst.
* **Dynamic Payload Aggregation:** Updated the API request handler to accept a `role` field and return structured `matched_skills` and `missing_skills` arrays based on the text evaluation.
* **Role Selector & Gap Dashboard (Frontend):** Added an interactive dropdown selection component and a visual diagnostic card that lists matched vs. missing skills as color-coded badges.

Closes #5