### PR TITLE
Fix: remove debug block overwriting detected_skills with fake data

### DIFF
--- a/resume_analyzer/analyzer/views.py
+++ b/resume_analyzer/analyzer/views.py
@@ -53,9 +53,6 @@ def upload_resume(request):
         suggestions.append("Add frontend skills like React")
 
 
-    # TEMPORARY TESTING BLOCK FOR ISSUE #6
-    # Overwrites detected_skills with 50 fake items to verify UI layout boundaries
-    detected_skills = [f"Skill-{i}" for i in range(1, 51)]
     # --- NEW SKILL GAP ANALYSIS LOGIC ---
     matched_skills = []
     missing_skills = []


### PR DESCRIPTION
## Summary
- Removes a leftover debug block in `upload_resume` (views.py) that unconditionally overwrote the real, keyword-matched `detected_skills` list with 50 fake placeholder strings (`Skill-1`...`Skill-50`).
- This was test scaffolding for #6 (skill-list pagination/UI truncation) that never got cleaned up, and it was silently corrupting `skills_found` and the `matched_skills`/`missing_skills` gap-analysis output for every request in production.

Fixes #25

## Test plan
- [x] Confirmed via code read that `detected_skills` is now the real keyword-matched list computed from the extracted PDF text, with no later overwrite.
- [x] Verified `matched_skills` / `missing_skills` gap analysis (used when a `role` is passed) now operates against real detected skills instead of the fake list.
- [ ] Maintainer/CI: run the backend and upload a sample resume to confirm `skills_found` reflects actual resume content.