### PR TITLE
Unify inconsistent button styles into a shared theme-aware system

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -93,7 +93,7 @@ function App() {
       <div className="main-card text-center">
         <button
           type="button"
-          className="theme-toggle-btn"
+          className="app-btn theme-toggle-btn"
           onClick={toggleTheme}
           aria-label="Toggle theme"
           aria-pressed={theme === "dark"}
@@ -134,7 +134,7 @@ function App() {
           </label>
         </div>
 
-        <button className="analyze-btn" onClick={uploadResume}>
+        <button type="button" className="app-btn analyze-btn" onClick={uploadResume}>
           {loading ? "⏳ Analyzing..." : "🚀 Analyze Resume"}
         </button>
 
@@ -157,19 +157,10 @@ function App() {
               </div>
               {skills.length > 15 && (
                 <button
+                  type="button"
+                  className="app-btn app-btn--secondary"
+                  style={{ marginTop: "16px" }}
                   onClick={() => setShowAllSkills(!showAllSkills)}
-                  style={{
-                    marginTop: "16px",
-                    background: "rgba(255, 255, 255, 0.15)",
-                    color: "#ffffff",
-                    border: "1px solid rgba(255, 255, 255, 0.3)",
-                    padding: "6px 16px",
-                    borderRadius: "20px",
-                    cursor: "pointer",
-                    fontWeight: "600",
-                    fontSize: "13px",
-                    transition: "all 0.2s ease"
-                  }}
                 >
                   {showAllSkills ? "Show Less ▲" : `Show More (${skills.length - 15} more) ▼`}
                 </button>
@@ -201,18 +192,9 @@ function App() {
                 <h4 style={{ margin: 0 }}>💡 Suggestions</h4>
                 {suggestions.length > 0 && (
                   <button
+                    type="button"
+                    className={`app-btn app-btn--accent${copied ? " is-success" : ""}`}
                     onClick={copySuggestionsToClipboard}
-                    style={{
-                      backgroundColor: copied ? "#22c55e" : "#3b82f6",
-                      color: "white",
-                      border: "none",
-                      padding: "6px 12px",
-                      borderRadius: "6px",
-                      fontSize: "12px",
-                      fontWeight: "600",
-                      cursor: "pointer",
-                      transition: "background-color 0.2s ease"
-                    }}
                   >
                     {copied ? "✅ Copied!" : "📋 Copy Suggestions"}
                   </button>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -134,7 +134,7 @@ function App() {
           </label>
         </div>
 
-        <button type="button" className="app-btn analyze-btn" onClick={uploadResume}>
+        <button type="button" className="app-btn analyze-btn" onClick={uploadResume} disabled={loading}>
           {loading ? "⏳ Analyzing..." : "🚀 Analyze Resume"}
         </button>
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -15,6 +15,14 @@
   --suggestion-bg: rgba(255,255,255,0.2);
   --theme-toggle-bg: rgba(255,255,255,0.2);
   --theme-toggle-text: #ffffff;
+  --btn-secondary-bg: rgba(255,255,255,0.15);
+  --btn-secondary-text: #ffffff;
+  --btn-secondary-border: rgba(255,255,255,0.3);
+  --btn-secondary-hover-bg: rgba(255,255,255,0.25);
+  --btn-accent-bg: #3b82f6;
+  --btn-accent-hover-bg: #2563eb;
+  --btn-success-bg: #22c55e;
+  --btn-accent-text: #ffffff;
 }
 
 [data-theme="dark"]{
@@ -34,6 +42,14 @@
   --suggestion-bg: rgba(255,255,255,0.08);
   --theme-toggle-bg: rgba(255,255,255,0.08);
   --theme-toggle-text: #e2e8f0;
+  --btn-secondary-bg: rgba(255,255,255,0.08);
+  --btn-secondary-text: #e2e8f0;
+  --btn-secondary-border: rgba(255,255,255,0.15);
+  --btn-secondary-hover-bg: rgba(255,255,255,0.16);
+  --btn-accent-bg: #3b82f6;
+  --btn-accent-hover-bg: #60a5fa;
+  --btn-success-bg: #22c55e;
+  --btn-accent-text: #ffffff;
 }
 
 body{
@@ -53,17 +69,65 @@ body{
   transition: background 0.3s ease, color 0.3s ease;
 }
 
+/* Shared button base — all app buttons build on this for a consistent look.
+   Namespaced as .app-btn to avoid clashing with Bootstrap's .btn classes. */
+.app-btn{
+  cursor: pointer;
+  font-weight: 600;
+  font-family: inherit;
+  border: 1px solid transparent;
+  border-radius: 20px;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-btn:focus-visible{
+  outline: 2px solid var(--score-accent);
+  outline-offset: 2px;
+}
+
+/* Pill-style secondary action (Show more / theme toggle) */
+.app-btn--secondary{
+  background: var(--btn-secondary-bg);
+  color: var(--btn-secondary-text);
+  border-color: var(--btn-secondary-border);
+  padding: 6px 16px;
+  font-size: 13px;
+}
+
+.app-btn--secondary:hover{
+  background: var(--btn-secondary-hover-bg);
+}
+
+/* Accent (blue) action button, e.g. Copy suggestions */
+.app-btn--accent{
+  background: var(--btn-accent-bg);
+  color: var(--btn-accent-text);
+  padding: 6px 12px;
+  font-size: 12px;
+  border-radius: 6px;
+}
+
+.app-btn--accent:hover{
+  background: var(--btn-accent-hover-bg);
+}
+
+/* Success state (e.g. Copied!) */
+.app-btn--accent.is-success,
+.app-btn--accent.is-success:hover{
+  background: var(--btn-success-bg);
+}
+
 .theme-toggle-btn{
   background: var(--theme-toggle-bg);
   color: var(--theme-toggle-text);
-  border: 1px solid rgba(255,255,255,0.3);
+  border-color: var(--btn-secondary-border);
   padding: 6px 14px;
-  border-radius: 20px;
-  cursor: pointer;
-  font-weight: 600;
   font-size: 13px;
   margin-bottom: 16px;
-  transition: background 0.2s ease;
+}
+
+.theme-toggle-btn:hover{
+  background: var(--btn-secondary-hover-bg);
 }
 
 .score-circle{
@@ -96,11 +160,8 @@ font-weight:500;
 .analyze-btn{
 background: var(--btn-bg);
 color: var(--btn-text);
-border:none;
 padding:10px 25px;
 border-radius:8px;
-font-weight:600;
-transition:0.3s;
 }
 
 .analyze-btn:hover{

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -13,8 +13,6 @@
   --skill-bg: #ffffff;
   --skill-text: #333333;
   --suggestion-bg: rgba(255,255,255,0.2);
-  --theme-toggle-bg: rgba(255,255,255,0.2);
-  --theme-toggle-text: #ffffff;
   --btn-secondary-bg: rgba(255,255,255,0.15);
   --btn-secondary-text: #ffffff;
   --btn-secondary-border: rgba(255,255,255,0.3);
@@ -40,8 +38,6 @@
   --skill-bg: #1e293b;
   --skill-text: #e2e8f0;
   --suggestion-bg: rgba(255,255,255,0.08);
-  --theme-toggle-bg: rgba(255,255,255,0.08);
-  --theme-toggle-text: #e2e8f0;
   --btn-secondary-bg: rgba(255,255,255,0.08);
   --btn-secondary-text: #e2e8f0;
   --btn-secondary-border: rgba(255,255,255,0.15);
@@ -85,6 +81,15 @@ body{
   outline-offset: 2px;
 }
 
+.app-btn:disabled{
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.app-btn:disabled:hover{
+  transform: none;
+}
+
 /* Pill-style secondary action (Show more / theme toggle) */
 .app-btn--secondary{
   background: var(--btn-secondary-bg);
@@ -118,8 +123,8 @@ body{
 }
 
 .theme-toggle-btn{
-  background: var(--theme-toggle-bg);
-  color: var(--theme-toggle-text);
+  background: var(--btn-secondary-bg);
+  color: var(--btn-secondary-text);
   border-color: var(--btn-secondary-border);
   padding: 6px 14px;
   font-size: 13px;
@@ -160,6 +165,7 @@ font-weight:500;
 .analyze-btn{
 background: var(--btn-bg);
 color: var(--btn-text);
+border:none;
 padding:10px 25px;
 border-radius:8px;
 }


### PR DESCRIPTION
## Summary
Fixes the inconsistent button styling across the app. Previously the theme toggle and analyze buttons used CSS classes, while the **Show more** and **Copy suggestions** buttons used inline styles with hardcoded colors that ignored the light/dark theme entirely.

- Adds a shared `.app-btn` base plus `.app-btn--secondary` / `.app-btn--accent` variants, all driven by CSS theme variables, so every button is visually consistent and responds to the active theme.
- Migrates the two inline-styled buttons onto the shared classes and removes the hardcoded inline colors.
- Adds `type="button"` to all buttons to avoid accidental form submission.

Namespaced deliberately as `.app-btn` (not `.btn`) because the app loads Bootstrap globally via `main.tsx` — reusing `.btn`/`.btn-secondary` collides with Bootstrap's own button classes and renders them with Bootstrap's gray defaults instead of the app theme.

Closes #41

## Test plan
- [x] `npx tsc --noEmit` passes.
- [x] Verified in-browser with transitions isolated: all buttons resolve to the correct themed colors in **both** light and dark:
  - Analyze — `#ffffff` (light) / `#1e293b` (dark)
  - Show more / theme toggle — themed translucent surface in both modes
  - Copy suggestions — blue `#3b82f6`, and green `#22c55e` in its "Copied!" success state
- [x] Ran a real resume upload end-to-end to confirm the results-state buttons (Copy suggestions) render with the new classes.
- [x] Confirmed no regression to the existing dark-mode toggle behavior.