### PR TITLE
docs: add GitHub issue templates (bug report + feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: "🐞 Bug Report"
+description: Report a problem with the AI Resume Analyzer
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out the sections below so we can reproduce and fix it quickly.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of what the bug is.
+      placeholder: "When I upload a PDF and click Analyze, the score never appears..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the behavior?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area affected
+      options:
+        - Frontend (React UI)
+        - Backend (Django API)
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / screenshots
+      description: Paste any console output, error messages, or screenshots (drag & drop images here).
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I have searched existing issues and this has not been reported before.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "🔒 Security Vulnerability"
+    url: https://github.com/Muskankr/AI-Resume-Analyzer/security/advisories/new
+    about: Please report security issues privately through Security Advisories instead of a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: "✨ Feature Request"
+description: Suggest a new feature or improvement for the AI Resume Analyzer
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Got an idea to make the analyzer better? Tell us about it!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is.
+      placeholder: "I'm always frustrated when [...]; it would help if [...]"
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: Any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Frontend (React UI)
+        - Backend (Django API)
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I have checked that a similar feature has not already been requested.
+          required: true


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/` with reusable issue forms:
  - `bug_report.yml` — structured bug reports (steps, expected behavior, area, logs, CoC checkbox)
  - `feature_request.yml` — structured feature requests (problem, solution, area, CoC checkbox)
  - `config.yml` — enables blank issues and links security reports to private Security Advisories
- Standardizes how contributors file issues and reduces triage overhead.

Closes #71

## Test plan
- [x] Files are valid YAML (GitHub will render them as issue forms)
- [x] Navigate to **Issues → New issue** to confirm the new templates appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)