### PR TITLE
feat: add DOCX resume upload support (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Key Features
 
-- **Flexible Multi-Format Parsing** — Instant text extraction from files (PDF format) using Python `pdfplumber`.
+- **Flexible Multi-Format Parsing** — Instant text extraction from PDF resumes (`pdfplumber`) and Word `.docx` resumes (`python-docx`), all fed through the same     downstream analysis pipeline.
 - **ATS Optimizer & Scoring Engine** — High-performance scoring algorithm that parses resumes against technical standard keywords.
 - **Contextual Skill Extraction** — Detects core programming languages, frameworks, developer tools, database engines, and libraries.
 - **Dynamic Feedback Generation** — Yields smart suggestions recommending targeted certifications, technologies, and formatting changes.
@@ -55,7 +55,7 @@
                                                              │
                                                              ▼
                                                     ┌─────────────────┐
-                                                    │  PDFPlumber Parser│
+                                                    │ PDF / DOCX Parser│
                                                     └─────────────────┘
                                                              │
                                                              ▼
@@ -79,7 +79,7 @@
 * **Framework**: Django REST Framework (DRF)
 * **Language**: Python 3.10+
 * **CORS Management**: django-cors-headers
-* **Text Extractor**: PDFPlumber
+* **Text Extractors**: PDFPlumber (PDF) + python-docx (DOCX)
 
 ---
 
@@ -264,7 +264,7 @@ When the limit is exceeded, the API returns:
 
 ## Roadmap
 
-- [ ] **DOCX Document Parsing** — Integrate `python-docx` to support Word resume parser pipelines.
+- [x] **DOCX Document Parsing** — Integrate `python-docx` to support Word resume parser pipelines. #29
 - [ ] **Dark Mode Toggle** — Implement user-theme selections with CSS theme tokens persisted in `localStorage`.
 - [ ] **Target Job Role Comparison** — Match resume skill outputs directly against selectable target job roles.
 - [ ] **Persistent User Dashboard** — Save and render a timeline history of past scores using client-side indexing.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,22 @@ import { Footer } from "./Footer";
 
 type Theme = "light" | "dark";
 
+// Keep this in sync with the backend's SUPPORTED_RESUME_EXTENSIONS list
+// (server/analyzer/views.py). Used for both the file picker filter and
+// pre-upload validation so the user gets immediate feedback instead of
+// waiting for a 400 from the API.
+const SUPPORTED_RESUME_EXTENSIONS = [".pdf", ".docx"];
+const ACCEPTED_FILE_TYPES = ".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+function getResumeExtension(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot === -1 ? "" : name.slice(dot).toLowerCase();
+}
+
+function isSupportedResume(file: File): boolean {
+  return SUPPORTED_RESUME_EXTENSIONS.includes(getResumeExtension(file.name));
+}
+
 function getInitialTheme(): Theme {
   try {
     const saved = localStorage.getItem("theme");
@@ -107,6 +123,24 @@ function App() {
       setSuggestions(res.data.suggestions);
       setMatchedSkills(res.data.matched_skills || []);
       setMissingSkills(res.data.missing_skills || []);
+      setActiveFileName(fileToAnalyze.name);
+
+      // Persist to history for anonymous users (authenticated users get this
+      // server-side via /api/history/, so we just refresh from the DB instead).
+      if (!user) {
+        addEntry({
+          score: res.data.score,
+          skills: res.data.skills_found,
+          suggestions: res.data.suggestions,
+          matchedSkills: res.data.matched_skills || [],
+          missingSkills: res.data.missing_skills || [],
+          targetRole,
+          fileName: fileToAnalyze.name,
+        });
+      } else {
+        fetchDbHistory(user.token);
+      }
+
       setLoading(false);
     } catch (error) {
       console.error(error);
@@ -118,6 +152,13 @@ function App() {
   const uploadResume = async () => {
     if (!file) {
       alert("Please upload resume");
+      return;
+    }
+    if (!isSupportedResume(file)) {
+      alert(
+        `Unsupported file type. Please upload a PDF or DOCX resume (${SUPPORTED_RESUME_EXTENSIONS.join(", ")}).`
+      );
+      setFile(null);
       return;
     }
     await runAnalysis(file, "upload");
@@ -135,32 +176,9 @@ function App() {
       const sampleFile = new File([blob], "sample-resume.pdf", { type: "application/pdf" });
       await runAnalysis(sampleFile, "sample");
     } catch (error) {
-      console.error(error);
+      console.error("Could not load sample resume:", error instanceof Error ? error.message : "Unknown error");
       alert("Could not load sample resume");
       setLoading(false);
-      setActiveFileName(file.name);
-
-      // Save to localStorage only for anonymous users (authenticated saves to DB)
-      if (!user) {
-        addEntry({
-          score: res.data.score,
-          skills: res.data.skills_found,
-          suggestions: res.data.suggestions,
-          matchedSkills: res.data.matched_skills || [],
-          missingSkills: res.data.missing_skills || [],
-          targetRole,
-          fileName: file.name,
-        });
-      } else {
-        // Refresh DB history to include the new entry
-        fetchDbHistory(user.token);
-      }
-
-      setLoading(false);   
-    } catch (error) {
-      console.error("Upload failed:", error instanceof Error ? error.message : "Unknown error");
-      alert("Upload failed");
-      setLoading(false);   
     }
   };
 
@@ -253,13 +271,27 @@ function App() {
           <input
             type="file"
             id="fileUpload"
+            accept={ACCEPTED_FILE_TYPES}
             hidden
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              if (e.target.files) setFile(e.target.files[0]);
+              if (e.target.files && e.target.files.length > 0) {
+                const selected = e.target.files[0];
+                if (!isSupportedResume(selected)) {
+                  alert(
+                    `Unsupported file type. Please upload a PDF or DOCX resume (${SUPPORTED_RESUME_EXTENSIONS.join(", ")}).`
+                  );
+                  // Reset the input so the same invalid file can be re-selected
+                  // later without the browser ignoring the change event.
+                  e.target.value = "";
+                  setFile(null);
+                  return;
+                }
+                setFile(selected);
+              }
             }}
           />
           <label htmlFor="fileUpload" className="upload-label">
-            📄 {file ? file.name : "Drag & Drop Resume or Click to Upload"}
+            📄 {file ? file.name : "Drag & Drop Resume (PDF / DOCX) or Click to Upload"}
           </label>
         </div>
 

--- a/server/analyzer/views.py
+++ b/server/analyzer/views.py
@@ -4,11 +4,74 @@ from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework.throttling import SimpleRateThrottle
 from rest_framework import status
+import os
+
 import pdfplumber
+from docx import Document
+
 from django.conf import settings
 
 from .models import ResumeAnalysis
 from .serializers import SignupSerializer, ResumeAnalysisSerializer
+
+
+# Supported upload formats — kept in one place so frontend/backend stay in sync.
+SUPPORTED_RESUME_EXTENSIONS = (".pdf", ".docx")
+
+
+def extract_text_from_file(file_obj):
+    """
+    Extract plain text from an uploaded resume file.
+
+    Dispatches to the right parser based on the file extension so that the
+    rest of the analysis pipeline (skill detection, scoring, suggestions)
+    can stay 100% format-agnostic and produce the same output shape
+    regardless of whether the source was a PDF or a Word document.
+
+    Args:
+        file_obj: A Django UploadedFile (has .name and a file-like .file).
+
+    Returns:
+        str: The lowercased text content of the resume.
+
+    Raises:
+        ValueError: If the file extension is not supported or parsing fails.
+    """
+    original_name = getattr(file_obj, "name", "") or ""
+    ext = os.path.splitext(original_name)[1].lower()
+
+    if ext == ".pdf":
+        text = ""
+        # pdfplumber needs to read from the underlying file pointer.
+        # Reset to start in case anything has touched it already.
+        if hasattr(file_obj, "seek"):
+            file_obj.seek(0)
+        with pdfplumber.open(file_obj) as pdf:
+            for page in pdf.pages:
+                page_text = page.extract_text()
+                if page_text:
+                    text += page_text + "\n"
+        return text
+
+    if ext == ".docx":
+        # python-docx reads from the .docx zip archive directly.
+        if hasattr(file_obj, "seek"):
+            file_obj.seek(0)
+        document = Document(file_obj)
+        # Paragraphs cover most resume content; tables are also common in
+        # Word resumes (e.g. contact info, experience grids), so include them.
+        parts = [p.text for p in document.paragraphs if p.text]
+        for table in document.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    if cell.text:
+                        parts.append(cell.text)
+        return "\n".join(parts)
+
+    raise ValueError(
+        f"Unsupported file type '{ext or 'unknown'}'. "
+        f"Supported types: {', '.join(SUPPORTED_RESUME_EXTENSIONS)}"
+    )
 
 
 class UploadRateThrottle(SimpleRateThrottle):
@@ -53,14 +116,38 @@ def signup(request):
 def upload_resume(request):
     file = request.FILES.get("file")
     target_role = request.data.get("role", None)
-    file_name = file.name if file else "unknown"
 
-    text = ""
-    with pdfplumber.open(file) as pdf:
-        for page in pdf.pages:
-            page_text = page.extract_text()
-            if page_text:
-                text += page_text
+    # --- Input validation -------------------------------------------------
+    if not file:
+        return Response(
+            {"detail": "No file uploaded. Please attach a .pdf or .docx resume."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    file_name = file.name
+    ext = os.path.splitext(file_name)[1].lower()
+    if ext not in SUPPORTED_RESUME_EXTENSIONS:
+        return Response(
+            {
+                "detail": (
+                    f"Unsupported file type '{ext or 'unknown'}'. "
+                    f"Please upload one of: {', '.join(SUPPORTED_RESUME_EXTENSIONS)}."
+                )
+            },
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # --- Text extraction (format-agnostic from here on) -------------------
+    try:
+        text = extract_text_from_file(file)
+    except Exception as exc:
+        # Unsupported extension, corrupted file, encrypted PDF, malformed
+        # .docx, etc. — all surface to the client as a 400 with a helpful
+        # message so the rest of the API contract stays stable.
+        return Response(
+            {"detail": str(exc) or "Could not read the uploaded file."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
     text = text.lower()
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,4 +2,5 @@ django>=4.2,<6.0
 djangorestframework>=3.14.0
 django-cors-headers>=4.0.0
 pdfplumber>=0.10.0
+python-docx>=1.0.0
 djangorestframework-simplejwt>=5.3.0


### PR DESCRIPTION
Closes #29 

Extends resume upload support to .docx files (Word documents) alongside the existing PDF pipeline, using python-docx for text extraction. The downstream analysis pipeline (skill detection, scoring, suggestions) is unchanged, so PDF and DOCX uploads produce the same output shape.

**_Changes_**

**Backend**

- server/requirements.txt — Added python-docx>=1.0.0.
- server/analyzer/views.py
- - Added extract_text_from_file() helper that dispatches to the right parser by extension:
- - .pdf → pdfplumber
- - .docx → python-docx (paragraphs + tables)
- upload_resume now:
- - Returns 400 if no file is uploaded.
- - Returns 400 for unsupported file extensions.
- - Wraps extraction in try/except so corrupted/encrypted/malformed files surface as 400 with a helpful message instead of a 500.
- Added SUPPORTED_RESUME_EXTENSIONS = (".pdf", ".docx") constant (single source of truth, referenced in both frontend and backend).
- Analysis output JSON shape unchanged: {score, skills_found, suggestions, target_role, matched_skills, missing_skills}.

**Frontend**

- client/src/App.tsx
-- Added accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" to the file input.
-- Added isSupportedResume() client-side validation on both file selection and upload (immediate alert on invalid type, input reset so the same file can be re-selected later).
-- Updated upload-box label to 📄 Drag & Drop Resume (PDF / DOCX) or Click to Upload.
-- Kept the SUPPORTED_RESUME_EXTENSIONS list in sync with the backend (documented inline).
-- Fixed a pre-existing TypeScript build break in handleSampleResume (an orphaned catch block from an older uploadResume had been merged into it, producing error TS1005: 'try' expected). Without this fix the client could not build, blocking the new DOCX feature from running. The orphaned history-save logic was moved into the runAnalysis success path so it now actually fires for both PDF and DOCX uploads.

**Docs**
README.md — Updated Key Features, architecture diagram, and Tech Stack to mention DOCX support; checked off the "DOCX Document Parsing" roadmap item and tagged it (#29).

**Acceptance Criteria Checklist**
From issue #29:

- [x]  .docx files accepted by frontend validation
- [x]  Backend extracts text correctly from .docx
- [x]  Same analysis output format regardless of source file type

**Verification**

- python -m py_compile server/analyzer/views.py — OK
- npx tsc -b --noEmit (client) — clean, exit 0
- npm run build (client) — built successfully
- PDF regression test: ran the original pdfplumber.open path and the new extract_text_from_file path on client/public/sample-resume.pdf. Analysis output (score, skills_found, suggestions, matched_skills, missing_skills, target_role) is byte-for-byte identical between old and new code.
- DOCX functional test: generated a .docx with resume content (paragraphs + table), ran it through extract_text_from_file. All expected skills were detected and table content was extracted correctly.
- Unsupported extension test: .txt returns a 400 with a clear error message.

**How to Test**

1. pip install -r server/requirements.txt (picks up python-docx)
2. cd client && npm install && npm run dev
3. python server/manage.py runserver (ensure .env has SECRET_KEY set)
4. Upload a .docx resume → verify it produces the same JSON shape as a PDF upload
5. Try uploading a .txt or .png → verify frontend alert + backend 400