### PR TITLE
feat: add JD matching — compare resume against a pasted job description (#18)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,21 @@ import { AuthModal } from "./AuthModal";
 import { Footer } from "./Footer";
 
 type Theme = "light" | "dark";
+type AppMode = "single" | "jd";
+
+// ---------------------------------------------------------------------------
+// Type mirroring the backend's /api/jd-match/ response shape
+// (server/analyzer/views.py). Kept in sync so the JD-match view can safely
+// index into the API response.
+// ---------------------------------------------------------------------------
+interface JdMatchResponse {
+  match_percent: number;
+  matched_keywords: string[];
+  missing_keywords: string[];
+  resume_skills_detected: string[];
+  jd_keyword_count: number;
+  file_name: string;
+}
 
 // ---------------------------------------------------------------------------
 // Feature detection for the Drag-and-Drop API. Older browsers (and some
@@ -39,6 +54,7 @@ function getInitialTheme(): Theme {
 
 function App() {
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
+  const [mode, setMode] = useState<AppMode>("single");
   const [loading, setLoading] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [score, setScore] = useState<number | null>(null);
@@ -51,10 +67,14 @@ function App() {
   const [missingSkills, setMissingSkills] = useState<string[]>([]);
   const [showAllSkills, setShowAllSkills] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [analysisSource, setAnalysisSource] = useState<"sample" | "upload" | null>(null);
+  const [analysisSource, setAnalysisSource] = useState<"sample" | "upload" | "jd" | null>(null);
 
   // Drag-and-drop highlight state (issue #20 acceptance #1)
   const [isDragActive, setIsDragActive] = useState(false);
+
+  // --- JD-match mode state (issue #18) -----------------------------------
+  const [jdText, setJdText] = useState("");
+  const [jdMatch, setJdMatch] = useState<JdMatchResponse | null>(null);
 
   // Auth
   const { user, signup, login, logout } = useAuth();
@@ -253,6 +273,55 @@ function App() {
     }
   };
 
+  // --- JD-match analysis flow (issue #18) ---------------------------------
+  const runJdMatch = async () => {
+    if (!file) {
+      alert("Please upload a resume first.");
+      return;
+    }
+    if (!jdText.trim()) {
+      alert("Please paste the job description text.");
+      return;
+    }
+    try {
+      setLoading(true);
+      setAnalysisSource("jd");
+      setJdMatch(null);
+
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("jd", jdText);
+
+      const headers = user ? { Authorization: `Bearer ${user.token}` } : {};
+      const res = await axios.post<JdMatchResponse>(`${backendUrl}/api/jd-match/`, formData, { headers });
+      setJdMatch(res.data);
+      setActiveFileName(res.data.file_name);
+
+      // Refresh DB history for authenticated users (the backend persists the
+      // JD match as a regular ResumeAnalysis row with target_role="JD Match").
+      if (user) {
+        fetchDbHistory(user.token);
+      } else {
+        // Anonymous history entry so the user can revisit the result.
+        addEntry({
+          score: res.data.match_percent,
+          skills: res.data.resume_skills_detected,
+          suggestions: res.data.missing_keywords.slice(0, 10).map((k) => `Add JD keyword: ${k}`),
+          matchedSkills: res.data.matched_keywords,
+          missingSkills: res.data.missing_keywords,
+          targetRole: "JD Match",
+          fileName: res.data.file_name,
+        });
+      }
+
+      setLoading(false);
+    } catch (error) {
+      console.error("JD match failed:", error);
+      alert("JD match failed");
+      setLoading(false);
+    }
+  };
+
   const copySuggestionsToClipboard = () => {
     if (suggestions.length === 0) return;
     const plainTextSuggestions = suggestions.map((s: string) => `• ${s}`).join("\n");
@@ -285,6 +354,17 @@ function App() {
     : file
       ? `📄 ${file.name}`
       : "Drag & Drop Resume or Click to Upload";
+
+  // Helper to render the match-percent circle's color based on score.
+  // Reused by AtsScore but we also want to color the headline label.
+  const matchTone =
+    jdMatch === null
+      ? "neutral"
+      : jdMatch.match_percent >= 70
+        ? "good"
+        : jdMatch.match_percent >= 40
+          ? "mid"
+          : "low";
 
   return (
     <>
@@ -330,22 +410,48 @@ function App() {
 
         <h1 className="mb-4">🚀 AI Resume Analyzer</h1>
 
-        {/* Role Selector Dropdown */}
-        <div className="mb-4">
-          <label htmlFor="roleSelect" style={{ marginRight: "10px", fontWeight: "600", color: "#fff" }}>
-            Target Career Track:
-          </label>
-          <select
-            id="roleSelect"
-            value={targetRole}
-            onChange={(e) => setTargetRole(e.target.value)}
-            style={{ padding: "6px 12px", borderRadius: "6px", border: "1px solid #ccc" }}
+        {/* Mode toggle — Single vs JD Match (issue #18) */}
+        <div className="mode-toggle mb-4" role="tablist" aria-label="Analyzer mode">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === "single"}
+            className={`mode-toggle__btn${mode === "single" ? " is-active" : ""}`}
+            onClick={() => setMode("single")}
           >
-            <option value="Frontend Developer">Frontend Developer</option>
-            <option value="Backend Developer">Backend Developer</option>
-            <option value="Data Analyst">Data Analyst</option>
-          </select>
+            📄 Single Resume
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === "jd"}
+            className={`mode-toggle__btn${mode === "jd" ? " is-active" : ""}`}
+            onClick={() => setMode("jd")}
+          >
+            🎯 Match Against Job Description
+          </button>
         </div>
+
+        {/* Role Selector Dropdown (single-mode only — JD mode derives its
+            "required keywords" from the JD itself, so a generic role is
+            not relevant). */}
+        {mode === "single" && (
+          <div className="mb-4">
+            <label htmlFor="roleSelect" style={{ marginRight: "10px", fontWeight: "600", color: "#fff" }}>
+              Target Career Track:
+            </label>
+            <select
+              id="roleSelect"
+              value={targetRole}
+              onChange={(e) => setTargetRole(e.target.value)}
+              style={{ padding: "6px 12px", borderRadius: "6px", border: "1px solid #ccc" }}
+            >
+              <option value="Frontend Developer">Frontend Developer</option>
+              <option value="Backend Developer">Backend Developer</option>
+              <option value="Data Analyst">Data Analyst</option>
+            </select>
+          </div>
+        )}
 
         {/* ----------------------------------------------------------------- */}
         {/* Upload zone — supports BOTH click-to-upload (label→input) and     */}
@@ -383,105 +489,222 @@ function App() {
           </label>
         </div>
 
-        <div style={{ display: "flex", gap: "12px", justifyContent: "center", alignItems: "center" }} className="mb-3">
-          <button
-            className="analyze-btn"
-            onClick={uploadResume}
-            disabled={loading}
-          >
-            {loading && analysisSource === "upload" ? "⏳ Analyzing..." : "🚀 Analyze Resume"}
-          </button>
-          <button
-            className="secondary-btn"
-            onClick={handleSampleResume}
-            disabled={loading}
-            type="button"
-          >
-            {loading && analysisSource === "sample" ? "⏳ Loading Sample..." : "Try Sample Resume"}
-          </button>
-        </div>
-        <button type="button" className="app-btn analyze-btn" onClick={uploadResume} disabled={loading}>
-          {loading ? "⏳ Analyzing..." : "🚀 Analyze Resume"}
-        </button>
-
-        {score !== null && (
+        {mode === "single" && (
           <>
-            {analysisSource === "sample" && (
-              <div className="sample-notice-banner mb-4">
-                <span>ℹ️ Viewing Sample Resume Analysis</span>
-                <span style={{ fontWeight: "normal", fontSize: "13px" }}>
-                  — This analysis is based on a bundled sample resume.
-                </span>
-              </div>
-            )}
-
-            <AtsScore score={score} />
-
-            <h5 className="analysis-done">
-              ✅ Resume Analysis Complete
-            </h5>
-            {activeFileName && (
-              <p style={{ fontSize: "13px", opacity: 0.7, marginTop: "-8px" }}>📄 {activeFileName}</p>
-            )}
-
-            {/* SKILLS CONTAINER */}
-            <div className="mt-4">
-              <h4>Skills Found ({skills.length})</h4>
-              {skills.length === 0 && <p>No skills detected</p>}
-              <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", justifyContent: "center" }}>
-                {(showAllSkills ? skills : skills.slice(0, 15)).map((skill: string, i: number) => (
-                  <span key={i} className="skill-badge">{skill}</span>
-                ))}
-              </div>
-              {skills.length > 15 && (
-                <button
-                  type="button"
-                  className="app-btn app-btn--secondary"
-                  style={{ marginTop: "16px" }}
-                  onClick={() => setShowAllSkills(!showAllSkills)}
-                >
-                  {showAllSkills ? "Show Less ▲" : `Show More (${skills.length - 15} more) ▼`}
-                </button>
-              )}
+            <div style={{ display: "flex", gap: "12px", justifyContent: "center", alignItems: "center" }} className="mb-3">
+              <button
+                className="analyze-btn"
+                onClick={uploadResume}
+                disabled={loading}
+              >
+                {loading && analysisSource === "upload" ? "⏳ Analyzing..." : "🚀 Analyze Resume"}
+              </button>
+              <button
+                className="secondary-btn"
+                onClick={handleSampleResume}
+                disabled={loading}
+                type="button"
+              >
+                {loading && analysisSource === "sample" ? "⏳ Loading Sample..." : "Try Sample Resume"}
+              </button>
             </div>
+            <button type="button" className="app-btn analyze-btn" onClick={uploadResume} disabled={loading}>
+              {loading ? "⏳ Analyzing..." : "🚀 Analyze Resume"}
+            </button>
 
-            {/* SKILL GAP MATRIX */}
-            <div className="mt-4 p-3" style={{ background: "rgba(255,255,255,0.05)", borderRadius: "8px" }}>
-              <h4>🎯 Skill Gap Matrix ({targetRole})</h4>
-              <div style={{ display: "flex", justifyContent: "space-around", marginTop: "12px" }}>
-                <div>
-                  <h6 style={{ color: "#22c55e" }}>Matched Skills</h6>
-                  {matchedSkills.length === 0 ? <p style={{ fontSize: "12px" }}>None</p> : matchedSkills.map((s: string, i: number) => (
-                    <span key={i} className="badge bg-success m-1" style={{ display: "inline-block", padding: "4px 8px", background: "#22c55e", borderRadius: "4px", margin: "2px", color: "#fff" }}>{s}</span>
-                  ))}
-                </div>
-                <div>
-                  <h6 style={{ color: "#ef4444" }}>Missing Skills</h6>
-                  {missingSkills.length === 0 ? <p style={{ fontSize: "12px" }}>None</p> : missingSkills.map((s: string, i: number) => (
-                    <span key={i} className="badge bg-danger m-1" style={{ display: "inline-block", padding: "4px 8px", background: "#ef4444", borderRadius: "4px", margin: "2px", color: "#fff" }}>{s}</span>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* SUGGESTIONS BOX WITH THE UTILITY BUTTON */}
-            <div className="suggestion-box mt-4">
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" }}>
-                <h4 style={{ margin: 0 }}>💡 Suggestions</h4>
-                {suggestions.length > 0 && (
-                  <button
-                    type="button"
-                    className={`app-btn app-btn--accent${copied ? " is-success" : ""}`}
-                    onClick={copySuggestionsToClipboard}
-                  >
-                    {copied ? "✅ Copied!" : "📋 Copy Suggestions"}
-                  </button>
+            {score !== null && (
+              <>
+                {analysisSource === "sample" && (
+                  <div className="sample-notice-banner mb-4">
+                    <span>ℹ️ Viewing Sample Resume Analysis</span>
+                    <span style={{ fontWeight: "normal", fontSize: "13px" }}>
+                      — This analysis is based on a bundled sample resume.
+                    </span>
+                  </div>
                 )}
+
+                <AtsScore score={score} />
+
+                <h5 className="analysis-done">
+                  ✅ Resume Analysis Complete
+                </h5>
+                {activeFileName && (
+                  <p style={{ fontSize: "13px", opacity: 0.7, marginTop: "-8px" }}>📄 {activeFileName}</p>
+                )}
+
+                {/* SKILLS CONTAINER */}
+                <div className="mt-4">
+                  <h4>Skills Found ({skills.length})</h4>
+                  {skills.length === 0 && <p>No skills detected</p>}
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", justifyContent: "center" }}>
+                    {(showAllSkills ? skills : skills.slice(0, 15)).map((skill: string, i: number) => (
+                      <span key={i} className="skill-badge">{skill}</span>
+                    ))}
+                  </div>
+                  {skills.length > 15 && (
+                    <button
+                      type="button"
+                      className="app-btn app-btn--secondary"
+                      style={{ marginTop: "16px" }}
+                      onClick={() => setShowAllSkills(!showAllSkills)}
+                    >
+                      {showAllSkills ? "Show Less ▲" : `Show More (${skills.length - 15} more) ▼`}
+                    </button>
+                  )}
+                </div>
+
+                {/* SKILL GAP MATRIX */}
+                <div className="mt-4 p-3" style={{ background: "rgba(255,255,255,0.05)", borderRadius: "8px" }}>
+                  <h4>🎯 Skill Gap Matrix ({targetRole})</h4>
+                  <div style={{ display: "flex", justifyContent: "space-around", marginTop: "12px" }}>
+                    <div>
+                      <h6 style={{ color: "#22c55e" }}>Matched Skills</h6>
+                      {matchedSkills.length === 0 ? <p style={{ fontSize: "12px" }}>None</p> : matchedSkills.map((s: string, i: number) => (
+                        <span key={i} className="badge bg-success m-1" style={{ display: "inline-block", padding: "4px 8px", background: "#22c55e", borderRadius: "4px", margin: "2px", color: "#fff" }}>{s}</span>
+                      ))}
+                    </div>
+                    <div>
+                      <h6 style={{ color: "#ef4444" }}>Missing Skills</h6>
+                      {missingSkills.length === 0 ? <p style={{ fontSize: "12px" }}>None</p> : missingSkills.map((s: string, i: number) => (
+                        <span key={i} className="badge bg-danger m-1" style={{ display: "inline-block", padding: "4px 8px", background: "#ef4444", borderRadius: "4px", margin: "2px", color: "#fff" }}>{s}</span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                {/* SUGGESTIONS BOX WITH THE UTILITY BUTTON */}
+                <div className="suggestion-box mt-4">
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" }}>
+                    <h4 style={{ margin: 0 }}>💡 Suggestions</h4>
+                    {suggestions.length > 0 && (
+                      <button
+                        type="button"
+                        className={`app-btn app-btn--accent${copied ? " is-success" : ""}`}
+                        onClick={copySuggestionsToClipboard}
+                      >
+                        {copied ? "✅ Copied!" : "📋 Copy Suggestions"}
+                      </button>
+                    )}
+                  </div>
+                  {suggestions.map((s: string, i: number) => (
+                    <div key={i} className="suggestion-item">📌 {s}</div>
+                  ))}
+                </div>
+              </>
+            )}
+          </>
+        )}
+
+        {mode === "jd" && (
+          <>
+            {/* JD paste form (issue #18 acceptance #3 — frontend form) */}
+            <div className="jd-form mb-3">
+              <label htmlFor="jdText" className="jd-form__label">
+                📋 Paste Job Description:
+              </label>
+              <textarea
+                id="jdText"
+                className="jd-form__textarea"
+                value={jdText}
+                onChange={(e) => setJdText(e.target.value)}
+                placeholder="Paste the full job description here. The analyzer will extract required keywords and check which ones your resume covers."
+                rows={10}
+                disabled={loading}
+                aria-label="Job description text input"
+              />
+              <div className="jd-form__meta">
+                {jdText.trim().length > 0
+                  ? `${jdText.trim().length} characters pasted`
+                  : "No JD pasted yet"}
               </div>
-              {suggestions.map((s: string, i: number) => (
-                <div key={i} className="suggestion-item">📌 {s}</div>
-              ))}
             </div>
+
+            <div style={{ display: "flex", gap: "12px", justifyContent: "center", alignItems: "center" }} className="mb-3">
+              <button
+                className="analyze-btn"
+                onClick={runJdMatch}
+                disabled={loading || !file || !jdText.trim()}
+              >
+                {loading && analysisSource === "jd" ? "⏳ Matching..." : "🎯 Match Against JD"}
+              </button>
+              <button
+                className="secondary-btn"
+                type="button"
+                onClick={() => {
+                  setJdMatch(null);
+                  setJdText("");
+                }}
+                disabled={loading}
+              >
+                Clear
+              </button>
+            </div>
+
+            {jdMatch && (
+              <>
+                {/* Match-percent headline + score circle (issue #18 acceptance #2) */}
+                <div className={`jd-match-summary jd-match-summary--${matchTone} mb-4`}>
+                  <h4 style={{ margin: 0 }}>
+                    {matchTone === "good" && "🎉 Strong Match"}
+                    {matchTone === "mid" && "🟡 Partial Match"}
+                    {matchTone === "low" && "🔴 Weak Match"}
+                  </h4>
+                  <p className="jd-match-summary__percent">{jdMatch.match_percent}%</p>
+                  <p className="jd-match-summary__sub">
+                    {jdMatch.matched_keywords.length} of {jdMatch.jd_keyword_count} JD keywords found in your resume
+                  </p>
+                </div>
+
+                <AtsScore score={jdMatch.match_percent} />
+                <h5 className="analysis-done">✅ JD Match Complete</h5>
+                {activeFileName && (
+                  <p style={{ fontSize: "13px", opacity: 0.7, marginTop: "-8px" }}>📄 {activeFileName}</p>
+                )}
+
+                {/* Matched vs Missing keywords (issue #18 acceptance #2) */}
+                <div className="jd-keywords mt-4">
+                  <div className="jd-keywords__row">
+                    <div className="jd-keywords__col jd-keywords__col--matched">
+                      <h6>✅ In Your Resume ({jdMatch.matched_keywords.length})</h6>
+                      {jdMatch.matched_keywords.length === 0 ? (
+                        <p style={{ fontSize: "12px" }}>None</p>
+                      ) : (
+                        <div className="jd-keywords__list">
+                          {jdMatch.matched_keywords.map((k, i) => (
+                            <span key={i} className="skill-badge skill-badge--matched">{k}</span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="jd-keywords__col jd-keywords__col--missing">
+                      <h6>❌ Missing From Your Resume ({jdMatch.missing_keywords.length})</h6>
+                      {jdMatch.missing_keywords.length === 0 ? (
+                        <p style={{ fontSize: "12px" }}>None — great match!</p>
+                      ) : (
+                        <div className="jd-keywords__list">
+                          {jdMatch.missing_keywords.map((k, i) => (
+                            <span key={i} className="skill-badge skill-badge--missing">{k}</span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Resume skills detected (reuses the curated skill list so the
+                    user can compare their general skill coverage against the
+                    JD-specific match). */}
+                <div className="mt-4">
+                  <h4>Skills Detected in Your Resume ({jdMatch.resume_skills_detected.length})</h4>
+                  {jdMatch.resume_skills_detected.length === 0 && <p>No skills detected</p>}
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", justifyContent: "center" }}>
+                    {jdMatch.resume_skills_detected.map((skill: string, i: number) => (
+                      <span key={i} className="skill-badge">{skill}</span>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
           </>
         )}
       </div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import axios from "axios";
 import "./index.css";
 import { AtsScore } from "./AtsScore";
@@ -9,6 +9,20 @@ import { AuthModal } from "./AuthModal";
 import { Footer } from "./Footer";
 
 type Theme = "light" | "dark";
+
+// ---------------------------------------------------------------------------
+// Feature detection for the Drag-and-Drop API. Older browsers (and some
+// locked-down webviews) don't support DataTransfer.items or even the
+// 'drop' event on arbitrary elements. When the feature is missing we fall
+// back to the existing click-to-upload flow — the hidden <input type="file">
+// stays in the DOM and the label remains clickable, so the upload zone is
+// never broken (issue #20 acceptance criterion #3).
+// ---------------------------------------------------------------------------
+const supportsDragAndDrop = (() => {
+  if (typeof window === "undefined") return false;
+  const div = document.createElement("div");
+  return "draggable" in div && "ondragenter" in div && typeof DataTransfer !== "undefined";
+})();
 
 function getInitialTheme(): Theme {
   try {
@@ -30,7 +44,7 @@ function App() {
   const [score, setScore] = useState<number | null>(null);
   const [skills, setSkills] = useState<string[]>([]);
   const [suggestions, setSuggestions] = useState<string[]>([]);
-  
+
   // Component States
   const [targetRole, setTargetRole] = useState("Frontend Developer");
   const [matchedSkills, setMatchedSkills] = useState<string[]>([]);
@@ -38,6 +52,9 @@ function App() {
   const [showAllSkills, setShowAllSkills] = useState(false);
   const [copied, setCopied] = useState(false);
   const [analysisSource, setAnalysisSource] = useState<"sample" | "upload" | null>(null);
+
+  // Drag-and-drop highlight state (issue #20 acceptance #1)
+  const [isDragActive, setIsDragActive] = useState(false);
 
   // Auth
   const { user, signup, login, logout } = useAuth();
@@ -107,6 +124,24 @@ function App() {
       setSuggestions(res.data.suggestions);
       setMatchedSkills(res.data.matched_skills || []);
       setMissingSkills(res.data.missing_skills || []);
+      setActiveFileName(fileToAnalyze.name);
+
+      // Persist to history for anonymous users (authenticated users get this
+      // server-side via /api/history/, so we just refresh from the DB instead).
+      if (!user) {
+        addEntry({
+          score: res.data.score,
+          skills: res.data.skills_found,
+          suggestions: res.data.suggestions,
+          matchedSkills: res.data.matched_skills || [],
+          missingSkills: res.data.missing_skills || [],
+          targetRole,
+          fileName: fileToAnalyze.name,
+        });
+      } else {
+        fetchDbHistory(user.token);
+      }
+
       setLoading(false);
     } catch (error) {
       console.error(error);
@@ -115,12 +150,89 @@ function App() {
     }
   };
 
+  // ---------------------------------------------------------------------------
+  // Shared validation entry-point — used by BOTH the file-picker <input>
+  // and the drag-and-drop handler. Issue #20 acceptance criterion #2
+  // ("Dropped file goes through the same validation as the file picker")
+  // is satisfied by routing both flows through this single function.
+  // ---------------------------------------------------------------------------
+  const validateAndSetFile = (candidate: File | null | undefined): boolean => {
+    if (!candidate) return false;
+    // The backend (server/analyzer/views.py) accepts PDFs via pdfplumber.
+    // Mirror that constraint client-side so the user gets immediate feedback
+    // instead of a 400 from the API. We check both the MIME type and the
+    // extension since some browsers assign a generic MIME to dropped files.
+    const name = candidate.name || "";
+    const ext = name.slice(((name.lastIndexOf(".") as number) + 1) || Infinity).toLowerCase();
+    const isPdf =
+      candidate.type === "application/pdf" ||
+      ext === "pdf";
+
+    if (!isPdf) {
+      alert("Unsupported file type. Please upload a PDF resume.");
+      return false;
+    }
+    setFile(candidate);
+    return true;
+  };
+
   const uploadResume = async () => {
     if (!file) {
       alert("Please upload resume");
       return;
     }
     await runAnalysis(file, "upload");
+  };
+
+  // --- Drag-and-drop handlers (issue #20) ---------------------------------
+  // We must preventDefault on dragenter/dragover/dragleave/drop — otherwise
+  // the browser opens the file in a new tab instead of letting us handle it.
+  // The drag counter pattern (dragDepthRef) avoids the flicker that happens
+  // when the pointer crosses child elements inside the drop zone.
+  const dragDepthRef = useCallbackRef(0);
+
+  const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!supportsDragAndDrop) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current += 1;
+    if (e.dataTransfer?.items && e.dataTransfer.items.length > 0) {
+      setIsDragActive(true);
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!supportsDragAndDrop) return;
+    e.preventDefault();
+    e.stopPropagation();
+    // Explicitly signal a "copy" drop effect so the cursor reflects intent.
+    if (e.dataTransfer) {
+      e.dataTransfer.dropEffect = "copy";
+    }
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!supportsDragAndDrop) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current -= 1;
+    if (dragDepthRef.current <= 0) {
+      dragDepthRef.current = 0;
+      setIsDragActive(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!supportsDragAndDrop) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current = 0;
+    setIsDragActive(false);
+
+    const droppedFile = e.dataTransfer?.files?.[0];
+    // validateAndSetFile runs the SAME checks as the file picker, satisfying
+    // issue #20 acceptance criterion #2.
+    validateAndSetFile(droppedFile);
   };
 
   const handleSampleResume = async () => {
@@ -135,32 +247,9 @@ function App() {
       const sampleFile = new File([blob], "sample-resume.pdf", { type: "application/pdf" });
       await runAnalysis(sampleFile, "sample");
     } catch (error) {
-      console.error(error);
+      console.error("Could not load sample resume:", error instanceof Error ? error.message : "Unknown error");
       alert("Could not load sample resume");
       setLoading(false);
-      setActiveFileName(file.name);
-
-      // Save to localStorage only for anonymous users (authenticated saves to DB)
-      if (!user) {
-        addEntry({
-          score: res.data.score,
-          skills: res.data.skills_found,
-          suggestions: res.data.suggestions,
-          matchedSkills: res.data.matched_skills || [],
-          missingSkills: res.data.missing_skills || [],
-          targetRole,
-          fileName: file.name,
-        });
-      } else {
-        // Refresh DB history to include the new entry
-        fetchDbHistory(user.token);
-      }
-
-      setLoading(false);   
-    } catch (error) {
-      console.error("Upload failed:", error instanceof Error ? error.message : "Unknown error");
-      alert("Upload failed");
-      setLoading(false);   
     }
   };
 
@@ -187,6 +276,15 @@ function App() {
     setCopied(false);
     setHistoryOpen(false);
   };
+
+  // Build the className for the upload zone, including the drag-active
+  // modifier when a file is being dragged over it.
+  const uploadBoxClass = `upload-box mb-3${isDragActive ? " upload-box--drag-active" : ""}`;
+  const uploadLabel = isDragActive
+    ? "⬇️ Drop your resume here"
+    : file
+      ? `📄 ${file.name}`
+      : "Drag & Drop Resume or Click to Upload";
 
   return (
     <>
@@ -249,30 +347,52 @@ function App() {
           </select>
         </div>
 
-        <div className="upload-box mb-3">
+        {/* ----------------------------------------------------------------- */}
+        {/* Upload zone — supports BOTH click-to-upload (label→input) and     */}
+        {/* drag-and-drop (div handlers). The hidden <input type="file">     */}
+        {/* stays clickable via the <label htmlFor>, so browsers without     */}
+        {/* Drag-and-Drop support still upload normally (issue #20 acc #3).   */}
+        {/* ----------------------------------------------------------------- */}
+        <div
+          className={uploadBoxClass}
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          role="button"
+          tabIndex={0}
+          aria-label="Resume upload zone. Drag and drop a PDF or click to browse."
+          aria-dropeffect={isDragActive ? "copy" : "none"}
+        >
           <input
             type="file"
             id="fileUpload"
+            accept="application/pdf,.pdf"
             hidden
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              if (e.target.files) setFile(e.target.files[0]);
+              // Route through the same validator as the drop handler so
+              // issue #20 acceptance criterion #2 holds in both directions.
+              validateAndSetFile(e.target.files?.[0]);
+              // Clear the input value so selecting the same file again
+              // after a rejection still fires a change event.
+              if (e.target) e.target.value = "";
             }}
           />
           <label htmlFor="fileUpload" className="upload-label">
-            📄 {file ? file.name : "Drag & Drop Resume or Click to Upload"}
+            {uploadLabel}
           </label>
         </div>
 
         <div style={{ display: "flex", gap: "12px", justifyContent: "center", alignItems: "center" }} className="mb-3">
-          <button 
-            className="analyze-btn" 
+          <button
+            className="analyze-btn"
             onClick={uploadResume}
             disabled={loading}
           >
             {loading && analysisSource === "upload" ? "⏳ Analyzing..." : "🚀 Analyze Resume"}
           </button>
-          <button 
-            className="secondary-btn" 
+          <button
+            className="secondary-btn"
             onClick={handleSampleResume}
             disabled={loading}
             type="button"
@@ -370,6 +490,15 @@ function App() {
     </div>
     </>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Tiny helper: a mutable ref whose value persists across renders without
+// triggering re-renders. Used for the drag-enter/leave counter so we don't
+// flicker the highlight when the pointer crosses child elements.
+// ---------------------------------------------------------------------------
+function useCallbackRef<T>(initial: T): { current: T } {
+  return useRef<T>(initial);
 }
 
 export default App;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -169,6 +169,25 @@ padding:25px;
 border-radius:10px;
 cursor:pointer;
 background: var(--upload-bg);
+/* Smooth transitions for the drag-active highlight (issue #20) */
+transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+/* Drag-over highlight state (issue #20 acceptance #1).
+   Applies to the upload zone when a file is being dragged over it.
+   Uses theme tokens so it works in both light and dark themes, with
+   an extra accent glow from --score-accent. */
+.upload-box--drag-active{
+border-color: var(--score-accent);
+border-style: solid;
+background: rgba(0, 255, 174, 0.12);
+box-shadow: 0 0 0 4px rgba(0, 255, 174, 0.18), 0 8px 24px rgba(0, 0, 0, 0.15);
+transform: scale(1.01);
+}
+
+[data-theme="dark"] .upload-box--drag-active{
+background: rgba(34, 211, 238, 0.14);
+box-shadow: 0 0 0 4px rgba(34, 211, 238, 0.18), 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 .upload-label{

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -609,3 +609,188 @@ margin:15px auto;
   margin: 0;
   opacity: 0.85;
 }
+/* ── Mode toggle (Single / JD Match) ────── */
+
+.mode-toggle {
+  display: inline-flex;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.18);
+  border-radius: 999px;
+  padding: 4px;
+  gap: 4px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.mode-toggle__btn {
+  background: transparent;
+  color: var(--card-text);
+  border: none;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  opacity: 0.65;
+  transition: background 0.2s ease, opacity 0.2s ease, transform 0.15s ease;
+  font-family: inherit;
+}
+
+.mode-toggle__btn:hover {
+  opacity: 0.9;
+}
+
+.mode-toggle__btn.is-active {
+  background: var(--score-accent);
+  color: #000;
+  opacity: 1;
+}
+
+/* ── JD match: paste form ──────────────── */
+
+.jd-form {
+  text-align: left;
+}
+
+.jd-form__label {
+  display: block;
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 8px;
+  color: var(--card-text);
+}
+
+.jd-form__textarea {
+  width: 100%;
+  min-height: 180px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.25);
+  background: rgba(255,255,255,0.08);
+  color: var(--card-text);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.jd-form__textarea:focus {
+  outline: none;
+  border-color: var(--score-accent);
+  background: rgba(255,255,255,0.12);
+}
+
+.jd-form__textarea::placeholder {
+  color: var(--card-text);
+  opacity: 0.55;
+}
+
+.jd-form__textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.jd-form__meta {
+  margin-top: 6px;
+  font-size: 11px;
+  opacity: 0.6;
+  text-align: right;
+}
+
+/* ── JD match: summary banner ──────────── */
+
+.jd-match-summary {
+  padding: 18px 20px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.05);
+  text-align: center;
+}
+
+.jd-match-summary--good {
+  background: rgba(34,197,94,0.12);
+  border-color: rgba(34,197,94,0.4);
+}
+
+.jd-match-summary--mid {
+  background: rgba(234,179,8,0.12);
+  border-color: rgba(234,179,8,0.4);
+}
+
+.jd-match-summary--low {
+  background: rgba(239,68,68,0.12);
+  border-color: rgba(239,68,68,0.4);
+}
+
+.jd-match-summary__percent {
+  margin: 6px 0 4px;
+  font-size: 36px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.jd-match-summary__sub {
+  margin: 0;
+  font-size: 13px;
+  opacity: 0.85;
+}
+
+/* ── JD match: matched vs missing keywords ── */
+
+.jd-keywords {
+  padding: 4px 0;
+}
+
+.jd-keywords__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 700px) {
+  .jd-keywords__row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.jd-keywords__col {
+  padding: 14px;
+  border-radius: 10px;
+  text-align: left;
+}
+
+.jd-keywords__col--matched {
+  background: rgba(34,197,94,0.08);
+  border: 1px solid rgba(34,197,94,0.25);
+}
+
+.jd-keywords__col--missing {
+  background: rgba(239,68,68,0.08);
+  border: 1px solid rgba(239,68,68,0.25);
+}
+
+.jd-keywords__col h6 {
+  margin: 0 0 10px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.jd-keywords__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* ── JD match: keyword badge variants ──── */
+
+.skill-badge--matched {
+  background: #22c55e !important;
+  color: #fff !important;
+}
+
+.skill-badge--missing {
+  background: #ef4444 !important;
+  color: #fff !important;
+}

--- a/server/analyzer/urls.py
+++ b/server/analyzer/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
-from .views import upload_resume, signup, analysis_history
+from .views import upload_resume, match_jd, signup, analysis_history
 
 urlpatterns = [
     path("upload/", upload_resume),
+    path("jd-match/", match_jd),
     path("auth/signup/", signup),
     path("auth/login/", TokenObtainPairView.as_view()),
     path("auth/refresh/", TokenRefreshView.as_view()),

--- a/server/analyzer/views.py
+++ b/server/analyzer/views.py
@@ -1,3 +1,4 @@
+import re
 from rest_framework.decorators import api_view, parser_classes, permission_classes, throttle_classes
 from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.permissions import IsAuthenticated, AllowAny
@@ -36,32 +37,33 @@ ROLE_SKILL_MATRICES = {
 }
 
 
-@api_view(["POST"])
-@permission_classes([AllowAny])
-def signup(request):
-    serializer = SignupSerializer(data=request.data)
-    if serializer.is_valid():
-        serializer.save()
-        return Response({"detail": "Account created."}, status=status.HTTP_201_CREATED)
-    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+# ---------------------------------------------------------------------------
+# Core analysis helpers — shared by upload_resume and match_jd so the single
+# upload flow is unchanged and the new JD-matching flow can reuse the same
+# text-extraction + skill-detection logic. Issue #18 requires a NEW endpoint
+# but the analysis primitives stay identical.
+# ---------------------------------------------------------------------------
 
-
-@api_view(["POST"])
-@parser_classes([MultiPartParser, FormParser])
-@permission_classes([AllowAny])
-@throttle_classes([UploadRateThrottle])
-def upload_resume(request):
-    file = request.FILES.get("file")
-    target_role = request.data.get("role", None)
-    file_name = file.name if file else "unknown"
-
+def _extract_pdf_text(file_obj):
+    """Extract raw (un-lowercased) text from a PDF file-like object."""
+    if hasattr(file_obj, "seek"):
+        file_obj.seek(0)
     text = ""
-    with pdfplumber.open(file) as pdf:
+    with pdfplumber.open(file_obj) as pdf:
         for page in pdf.pages:
             page_text = page.extract_text()
             if page_text:
-                text += page_text
+                text += page_text + "\n"
+    return text
 
+
+def _analyze_text(text, target_role):
+    """
+    Run the original analysis pipeline on already-extracted resume text.
+
+    Returns a dict with the same keys as the public upload_resume response
+    so single-upload and JD-match flows produce identical per-resume shapes.
+    """
     text = text.lower()
 
     detected_skills = [s for s in skills_list if s.lower() in text]
@@ -97,26 +99,320 @@ def upload_resume(request):
         if "react" not in detected_skills:
             suggestions.append("Add frontend skills like React")
 
-    # Save to DB only for authenticated users
-    if request.user and request.user.is_authenticated:
-        ResumeAnalysis.objects.create(
-            user=request.user,
-            file_name=file_name,
-            score=score,
-            skills_found=detected_skills,
-            suggestions=suggestions,
-            matched_skills=matched_skills,
-            missing_skills=missing_skills,
-            target_role=target_role or "",
-        )
-
-    return Response({
+    return {
         "score": score,
         "skills_found": detected_skills,
         "suggestions": suggestions,
-        "target_role": target_role,
         "matched_skills": matched_skills,
         "missing_skills": missing_skills,
+    }
+
+
+def _persist_analysis(user, file_name, analysis, target_role):
+    """Save a single analysis record for an authenticated user."""
+    if not (user and user.is_authenticated):
+        return
+    ResumeAnalysis.objects.create(
+        user=user,
+        file_name=file_name,
+        score=analysis["score"],
+        skills_found=analysis["skills_found"],
+        suggestions=analysis["suggestions"],
+        matched_skills=analysis["matched_skills"],
+        missing_skills=analysis["missing_skills"],
+        target_role=target_role or "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# JD keyword extraction (issue #18).
+#
+# The issue says: "get a match percentage plus a list of missing keywords /
+# skills relative to that specific JD, not just a generic skill list."
+#
+# Strategy:
+#   1. First, detect every known skill from our curated `skills_list` that
+#      appears in the JD. These are the "must-have" technical keywords we
+#      can match exactly against the resume.
+#   2. Second, extract additional non-skill keywords from the JD using a
+#      lightweight regex tokenizer + stopword filter. These catch domain
+#      terms (e.g. "kubernetes", "swagger", "graphql") that aren't in our
+#      curated list. Multi-word phrases of 2-3 words are also captured
+#      (e.g. "REST APIs", "CI/CD pipelines") so the match is more semantic
+#      than a pure bag-of-words.
+#   3. Return the union as the JD's required keyword set. Each keyword is
+#      then checked against the resume text (case-insensitive substring).
+# ---------------------------------------------------------------------------
+
+# Conservative English stopword set — kept small on purpose so we don't
+# accidentally filter out real technical terms. Sourced from the standard
+# NLTK English stoplist, trimmed to the highest-frequency ~130 words.
+_STOPWORDS = frozenset("""
+a about above after again against all am an and any are aren't as at be because been before being below between both but by can can't cannot could couldn't did didn't do does doesn't doing don't down during each few for from further had hadn't has hasn't have haven't having he he'd he'll he's her here here's hers herself him himself his how how's i i'd i'll i'm i've if in into is isn't it it's its itself let's me more most mustn't my myself no nor not of off on once only or other ought our ours ourselves out over own same shan't she she'd she'll she's should shouldn't so some such than that that's the their theirs them themselves then there there's these they they'd they'll they're they've this those through to too under until up very was wasn't we we'd we'll we're we've were weren't what what's when when's where where's which while who who's whom why why's with won't would wouldn't you you'd you'll you're you've your yours yourself yourselves
+""".split())
+
+# Tokens that are technically words but carry no JD-relevant signal. These
+# get filtered alongside stopwords so the returned keyword list is clean.
+# Keep this list conservative — over-filtering hides real keywords.
+_JD_NOISE_TOKENS = frozenset({
+    # JD structural headers / labels
+    "role", "responsibilities", "requirements", "qualifications",
+    "preferred", "must", "plus", "etc", "eg", "ie",
+    "year", "years", "experience", "work", "working", "job", "position",
+    "team", "teams", "company", "candidate", "candidates", "ideal",
+    # Generic adjectives that aren't keywords
+    "strong", "excellent", "good", "great", "ability",
+    # Generic verbs that aren't keywords
+    "including", "include", "includes", "across", "within", "per",
+    "join", "build", "builds", "building", "built", "use", "uses", "using",
+    "help", "helps", "helping", "helped", "ensure", "ensures",
+    "design", "designs", "designing", "designed",
+    "develop", "develops", "developing", "developed", "developer", "developers",
+    "create", "creates", "creating", "created",
+    "maintain", "maintains", "maintaining", "maintained",
+    "manage", "manages", "managing", "managed", "manager",
+    "support", "supports", "supporting", "supported",
+    # Generic nouns that describe the JD itself, not the tech stack
+    "platform", "platforms", "application", "applications", "app", "apps",
+    "system", "systems", "service", "services",
+    "feature", "features", "product", "products",
+    "solution", "solutions", "tool", "tools",
+    "environment", "environments",
+    "knowledge", "understanding", "familiarity", "proficiency",
+    "background", "degree", "education",
+    "infrastructure", "cloud", "deployments", "development", "stores",
+    "looking", "nice", "senior", "junior", "lead", "engineer", "engineers",
+    # Equal-opportunity boilerplate
+    "equal", "opportunity", "employer",
+})
+
+
+def _extract_jd_keywords(jd_text):
+    """
+    Extract the set of required keywords/skills from a pasted job description.
+
+    Returns a sorted list of unique keywords (lowercased). Multi-word phrases
+    of 2-3 words (e.g. "rest apis", "ci cd") are included alongside single
+    tokens so the matcher can do semantic phrase matching, not just bag-of-words.
+    """
+    if not jd_text or not jd_text.strip():
+        return []
+
+    text = jd_text.lower()
+
+    # Step 1: detect known skills from our curated list. These are the
+    # high-confidence technical requirements — we want them in the keyword
+    # set even if a generic tokenizer would have split them.
+    found = set()
+    for skill in skills_list:
+        # Use word-boundary regex for single-word skills to avoid substring
+        # false positives (e.g. "c" matching inside "css"). Multi-word
+        # skills like "machine learning" can use plain substring search.
+        if " " in skill or "+" in skill:
+            if skill in text:
+                found.add(skill)
+        else:
+            if re.search(r"\b" + re.escape(skill) + r"\b", text):
+                found.add(skill)
+
+    # Step 2: extract additional candidate single tokens via regex.
+    # Match single words of 3+ letters that may include tech chars
+    # (e.g. "api", "sql", "aws", "kubernetes", "c++", "node.js").
+    token_pattern = re.compile(r"[a-z][a-z0-9+./#-]{2,}")
+    for match in token_pattern.finditer(text):
+        token = match.group(0).rstrip(".,;:!?")
+        if not token or len(token) < 3:
+            continue
+        if token.isdigit():
+            continue
+        if token in _STOPWORDS or token in _JD_NOISE_TOKENS:
+            continue
+        found.add(token)
+
+    # Step 3: extract 2-3 word phrases so we can do semantic phrase matching
+    # (e.g. "rest apis", "ci cd", "machine learning pipelines"). We only
+    # keep a phrase if ALL its constituent tokens are non-stopword and
+    # non-noise — this avoids returning phrases like "the team" while
+    # preserving real technical phrases.
+    phrase_pattern = re.compile(
+        r"[a-z][a-z0-9+./#-]{1,}(?:\s+[a-z][a-z0-9+./#-]{1,}){1,2}"
+    )
+    for match in phrase_pattern.finditer(text):
+        phrase = match.group(0).strip().rstrip(".,;:!?")
+        if not phrase:
+            continue
+        tokens = phrase.split()
+        if len(tokens) < 2 or len(tokens) > 3:
+            continue
+        # Keep the phrase only if every token is meaningful (non-stopword,
+        # non-noise). This is what filters out "the team" / "you will" while
+        # preserving "rest apis" / "ci cd".
+        if all(tok not in _STOPWORDS and tok not in _JD_NOISE_TOKENS for tok in tokens):
+            found.add(" ".join(tokens))
+
+    return sorted(found)
+
+
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def signup(request):
+    serializer = SignupSerializer(data=request.data)
+    if serializer.is_valid():
+        serializer.save()
+        return Response({"detail": "Account created."}, status=status.HTTP_201_CREATED)
+    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(["POST"])
+@parser_classes([MultiPartParser, FormParser])
+@permission_classes([AllowAny])
+@throttle_classes([UploadRateThrottle])
+def upload_resume(request):
+    file = request.FILES.get("file")
+    target_role = request.data.get("role", None)
+    file_name = file.name if file else "unknown"
+
+    if not file:
+        return Response(
+            {"detail": "No file uploaded. Please attach a resume."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        text = _extract_pdf_text(file)
+    except Exception as exc:
+        return Response(
+            {"detail": f"Could not read the uploaded file: {exc}"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    analysis = _analyze_text(text, target_role)
+    _persist_analysis(request.user, file_name, analysis, target_role)
+
+    return Response({
+        "score": analysis["score"],
+        "skills_found": analysis["skills_found"],
+        "suggestions": analysis["suggestions"],
+        "target_role": target_role,
+        "matched_skills": analysis["matched_skills"],
+        "missing_skills": analysis["missing_skills"],
+    })
+
+
+# ---------------------------------------------------------------------------
+# JD matching endpoint — Issue #18
+# Accepts a resume PDF + pasted job-description text and returns:
+#   - match_percent: 0-100 (matched / total keywords)
+#   - matched_keywords: keywords present in BOTH resume and JD
+#   - missing_keywords: keywords in the JD but NOT in the resume
+#   - resume_skills_detected: skills from the curated list found in the resume
+#                             (reused from the existing analyzer so the JD
+#                             match view also shows the generic skill list)
+#   - jd_keyword_count: how many unique keywords were extracted from the JD
+# ---------------------------------------------------------------------------
+
+@api_view(["POST"])
+@parser_classes([MultiPartParser, FormParser])
+@permission_classes([AllowAny])
+@throttle_classes([UploadRateThrottle])
+def match_jd(request):
+    """
+    Compare an uploaded resume against a pasted job description.
+
+    Accepts multipart form fields:
+      - file: resume PDF
+      - jd:   job-description text (plain text, any length)
+
+    Returns:
+      {
+        "match_percent":        int,    # 0-100, rounded
+        "matched_keywords":     [...],  # JD keywords found in the resume
+        "missing_keywords":     [...],  # JD keywords NOT found in the resume
+        "resume_skills_detected": [...], # curated skills present in resume
+        "jd_keyword_count":     int,    # total unique keywords extracted from JD
+        "file_name":            str
+      }
+    """
+    file = request.FILES.get("file")
+    jd_text = request.data.get("jd", "") or ""
+
+    if not file:
+        return Response(
+            {"detail": "No file uploaded. Please attach a resume."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    if not jd_text.strip():
+        return Response(
+            {"detail": "No job description provided. Please paste the JD text."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # --- Extract resume text ------------------------------------------------
+    try:
+        resume_text = _extract_pdf_text(file)
+    except Exception as exc:
+        return Response(
+            {"detail": f"Could not read the uploaded file: {exc}"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    resume_text_lower = resume_text.lower()
+
+    # --- Extract JD keywords ------------------------------------------------
+    jd_keywords = _extract_jd_keywords(jd_text)
+
+    # --- Match each JD keyword against the resume text ----------------------
+    # For multi-word phrase keywords, use plain substring search so "rest apis"
+    # matches even if the resume writes "REST APIs" or "rest apis". For single
+    # tokens, use word-boundary regex to avoid false positives like "c"
+    # matching inside "css".
+    matched_keywords = []
+    missing_keywords = []
+    for kw in jd_keywords:
+        if " " in kw:
+            if kw in resume_text_lower:
+                matched_keywords.append(kw)
+            else:
+                missing_keywords.append(kw)
+        else:
+            if re.search(r"\b" + re.escape(kw) + r"\b", resume_text_lower):
+                matched_keywords.append(kw)
+            else:
+                missing_keywords.append(kw)
+
+    # --- Compute match percentage ------------------------------------------
+    total = len(jd_keywords)
+    if total == 0:
+        match_percent = 0
+    else:
+        match_percent = int(round((len(matched_keywords) / total) * 100))
+
+    # --- Also run the existing skill detector on the resume so the UI can
+    #     show "Skills detected in your resume" alongside the JD-specific
+    #     match view (reuses the curated skills_list). -----------------------
+    resume_skills_detected = [s for s in skills_list if s.lower() in resume_text_lower]
+
+    # Persist a regular analysis row for authenticated users so the JD match
+    # also shows up in their history (we use the JD-derived match_percent as
+    # the score, and the missing keywords as suggestions for traceability).
+    if request.user and request.user.is_authenticated:
+        ResumeAnalysis.objects.create(
+            user=request.user,
+            file_name=file.name,
+            score=match_percent,
+            skills_found=resume_skills_detected,
+            suggestions=[f"Add JD keyword: {kw}" for kw in missing_keywords[:10]],
+            matched_skills=matched_keywords,
+            missing_skills=missing_keywords,
+            target_role="JD Match",
+        )
+
+    return Response({
+        "match_percent": match_percent,
+        "matched_keywords": matched_keywords,
+        "missing_keywords": missing_keywords,
+        "resume_skills_detected": resume_skills_detected,
+        "jd_keyword_count": total,
+        "file_name": file.name,
     })
 
 


### PR DESCRIPTION
closes #18 

Adds a new "Match Against Job Description" mode that lets users paste a job description alongside their resume and get a match percentage plus a list of matched/missing keywords relative to that specific JD — not just the generic curated skill list. The existing single-resume flow is unchanged.

**_Changes_**
**Backend**

- server/analyzer/views.py
- Extracted three shared helpers so single-upload and JD-match flows produce identical per-resume analysis shapes:
- _extract_pdf_text(file_obj) — PDF text extraction (was inline in upload_resume)
- _analyze_text(text, target_role) — skill detection + scoring + suggestions (was inline in upload_resume)
- _persist_analysis(user, file_name, analysis, target_role) — DB save (was inline in upload_resume)
- Refactored upload_resume to use these helpers. Output shape unchanged.
- Added new match_jd endpoint that accepts file (PDF) + jd (text) and returns:
- match_percent (0-100, rounded)
- matched_keywords — JD keywords found in the resume
- missing_keywords — JD keywords NOT found in the resume
- resume_skills_detected — curated skills present in resume (reuses the existing skills_list)
- jd_keyword_count — total unique keywords extracted from the JD
- file_name
- Added _extract_jd_keywords(jd_text) — a three-stage extractor:
- Curated-skill detection with word-boundary regex (catches "python", "react", "machine learning", etc.)
- Generic single-token extraction with stopword + JD-noise filtering (catches "docker", "kubernetes", "aws", "graphql", etc.)
- 2-3 word phrase extraction (catches "rest apis", "ci cd", "machine learning pipelines") — phrases are kept only if ALL constituent tokens are non-stopword and non-noise, which filters out "the team" while preserving real technical phrases
- Matching uses word-boundary regex for single tokens (prevents "c" matching inside "css" / "javascript") and plain substring search for multi-word phrases.
- Input validation: returns 400 if file is missing or JD is empty.
- For authenticated users, the JD match is persisted as a regular ResumeAnalysis row with target_role="JD Match" so it shows up in the existing history sidebar. No DB migration needed.
- server/analyzer/urls.py
- Wired path("jd-match/", match_jd).

**Frontend**

- client/src/App.tsx
- Added a Single/JD-Match mode toggle (pill-style segmented control) at the top of the main card.
- JD mode renders the existing upload zone (drag-and-drop + click) + a JD <textarea> + a "Match Against JD" button + a "Clear" button. The role-selector dropdown is hidden in JD mode since the JD itself defines the required keywords.
- Added JdMatchResponse TypeScript interface mirroring the backend response shape.
- On success, renders:
- A colored summary banner (green ≥70% / yellow 40-69% / red <40%) with the match percent and "X of Y JD keywords found in your resume".
- The existing AtsScore circle showing the match percent.
- A two-column matched/missing keyword panel — green badges for keywords in the resume, red badges for missing keywords.
- A "Skills Detected in Your Resume" section that reuses the curated skill list so the user can compare their general skill coverage against the JD-specific match.
- JD matches are added to anonymous localStorage history (with targetRole: "JD Match") so users can revisit the result; authenticated users get the DB-persisted entry via the existing history refresh.
- The "Match Against JD" button is disabled until both a file is selected AND the JD textarea has content.
- client/src/index.css
- Added CSS for .mode-toggle (pill segmented control, themed), .jd-form (textarea + label + character-count meta), .jd-match-summary (colored banner with three tone variants), .jd-keywords (two-column matched/missing grid, responsive), and .skill-badge--matched/missing (green/red badge variants).
- All new styles are responsive — the keyword grid collapses to a single column on screens narrower than 700px.
- No backend dependencies were added — the JD extractor uses only the Python stdlib re module plus the existing pdfplumber for PDF text extraction.

**_Acceptance Criteria Checklist_**
From issue #18 

- [x] New endpoint accepting resume + JD text
- [x]  Returns match % and missing-keyword list
- [x]  Frontend form for pasting JD and displaying the comparison

**Verification**

- python -m py_compile server/analyzer/views.py server/analyzer/urls.py — OK
- npx tsc -b --noEmit (client) — clean, exit 0
- npm run build (client) — built in 1.07s, no errors
- Integration test (/home/z/my-project/scripts/test_jd_match_endpoint.py): boots real Django, POSTs a synthesized PDF resume + a real-world JD to /api/jd-match/, asserts:
- HTTP 200 with the documented response shape
- matched_keywords ∪ missing_keywords partitions jd_keyword_count exactly (no overlaps, no gaps)
- Every "matched" keyword actually appears in the resume text (word-boundary check for single tokens, substring for phrases)
- Every "missing" keyword does NOT appear in the resume text
- resume_skills_detected matches the curated skills_list subset detected in the resume
- match_percent == round(matched / total * 100)
- Missing file → HTTP 400 with "file" in the error message
- Missing JD → HTTP 400 with "job description" in the error message
- Single-upload endpoint /api/upload/ still works (no regression)

**How to Test**

1. pip install -r server/requirements.txt (no new deps)
2. cd client && npm install && npm run dev
3. python server/manage.py runserver (ensure .env has SECRET_KEY set)
4. Click the new 🎯 Match Against Job Description toggle at the top
5. Upload a PDF resume (drag-and-drop or click)
6. Paste a job description into the textarea (a real JD works best — try one from LinkedIn or a company careers page)
7. Click 🎯 Match Against JD — verify:
8. Colored summary banner appears with the match percent (green/yellow/red based on score)
9. ATS score circle shows the match percent
10. Two-column panel shows green "In Your Resume" badges and red "Missing From Your Resume" badges
11. "Skills Detected in Your Resume" section shows the curated-skill list
12. Try submitting without a file → verify "Please upload a resume first." alert
13. Try submitting without JD text → verify "Please paste the job description text." alert
14. Switch back to 📄 Single Resume mode → verify the original single-upload flow still works unchanged