### PR TITLE
Feature/rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,30 @@ Validates and parses an uploaded resume, matches standard technical keywords, ca
 
 ---
 
+## Rate Limiting
+
+The resume upload endpoint (`POST /api/upload/`) is throttled per client IP using DRF's `SimpleRateThrottle`.
+
+| Setting | Default | Description |
+| :--- | :--- | :--- |
+| `RESUME_UPLOAD_RATE` | `10/hour` | Max requests per IP. Format: `<n>/hour`, `<n>/day`, `<n>/min` |
+
+To change the limit, set `RESUME_UPLOAD_RATE` in your `server/.env`:
+
+```env
+RESUME_UPLOAD_RATE=20/hour
+```
+
+When the limit is exceeded, the API returns:
+
+```json
+// HTTP 429 Too Many Requests
+// Retry-After: <seconds>
+{ "detail": "Request was throttled. Expected available in <N> seconds." }
+```
+
+---
+
 ## Roadmap
 
 - [ ] **DOCX Document Parsing** — Integrate `python-docx` to support Word resume parser pipelines.

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,3 +2,7 @@
 SECRET_KEY=your_django_secret_key_here
 DEBUG=True
 ALLOWED_HOSTS=localhost,127.0.0.1,127.0.0.1:8000
+
+# Rate limiting for resume upload endpoint (default: 10/hour per IP)
+# Format: <number>/<period> — e.g. 10/hour, 100/day, 5/min
+RESUME_UPLOAD_RATE=10/hour

--- a/server/analyzer/views.py
+++ b/server/analyzer/views.py
@@ -1,12 +1,25 @@
-from rest_framework.decorators import api_view, parser_classes, permission_classes
+from rest_framework.decorators import api_view, parser_classes, permission_classes, throttle_classes
 from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
+from rest_framework.throttling import SimpleRateThrottle
 from rest_framework import status
 import pdfplumber
+from django.conf import settings
 
 from .models import ResumeAnalysis
 from .serializers import SignupSerializer, ResumeAnalysisSerializer
+
+
+class UploadRateThrottle(SimpleRateThrottle):
+    scope = "upload"
+
+    def get_rate(self):
+        return getattr(settings, "RESUME_UPLOAD_RATE", "10/hour")
+
+    def get_cache_key(self, request, view):
+        ident = self.get_ident(request)  # client IP
+        return self.cache_format % {"scope": self.scope, "ident": ident}
 
 skills_list = [
     "python", "django", "react", "javascript", "sql",
@@ -36,6 +49,7 @@ def signup(request):
 @api_view(["POST"])
 @parser_classes([MultiPartParser, FormParser])
 @permission_classes([AllowAny])
+@throttle_classes([UploadRateThrottle])
 def upload_resume(request):
     file = request.FILES.get("file")
     target_role = request.data.get("role", None)

--- a/server/resume_analyzer/settings.py
+++ b/server/resume_analyzer/settings.py
@@ -117,3 +117,6 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.AllowAny',
     ),
 }
+
+# Rate limiting: resume upload endpoint
+RESUME_UPLOAD_RATE = os.environ.get('RESUME_UPLOAD_RATE', '10/hour')


### PR DESCRIPTION
## Description

Added per-IP rate limiting to the resume upload endpoint using DRF's SimpleRateThrottle. Prevents abuse by capping requests to 10/hour per IP by default, returns a standard 429 response with retry info, and is fully configurable via environment variable.

## Related issue

Closes #21 

## Changes Made

- analyzer/views.py — added UploadRateThrottle class extending SimpleRateThrottle, reads rate from settings.RESUME_UPLOAD_RATE, applied to upload_resume via @throttle_classes
- resume_analyzer/settings.py — added RESUME_UPLOAD_RATE = os.environ.get('RESUME_UPLOAD_RATE', '10/hour')
- server/.env.example — documented RESUME_UPLOAD_RATE with format examples
- README.md — added Rate Limiting section with config table, .env example, and 429 response format

## Checklist

- [x]  10 requests/hour per IP via DRF throttle classes
- [x]  Returns 429 with Retry-After header and clear error message
- [x]  Configurable via RESUME_UPLOAD_RATE in settings/.env
- [x]  Documented in README

## Additional Notes

- Throttle applies only to POST /api/upload/ — auth and history endpoints are unaffected
- DRF handles the Retry-After header and 429 status automatically, no custom exception handling needed
- Rate format supports 10/hour, 100/day, 5/min — just update RESUME_UPLOAD_RATE in .env
