### PR TITLE
feat: add localStorage-backed analysis history sidebar

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 import "./index.css";
 import { AtsScore } from "./AtsScore";
+import { useAnalysisHistory, type AnalysisEntry } from "./hooks/useAnalysisHistory";
+import { HistorySidebar } from "./HistorySidebar";
 
 type Theme = "light" | "dark";
 
@@ -32,6 +34,11 @@ function App() {
   const [missingSkills, setMissingSkills] = useState<string[]>([]);
   const [showAllSkills, setShowAllSkills] = useState(false);
   const [copied, setCopied] = useState(false);
+
+  // History
+  const { entries, addEntry, deleteEntry, clearHistory } = useAnalysisHistory();
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [activeFileName, setActiveFileName] = useState("");
 
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
@@ -69,9 +76,22 @@ function App() {
       setSuggestions(res.data.suggestions);
       setMatchedSkills(res.data.matched_skills || []);
       setMissingSkills(res.data.missing_skills || []);
+      setActiveFileName(file.name);
+
+      // Save to history
+      addEntry({
+        score: res.data.score,
+        skills: res.data.skills_found,
+        suggestions: res.data.suggestions,
+        matchedSkills: res.data.matched_skills || [],
+        missingSkills: res.data.missing_skills || [],
+        targetRole,
+        fileName: file.name,
+      });
+
       setLoading(false);   
     } catch (error) {
-      console.error(error);
+      console.error("Upload failed:", error instanceof Error ? error.message : "Unknown error");
       alert("Upload failed");
       setLoading(false);   
     }
@@ -88,8 +108,30 @@ function App() {
       .catch((err) => console.error("Failed to copy text: ", err));
   };
 
+  const selectHistoryEntry = (entry: AnalysisEntry) => {
+    setScore(entry.score);
+    setSkills(entry.skills);
+    setSuggestions(entry.suggestions);
+    setMatchedSkills(entry.matchedSkills);
+    setMissingSkills(entry.missingSkills);
+    setTargetRole(entry.targetRole);
+    setActiveFileName(entry.fileName);
+    setShowAllSkills(false);
+    setCopied(false);
+    setHistoryOpen(false);
+  };
+
   return (
-    <div className="container mt-5">
+    <>
+      <HistorySidebar
+        entries={entries}
+        onSelect={selectHistoryEntry}
+        onDelete={deleteEntry}
+        onClear={clearHistory}
+        isOpen={historyOpen}
+        onToggle={() => setHistoryOpen((v) => !v)}
+      />
+      <div className="container mt-5">
       <div className="main-card text-center">
         <button
           type="button"
@@ -145,6 +187,9 @@ function App() {
             <h5 className="analysis-done">
               ✅ Resume Analysis Complete
             </h5>
+            {activeFileName && (
+              <p style={{ fontSize: "13px", opacity: 0.7, marginTop: "-8px" }}>📄 {activeFileName}</p>
+            )}
 
             {/* SKILLS CONTAINER */}
             <div className="mt-4">
@@ -226,6 +271,7 @@ function App() {
         )}
       </div>
     </div>
+    </>
   );
 }
 

--- a/client/src/HistorySidebar.tsx
+++ b/client/src/HistorySidebar.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import type { AnalysisEntry } from "./hooks/useAnalysisHistory";
+
+interface HistorySidebarProps {
+  entries: AnalysisEntry[];
+  onSelect: (entry: AnalysisEntry) => void;
+  onDelete: (id: string) => void;
+  onClear: () => void;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+export const HistorySidebar: React.FC<HistorySidebarProps> = ({
+  entries,
+  onSelect,
+  onDelete,
+  onClear,
+  isOpen,
+  onToggle,
+}) => {
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  const formatDate = (ts: number) => {
+    const d = new Date(ts);
+    return d.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  return (
+    <>
+      {/* Toggle button — always visible */}
+      <button
+        className="history-toggle-btn"
+        onClick={onToggle}
+        aria-label={isOpen ? "Close history" : "Open history"}
+        title={isOpen ? "Close history" : "View history"}
+      >
+        {isOpen ? "✕" : "📋"}
+        {!isOpen && entries.length > 0 && (
+          <span className="history-badge">{entries.length}</span>
+        )}
+      </button>
+
+      {/* Sidebar panel */}
+      <div className={`history-sidebar ${isOpen ? "history-sidebar--open" : ""}`}>
+        <div className="history-sidebar-header">
+          <h3>📚 History</h3>
+          {entries.length > 0 && (
+            <button
+              className="history-clear-btn"
+              onClick={() => {
+                if (confirmClear) {
+                  onClear();
+                  setConfirmClear(false);
+                } else {
+                  setConfirmClear(true);
+                  setTimeout(() => setConfirmClear(false), 2500);
+                }
+              }}
+            >
+              {confirmClear ? "Confirm?" : "Clear All"}
+            </button>
+          )}
+        </div>
+
+        {entries.length === 0 ? (
+          <p className="history-empty">No past analyses yet.</p>
+        ) : (
+          <ul className="history-list">
+            {entries.map((entry) => (
+              <li
+                key={entry.id}
+                className="history-item"
+                onClick={() => onSelect(entry)}
+              >
+                <div className="history-item-top">
+                  <span className="history-item-score">{entry.score}%</span>
+                  <button
+                    className="history-item-delete"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDelete(entry.id);
+                    }}
+                    title="Delete entry"
+                  >
+                    🗑️
+                  </button>
+                </div>
+                <div className="history-item-role">{entry.targetRole}</div>
+                <div className="history-item-file">{entry.fileName}</div>
+                <div className="history-item-time">{formatDate(entry.timestamp)}</div>
+                <div className="history-item-skills">
+                  {entry.skills.slice(0, 4).join(" · ")}
+                  {entry.skills.length > 4 && ` +${entry.skills.length - 4} more`}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+};

--- a/client/src/hooks/useAnalysisHistory.ts
+++ b/client/src/hooks/useAnalysisHistory.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from "react";
+
+export interface AnalysisEntry {
+  id: string;
+  timestamp: number;
+  score: number;
+  skills: string[];
+  suggestions: string[];
+  matchedSkills: string[];
+  missingSkills: string[];
+  targetRole: string;
+  fileName: string;
+}
+
+const STORAGE_KEY = "resume_analysis_history";
+
+function loadHistory(): AnalysisEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(entries: AnalysisEntry[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // localStorage may be unavailable in restricted modes
+  }
+}
+
+export function useAnalysisHistory() {
+  const [entries, setEntries] = useState<AnalysisEntry[]>(() => loadHistory());
+
+  // Sync to localStorage whenever entries change
+  useEffect(() => {
+    saveHistory(entries);
+  }, [entries]);
+
+  const addEntry = useCallback(
+    (entry: Omit<AnalysisEntry, "id" | "timestamp">) => {
+      const newEntry: AnalysisEntry = {
+        ...entry,
+        id: crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        timestamp: Date.now(),
+      };
+      setEntries((prev) => [newEntry, ...prev]);
+      return newEntry;
+    },
+    []
+  );
+
+  const deleteEntry = useCallback((id: string) => {
+    setEntries((prev) => prev.filter((e) => e.id !== id));
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    setEntries([]);
+  }, []);
+
+  return { entries, addEntry, deleteEntry, clearHistory };
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -148,3 +148,177 @@ margin:15px auto;
 0%{transform:rotate(0deg);}
 100%{transform:rotate(360deg);}
 }
+
+/* ── History Sidebar ────────────────────── */
+
+.history-toggle-btn {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1001;
+  background: var(--card-bg);
+  backdrop-filter: blur(10px);
+  color: var(--card-text);
+  border: 1px solid rgba(255,255,255,0.3);
+  padding: 10px 14px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.history-toggle-btn:hover {
+  transform: scale(1.08);
+}
+
+.history-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.history-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 1000;
+  width: 320px;
+  height: 100vh;
+  background: var(--card-bg);
+  backdrop-filter: blur(16px);
+  box-shadow: -8px 0 24px rgba(0,0,0,0.2);
+  padding: 68px 16px 16px;
+  overflow-y: auto;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  color: var(--card-text);
+}
+
+.history-sidebar--open {
+  transform: translateX(0);
+}
+
+.history-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.history-sidebar-header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.history-clear-btn {
+  background: rgba(239,68,68,0.2);
+  color: #ef4444;
+  border: 1px solid rgba(239,68,68,0.4);
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.history-clear-btn:hover {
+  background: rgba(239,68,68,0.35);
+}
+
+.history-empty {
+  text-align: center;
+  opacity: 0.6;
+  margin-top: 40px;
+  font-size: 14px;
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.history-item {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.history-item:hover {
+  background: rgba(255,255,255,0.15);
+  transform: translateX(-3px);
+}
+
+.history-item-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.history-item-score {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--score-accent);
+}
+
+.history-item-delete {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  opacity: 0.5;
+  padding: 0 2px;
+  transition: opacity 0.2s ease;
+}
+
+.history-item-delete:hover {
+  opacity: 1;
+}
+
+.history-item-role {
+  font-size: 13px;
+  font-weight: 600;
+  opacity: 0.9;
+}
+
+.history-item-file {
+  font-size: 12px;
+  opacity: 0.6;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.history-item-time {
+  font-size: 11px;
+  opacity: 0.5;
+  margin-top: 2px;
+}
+
+.history-item-skills {
+  font-size: 12px;
+  opacity: 0.7;
+  margin-top: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
## Summary

- Implements a persistent analysis history feature for the AI Resume Analyzer. 
- Every resume analysis is now automatically saved to localStorage and displayed in a collapsible sidebar, allowing users to revisit past results across page refreshes.

---

## Issues Closed

Closes #15 

---

## What Was Changed

### `client/src/hooks/useAnalysisHistory.ts` (new file)
- Custom React hook that reads/writes analysis history to localStorage
- Exposes addEntry, deleteEntry, clearHistory, and entries
- Auto-syncs to localStorage via useEffect on every state change
- Generates unique IDs using crypto.randomUUID()

### `client/src/HistorySidebar.tsx` (new file)
- Fixed right-side slide-in panel listing all past analyses
- Each card shows: ATS score, target role, filename, timestamp, skill preview
- Per-entry delete (🗑️) button with stopPropagation to avoid accidental triggers
- "Clear All" with a 2.5s confirm step to prevent accidental wipes
- Red badge on toggle button showing unread entry count

### `client/src/App.tsx` (modified)
- Integrated useAnalysisHistory hook — addEntry called after every successful upload
- selectHistoryEntry() restores full result state when a history card is clicked
- Renamed fileName → activeFileName and rendered it in JSX to fix TS6133 build error
- Sanitized console.error to log only error.message (fixes log injection warning)

### `client/src/index.css` (modified)
- Added all history sidebar styles: .history-sidebar, .history-item, .history-badge, etc.
- Sidebar uses existing CSS variables (--card-bg, --card-text, --score-accent) 
  so it automatically supports both light and dark themes

---

## Acceptance Criteria Checklist

- [x] Past analyses (score + skills + timestamp) listed in sidebar
- [x] Clicking a past entry re-displays its full results
- [x] Works across page refresh via localStorage
- [x] Individual entry delete works
- [x] Clear all history works (with confirm step)
- [x] Badge count shows number of saved entries
- [x] Sidebar respects light/dark theme
- [x] npm run build passes with 0 errors

---

## Bug Fixes Included

| Bug | Fix |
|-----|-----|
| TS6133: fileName declared but never read | Renamed to activeFileName and rendered in JSX |
| Log injection via console.error(error) | Now logs error.message only |
| git add path error (doubled client/client/) | Ran commands from repo root |

---

## Screenshot

<img width="1896" height="1005" alt="resume" src="https://github.com/user-attachments/assets/0e4187bc-1b7b-4854-9d61-466cbf1e78bd" />

---

## Additional Notes

- localStorage is scoped to the browser session/origin — no backend changes required
- DB-backed history is listed in the roadmap as a stretch goal
- The CSRF warning on the POST /api/upload/ endpoint is a known false positive — the app uses no auth cookies so CSRF is not exploitable in the current state; this should be revisited when authentication is added
- The STORAGE_KEY constant flagged as hardcoded credential is a false positive — it is a localStorage key name, not a secret
