### PR TITLE
Add a site footer with GitHub link and copyright

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { useAnalysisHistory, type AnalysisEntry } from "./hooks/useAnalysisHisto
 import { HistorySidebar } from "./HistorySidebar";
 import { useAuth } from "./hooks/useAuth";
 import { AuthModal } from "./AuthModal";
+import { Footer } from "./Footer";
 
 type Theme = "light" | "dark";
 
@@ -310,6 +311,8 @@ function App() {
           </>
         )}
       </div>
+
+      <Footer />
     </div>
     </>
   );

--- a/client/src/Footer.tsx
+++ b/client/src/Footer.tsx
@@ -9,11 +9,11 @@ export const Footer = () => {
           target="_blank"
           rel="noopener noreferrer"
         >
-          ⭐ GitHub
+          <span aria-hidden="true">⭐</span> GitHub
         </a>
       </nav>
       <p className="app-footer__copy">
-        © 2026 AI Resume Analyzer
+        © {new Date().getFullYear()} AI Resume Analyzer
       </p>
     </footer>
   );

--- a/client/src/Footer.tsx
+++ b/client/src/Footer.tsx
@@ -1,0 +1,20 @@
+const REPO_URL = "https://github.com/Muskankr/AI-Resume-Analyzer";
+
+export const Footer = () => {
+  return (
+    <footer className="app-footer">
+      <nav className="app-footer__links" aria-label="Footer">
+        <a
+          href={REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ⭐ GitHub
+        </a>
+      </nav>
+      <p className="app-footer__copy">
+        © 2026 AI Resume Analyzer
+      </p>
+    </footer>
+  );
+};

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -518,6 +518,7 @@ margin:15px auto;
 
 .app-footer__links{
   display: flex;
+  flex-wrap: wrap;
   gap: 16px;
   justify-content: center;
   margin-bottom: 8px;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,6 +21,8 @@
   --btn-accent-hover-bg: #2563eb;
   --btn-success-bg: #22c55e;
   --btn-accent-text: #ffffff;
+  --footer-text: rgba(255,255,255,0.85);
+  --footer-link: #ffffff;
 }
 
 [data-theme="dark"]{
@@ -46,6 +48,8 @@
   --btn-accent-hover-bg: #60a5fa;
   --btn-success-bg: #22c55e;
   --btn-accent-text: #ffffff;
+  --footer-text: rgba(226,232,240,0.85);
+  --footer-link: #e2e8f0;
 }
 
 body{
@@ -503,4 +507,35 @@ margin:15px auto;
   font-size: 13px;
   padding: 0;
   text-decoration: underline;
+}
+
+.app-footer{
+  text-align: center;
+  padding: 24px 16px;
+  color: var(--footer-text);
+  font-size: 14px;
+}
+
+.app-footer__links{
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.app-footer__links a{
+  color: var(--footer-link);
+  text-decoration: none;
+  font-weight: 600;
+  transition: opacity 0.2s ease;
+}
+
+.app-footer__links a:hover{
+  text-decoration: underline;
+  opacity: 0.85;
+}
+
+.app-footer__copy{
+  margin: 0;
+  opacity: 0.85;
 }


### PR DESCRIPTION
## Summary
Adds an always-visible footer to the app (a new `Footer` component) with:
- A link back to the GitHub repository — opens in a new tab with `rel="noopener noreferrer"`.
- A copyright line.

Styled with theme-aware CSS variables so it matches the app in both light and dark mode.

Closes #40

## Notes on scope
- **LinkedIn / social link** was left out because the maintainer's social URL isn't known — the footer markup makes it a one-line add whenever you'd like to include it.
- **License link** was left out because the repo currently has no `LICENSE` file. Happy to add the link (and/or a `LICENSE` file) in a follow-up if you'd like — just let me know which license you prefer.

## Test plan
- [x] `npx tsc --noEmit` passes.
- [x] Verified in-browser: footer renders on both the upload screen and the results screen (it's outside the results-only block).
- [x] GitHub link points to the repo, opens in a new tab, and uses `rel="noopener noreferrer"`.
- [x] Footer text/link colors resolve correctly in **both** light and dark themes.