### PR TITLE
feat: show a loading spinner while analyzing a resume

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -307,6 +307,18 @@ function App() {
             </button>
           </div>
 
+          {/* Loading spinner — shown while the resume is being analyzed */}
+          {loading && (
+            <div
+              className="loader"
+              role="status"
+              aria-live="polite"
+              aria-label="Analyzing resume, please wait"
+            >
+              <span className="sr-only">Analyzing resume, please wait…</span>
+            </div>
+          )}
+
           {/* Results */}
           {score !== null && (
             <>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -256,13 +256,26 @@ border-radius:8px;
 }
 
 .loader{
-border:4px solid #f3f3f3;
-border-top:4px solid white;
+border:4px solid var(--score-track);
+border-top:4px solid var(--score-accent);
 border-radius:50%;
-width:30px;
-height:30px;
+width:36px;
+height:36px;
 animation:spin 1s linear infinite;
-margin:15px auto;
+margin:18px auto;
+}
+
+/* Visually hidden but available to screen readers */
+.sr-only{
+position:absolute;
+width:1px;
+height:1px;
+padding:0;
+margin:-1px;
+overflow:hidden;
+clip:rect(0,0,0,0);
+white-space:nowrap;
+border:0;
 }
 
 @keyframes spin{


### PR DESCRIPTION
## Summary
- Wires up the **previously unused** `.loader` CSS class so a spinner is shown during analysis, instead of only swapping the button label.
- Uses theme tokens (`--score-accent` / `--score-track`) so the spinner is visible in both light and dark modes.
- Adds an `.sr-only` helper and `role="status"` / `aria-live="polite"` so screen readers announce the loading state.

Closes #1

## Test plan
- [x] `npm run build` compiles (verified once deps are installed)
- [x] Spinner appears between clicking **Analyze** and results rendering
- [x] Spinner respects the active theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)