### PR TITLE
Add dark mode toggle with localStorage persistence

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,18 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import axios from "axios";
 import "./index.css";
-import { AtsScore } from "./AtsScore"; 
+import { AtsScore } from "./AtsScore";
+
+type Theme = "light" | "dark";
+
+function getInitialTheme(): Theme {
+  const saved = localStorage.getItem("theme");
+  if (saved === "light" || saved === "dark") return saved;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
 
 function App() {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const [loading, setLoading] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [score, setScore] = useState<number | null>(null);
@@ -16,6 +25,15 @@ function App() {
   const [missingSkills, setMissingSkills] = useState<string[]>([]);
   const [showAllSkills, setShowAllSkills] = useState(false);
   const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+  };
 
   const uploadResume = async () => {
     if (!file) {
@@ -61,8 +79,16 @@ function App() {
   return (
     <div className="container mt-5">
       <div className="main-card text-center">
+        <button
+          className="theme-toggle-btn"
+          onClick={toggleTheme}
+          aria-label="Toggle dark mode"
+        >
+          {theme === "light" ? "🌙 Dark Mode" : "☀️ Light Mode"}
+        </button>
+
         <h1 className="mb-4">🚀 AI Resume Analyzer</h1>
-        
+
         {/* Role Selector Dropdown */}
         <div className="mb-4">
           <label htmlFor="roleSelect" style={{ marginRight: "10px", fontWeight: "600", color: "#fff" }}>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,9 +6,16 @@ import { AtsScore } from "./AtsScore";
 type Theme = "light" | "dark";
 
 function getInitialTheme(): Theme {
-  const saved = localStorage.getItem("theme");
-  if (saved === "light" || saved === "dark") return saved;
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  try {
+    const saved = localStorage.getItem("theme");
+    if (saved === "light" || saved === "dark") return saved;
+    if (typeof window !== "undefined" && window.matchMedia) {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+  } catch {
+    // localStorage / matchMedia can throw in restricted privacy modes
+  }
+  return "light";
 }
 
 function App() {
@@ -28,7 +35,11 @@ function App() {
 
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
-    localStorage.setItem("theme", theme);
+    try {
+      localStorage.setItem("theme", theme);
+    } catch {
+      // persistence is best-effort; ignore if storage is unavailable
+    }
   }, [theme]);
 
   const toggleTheme = () => {
@@ -80,9 +91,11 @@ function App() {
     <div className="container mt-5">
       <div className="main-card text-center">
         <button
+          type="button"
           className="theme-toggle-btn"
           onClick={toggleTheme}
-          aria-label="Toggle dark mode"
+          aria-label="Toggle theme"
+          aria-pressed={theme === "dark"}
         >
           {theme === "light" ? "🌙 Dark Mode" : "☀️ Light Mode"}
         </button>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,16 +1,67 @@
+:root{
+  --body-bg: linear-gradient(135deg,#667eea,#764ba2);
+  --card-bg: rgba(255,255,255,0.15);
+  --card-text: #ffffff;
+  --score-track: rgba(255,255,255,0.2);
+  --score-accent: #00ffae;
+  --upload-border: #cccccc;
+  --upload-bg: rgba(255,255,255,0.1);
+  --btn-bg: #ffffff;
+  --btn-text: #333333;
+  --analysis-done: #d4ffdc;
+  --skill-bg: #ffffff;
+  --skill-text: #333333;
+  --suggestion-bg: rgba(255,255,255,0.2);
+  --theme-toggle-bg: rgba(255,255,255,0.2);
+  --theme-toggle-text: #ffffff;
+}
+
+[data-theme="dark"]{
+  --body-bg: linear-gradient(135deg,#1e1b4b,#0f172a);
+  --card-bg: rgba(15,23,42,0.6);
+  --card-text: #e2e8f0;
+  --score-track: rgba(255,255,255,0.08);
+  --score-accent: #22d3ee;
+  --upload-border: #475569;
+  --upload-bg: rgba(255,255,255,0.05);
+  --btn-bg: #1e293b;
+  --btn-text: #e2e8f0;
+  --analysis-done: #86efac;
+  --skill-bg: #1e293b;
+  --skill-text: #e2e8f0;
+  --suggestion-bg: rgba(255,255,255,0.08);
+  --theme-toggle-bg: rgba(255,255,255,0.08);
+  --theme-toggle-text: #e2e8f0;
+}
+
 body{
-  background: linear-gradient(135deg,#667eea,#764ba2);
+  background: var(--body-bg);
   min-height:100vh;
   font-family: Arial, Helvetica, sans-serif;
+  transition: background 0.3s ease;
 }
 
 .main-card{
-  background: rgba(255,255,255,0.15);
+  background: var(--card-bg);
   backdrop-filter: blur(12px);
   border-radius:20px;
   padding:40px;
   box-shadow:0 10px 30px rgba(0,0,0,0.2);
-  color:white;
+  color: var(--card-text);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.theme-toggle-btn{
+  background: var(--theme-toggle-bg);
+  color: var(--theme-toggle-text);
+  border: 1px solid rgba(255,255,255,0.3);
+  padding: 6px 14px;
+  border-radius: 20px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 16px;
+  transition: background 0.2s ease;
 }
 
 .score-circle{
@@ -22,17 +73,17 @@ body{
   justify-content:center;
   font-size:40px;
   font-weight:bold;
-  background:conic-gradient(#00ffae var(--score),rgba(255,255,255,0.2) 0);
+  background:conic-gradient(var(--score-accent) var(--score),var(--score-track) 0);
   margin:auto;
 }
 
 
 .upload-box{
-border:2px dashed #ccc;
+border:2px dashed var(--upload-border);
 padding:25px;
 border-radius:10px;
 cursor:pointer;
-background:rgba(255,255,255,0.1);
+background: var(--upload-bg);
 }
 
 .upload-label{
@@ -41,7 +92,8 @@ font-weight:500;
 }
 
 .analyze-btn{
-background:#ffffff;
+background: var(--btn-bg);
+color: var(--btn-text);
 border:none;
 padding:10px 25px;
 border-radius:8px;
@@ -54,15 +106,15 @@ transform:scale(1.05);
 }
 
 .analysis-done{
-color:#d4ffdc;
+color: var(--analysis-done);
 font-weight:600;
 }
 
 
 .skill-badge{
 display:inline-block;
-background:#ffffff;
-color:#333;
+background: var(--skill-bg);
+color: var(--skill-text);
 padding:6px 12px;
 border-radius:20px;
 margin:5px;
@@ -74,7 +126,7 @@ margin-top:20px;
 }
 
 .suggestion-item{
-background:rgba(255,255,255,0.2);
+background: var(--suggestion-bg);
 padding:10px;
 margin:8px 0;
 border-radius:8px;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,4 +1,5 @@
 :root{
+  color-scheme: light;
   --body-bg: linear-gradient(135deg,#667eea,#764ba2);
   --card-bg: rgba(255,255,255,0.15);
   --card-text: #ffffff;
@@ -17,6 +18,7 @@
 }
 
 [data-theme="dark"]{
+  color-scheme: dark;
   --body-bg: linear-gradient(135deg,#1e1b4b,#0f172a);
   --card-bg: rgba(15,23,42,0.6);
   --card-text: #e2e8f0;


### PR DESCRIPTION
## Summary
- Adds CSS custom properties in `index.css` for light/dark palettes (background, card, buttons, skill badges, suggestions, score ring).
- Adds a toggle button in the header that flips `data-theme` on `<html>`.
- Persists the chosen theme to `localStorage`, defaulting to the user's `prefers-color-scheme` on first visit.

Closes #19

## Test plan
- [x] `npx tsc --noEmit` passes with no errors.
- [x] Verified in-browser: toggle flips between light/dark instantly, all existing screens (upload box, score circle, skill badges, suggestions, skill gap matrix) respect the active theme.
- [x] Verified theme choice persists across a full page reload via `localStorage`.
- [x] Verified default theme follows system `prefers-color-scheme` when no preference is saved yet.