### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## 📝 Description
+
+<!-- Briefly describe what this PR does and why. -->
+
+## 🔗 Related Issue
+
+<!-- Replace XX with the issue number, e.g. Closes #12 or Fixes #34 -->
+Closes #
+
+## ✅ Type of Change
+
+- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 📚 Documentation update
+- [ ] 💅 UI/UX improvement
+- [ ] ♻️ Refactor (no functional change)
+- [ ] ⚡ Performance improvement
+
+## 🧪 How Has This Been Tested?
+
+<!-- Describe the steps you took to verify your change. -->
+- [ ] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
+- [ ] Backend tests pass (`python manage.py test analyzer`)
+- [ ] Manually tested in the browser / API client
+
+## 📸 Screenshots (if applicable)
+
+<!-- Drag & drop screenshots or a GIF here. -->
+
+## 📋 Checklist
+
+- [ ] My code follows the project's style and conventions
+- [ ] I have linked the related issue above
+- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
## Summary
- Adds `.github/pull_request_template.md` with sections for description, linked issue, change type, testing steps, screenshots, and a contributor checklist.
- Helps contributors open well-structured PRs and makes review faster.

Closes #72

## Test plan
- [x] File renders as the default PR template when opening a new PR from the fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)