### PR TITLE
#24 feat: Add .env.example files for frontend and backend (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Node / Frontend
+client/node_modules/
+client/dist/
+client/dist-ssr/
+client/*.local
+client/.env
+
+# Python / Django
+**/__pycache__/
+*.py[cod]
+*$py.class
+server/venv/
+server/env/
+server/ENV/
+server/.env
+server/db.sqlite3
+server/resumes/
+
+# Logs & OS Files
+*.log
+.DS_Store
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ venv\Scripts\activate
 # macOS/Linux:
 source venv/bin/activate
 
+# Create local environment configuration from the example
+# Windows:
+copy .env.example .env
+# macOS/Linux:
+cp .env.example .env
+
 # Install dependencies
 pip install -r requirements.txt
 
@@ -169,6 +175,12 @@ The API server starts on: `http://127.0.0.1:8000/`
 ```bash
 # Open a new terminal instance and navigate to client directory
 cd client
+
+# Create local environment configuration from the example
+# Windows:
+copy .env.example .env
+# macOS/Linux:
+cp .env.example .env
 
 # Install packages
 npm install

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+# Backend REST API Server URL
+VITE_BACKEND_URL=http://127.0.0.1:8000

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -58,8 +58,9 @@ function App() {
       formData.append("file", file);
       formData.append("role", targetRole);
 
+      const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://127.0.0.1:8000";
       const res = await axios.post(
-        "http://127.0.0.1:8000/api/upload/",
+        `${backendUrl}/api/upload/`,
         formData
       );
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+# Django Configuration
+SECRET_KEY=your_django_secret_key_here
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1,127.0.0.1:8000

--- a/server/resume_analyzer/settings.py
+++ b/server/resume_analyzer/settings.py
@@ -1,13 +1,14 @@
 from pathlib import Path
+import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 
-SECRET_KEY = 'django-insecure-s1j^wm#yot7&7i6+1%v&ju9ex%-!8rz320$89x3(7nx4m%e2tb'
+SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-s1j^wm#yot7&7i6+1%v&ju9ex%-!8rz320$89x3(7nx4m%e2tb')
 
-DEBUG = True
+DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [host.strip() for host in os.environ.get('ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',') if host.strip()]
 
 
 # Application definition


### PR DESCRIPTION
# PR Description
### 🚀 Summary & Goal
This PR addresses issue **#24** by adding environment variable configurations, templating them with `.env.example` files on both the frontend client (React) and backend server (Django), dynamic loading configurations, and updating the setup instructions to streamline environment onboarding for new contributors.
---
### 🛠️ Detailed Breakdown of Changes
#### 1. Frontend Client Changes (`client/`)
* **`client/.env.example` [NEW]**: Created configuration template mapping `VITE_BACKEND_URL` with local fallback `http://127.0.0.1:8000`.
* **`client/src/App.tsx` [MODIFY]**: Updated the hardcoded API post endpoint to load the server URL dynamically from `import.meta.env.VITE_BACKEND_URL` (with standard local host fallback).
#### 2. Backend Server Changes (`server/`)
* **`server/.env.example` [NEW]**: Created configuration template mapping `SECRET_KEY`, `DEBUG`, and `ALLOWED_HOSTS`.
* **`server/resume_analyzer/settings.py` [MODIFY]**: Refactored configurations to load dynamically via `os.environ` methods to avoid hardcoding production secrets, allowing safe configuration injection across hosting containers.
#### 3. Root Setup & Documentation
* **`README.md` [MODIFY]**: Updated the client and server installation and setup instructions. Added commands to instruct developers to copy environment example files (`copy .env.example .env` on Windows / `cp .env.example .env` on macOS/Linux).
* **`.gitignore` [NEW]**: Added a root-level gitignore to ensure local `.env` configurations, python bytecode (`__pycache__`), virtual environments, sqlite databases, and static media are safely excluded from version control.
---
### 📝 Acceptance Criteria Checklist
- [x] `.env.example` in both client (frontend) and server (backend) directories.
- [x] `README.md` references instructions on copy-pasting the environment templates.
- [x] Zero secrets/credentials committed.
- [x] Project builds successfully locally.
