### PR TITLE
feat: replace upload alert with inline validation feedback

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ function App() {
   const [showAllSkills, setShowAllSkills] = useState(false);
   const [copied, setCopied] = useState(false);
   const [analysisSource, setAnalysisSource] = useState<"sample" | "upload" | null>(null);
+  const [uploadError, setUploadError] = useState("");
 
   // Auth
   const { user, signup, login, logout } = useAuth();
@@ -140,9 +141,14 @@ function App() {
 
   const uploadResume = async () => {
     if (!file) {
-      alert("Please upload resume");
+      setUploadError("Please choose a resume file to analyze.");
       return;
     }
+    if (!/\.pdf$/i.test(file.name)) {
+      setUploadError("Only PDF resumes are supported — please upload a .pdf file.");
+      return;
+    }
+    setUploadError("");
     await runAnalysis(file, "upload");
   };
 
@@ -186,6 +192,7 @@ function App() {
     setCopied(false);
     setAnalysisSource(null);
     setActiveFileName("");
+    setUploadError("");
   };
 
   const copySuggestionsToClipboard = () => {
@@ -281,13 +288,22 @@ function App() {
               id="fileUpload"
               hidden
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                if (e.target.files) setFile(e.target.files[0]);
+                if (e.target.files) {
+                  setFile(e.target.files[0]);
+                  setUploadError("");
+                }
               }}
             />
             <label htmlFor="fileUpload" className="upload-label">
               📄 {file ? file.name : "Drag & Drop Resume or Click to Upload"}
             </label>
           </div>
+
+          {uploadError && (
+            <p className="upload-error" role="alert" aria-live="assertive">
+              ⚠️ {uploadError}
+            </p>
+          )}
 
           <div style={{ display: "flex", gap: "12px", justifyContent: "center", alignItems: "center" }} className="mb-3">
             <button

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -176,6 +176,22 @@ cursor:pointer;
 font-weight:500;
 }
 
+.upload-error{
+  color: #fecaca;
+  background: rgba(220,38,38,0.25);
+  border: 1px solid rgba(248,113,113,0.5);
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0 auto 16px;
+  max-width: 480px;
+}
+
+[data-theme="dark"] .upload-error{
+  color: #fecaca;
+}
+
 .analyze-btn{
 background: var(--btn-bg);
 color: var(--btn-text);


### PR DESCRIPTION
## Summary
- Replaces the blocking `alert("Please upload resume")` with an **inline, accessible** error message (`role="alert"`, `aria-live="assertive"`).
- Adds **PDF-only validation**: a non-`.pdf` file is rejected up front with a clear message instead of a confusing server error.
- Error clears when a file is selected or the analysis is reset.
- Styles the message with `.upload-error` (red-tinted, theme-aware).

Closes #34

## Test plan
- [x] `npm run build` compiles
- [x] Click **Analyze** with no file → inline "Please choose a resume file…" (no alert)
- [x] Select a `.txt`/`.docx` → "Only PDF resumes are supported…"
- [x] Select a valid PDF → error clears and analysis runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)