### PR TITLE
feat: add inline resume text preview with skill keyword highlighting

### DIFF
--- a/backend/analyzer/services.py
+++ b/backend/analyzer/services.py
@@ -1,3 +1,4 @@
+import re
 import os
 import pdfplumber
 from django.contrib.auth import get_user_model
@@ -7,61 +8,54 @@ User = get_user_model()
 
 
 SKILLS = [
-    "python",
-    "django",
-    "react",
-    "javascript",
-    "typescript",
-    "html",
-    "css",
-    "tailwind",
-    "sql",
-    "mysql",
-    "postgresql",
-    "mongodb",
-    "git",
-    "github",
-    "flask",
-    "docker",
-    "aws",
-    "machine learning",
-    "data analysis",
-    "excel",
+    # Languages — only include ones unlikely to false-match as common words
+    "python", "java", "c++", "javascript", "typescript",
+    "kotlin", "swift", "ruby", "php", "rust",
+
+    # C and single-letter langs need explicit listing but matched carefully
     "c",
-    "c++",
-    "java",
+
+    # Web Frontend
+    "html", "css", "react", "react.js", "angular", "vue", "vue.js",
+    "next.js", "tailwind", "bootstrap", "sass", "webpack",
+
+    # Web Backend
+    "node.js", "express", "express.js", "django", "flask", "fastapi",
+    "spring boot", "laravel",
+
+    # Databases
+    "sql", "mysql", "postgresql", "mongodb", "firebase", "redis",
+    "sqlite", "cassandra", "dynamodb",
+
+    # ML / AI
+    "machine learning", "deep learning", "data analysis",
+    "tensorflow", "keras", "pytorch", "scikit-learn", "opencv",
+    "mediapipe", "lstm", "cnn", "llm", "nlp", "pandas", "numpy",
+    "matplotlib", "seaborn", "huggingface",
+
+    # Cloud & DevOps
+    "aws", "azure", "gcp", "docker", "kubernetes", "terraform", "linux",
+
+    # Tools
+    "git", "github", "postman", "jupyter", "vs code", "excel",
 ]
 
 
 ROLE_SKILLS = {
     "Frontend Developer": [
-        "html",
-        "css",
-        "javascript",
-        "react",
-        "typescript",
-        "tailwind",
-        "git",
-        "github",
+        "html", "css", "javascript", "typescript", "react",
+        "next.js", "tailwind", "git", "github", "webpack",
     ],
 
     "Backend Developer": [
-        "python",
-        "django",
-        "flask",
-        "sql",
-        "mysql",
-        "git",
-        "github",
-        "docker",
+        "python", "django", "flask", "fastapi", "node.js", "express.js",
+        "sql", "mysql", "postgresql", "mongodb", "docker", "git", "github",
     ],
 
     "Data Analyst": [
-        "python",
-        "sql",
-        "excel",
-        "machine learning",
-        "data analysis",
+        "python", "sql", "excel", "machine learning", "deep learning",
+        "data analysis", "pandas", "numpy", "matplotlib", "tensorflow",
+        "scikit-learn", "jupyter",
     ],
 }
 
@@ -81,9 +75,14 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None)
         if os.path.exists(file_path):
             os.remove(file_path)
 
+    raw_text = text
     text = text.lower()
 
-    detected = [skill for skill in SKILLS if skill.lower() in text]
+    def skill_in_text(skill, text):
+        escaped = re.escape(skill)
+        return bool(re.search(rf'(?<![\w]){escaped}(?![\w])', text, re.IGNORECASE))
+
+    detected = [skill for skill in SKILLS if skill_in_text(skill, text)]
 
     matched = []
     missing = []
@@ -132,4 +131,5 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None)
         "matched_skills": matched,
         "missing_skills": missing,
         "target_role": target_role,
+        "resume_text": raw_text,
     }

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -117,6 +117,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CORS_ALLOWED_ORIGINS = [
     "https://ai-resume-analyzer-nine-brown.vercel.app",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
 ]
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,37 @@ function getInitialTheme(): Theme {
   return "light";
 }
 
+function highlightSkills(text: string, skills: string[]): React.ReactNode[] {
+  if (!text) return [];
+  if (skills.length === 0) return [text];
+
+  // Sort longest first so multi-word skills (e.g. "machine learning") match before shorter ones
+  const sorted = [...skills].sort((a, b) => b.length - a.length);
+  const escaped = sorted.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  // \b works for alphanumeric boundaries; for symbols like c++ we use lookahead/lookbehind
+  const pattern = new RegExp(`(?<![\\w])(${escaped.join('|')})(?![\\w])`, 'gi');
+  const parts = text.split(pattern);
+  const skillSet = new Set(skills.map(s => s.toLowerCase()));
+
+  return parts.map((part, i) =>
+    skillSet.has(part.toLowerCase())
+      ? <mark key={i} className="skill-highlight">{part}</mark>
+      : part
+  );
+}
+
+function ResumePreview({ text, skills }: { text: string; skills: string[] }) {
+  if (!text) return null;
+  return (
+    <div className="resume-preview mt-4">
+      <h4>📄 Resume Text Preview</h4>
+      <pre className="resume-preview__body">
+        {highlightSkills(text, skills)}
+      </pre>
+    </div>
+  );
+}
+
 function App() {
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const [loading, setLoading] = useState(false);
@@ -38,6 +69,7 @@ function App() {
   const [showAllSkills, setShowAllSkills] = useState(false);
   const [copied, setCopied] = useState(false);
   const [analysisSource, setAnalysisSource] = useState<"sample" | "upload" | null>(null);
+  const [resumeText, setResumeText] = useState<string>("");
 
   // Auth
   const { user, signup, login, logout } = useAuth();
@@ -108,6 +140,7 @@ function App() {
       setSuggestions(res.data.suggestions || []);
       setMatchedSkills(res.data.matched_skills || []);
       setMissingSkills(res.data.missing_skills || []);
+      setResumeText(res.data.resume_text || "");
       setActiveFileName(fileToAnalyze.name);
 
       setLoading(false);
@@ -182,6 +215,7 @@ function App() {
     setSuggestions([]);
     setMatchedSkills([]);
     setMissingSkills([]);
+    setResumeText("");
     setShowAllSkills(false);
     setCopied(false);
     setAnalysisSource(null);
@@ -332,6 +366,8 @@ function App() {
               )}
 
               <AtsScore score={score} />
+
+              <ResumePreview text={resumeText} skills={skills} />
 
               <h5 className="analysis-done">✅ Resume Analysis Complete</h5>
               {activeFileName && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -603,3 +603,40 @@ border:0;
   margin: 0;
   opacity: 0.85;
 }
+
+/* ── Resume Preview Pane ────────────────── */
+
+.resume-preview {
+  text-align: left;
+}
+
+.resume-preview h4 {
+  margin-bottom: 10px;
+}
+
+.resume-preview__body {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  padding: 16px;
+  max-height: 320px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--card-text);
+  font-family: inherit;
+}
+
+.skill-highlight {
+  background: rgba(0, 255, 174, 0.3);
+  color: inherit;
+  border-radius: 3px;
+  padding: 0 2px;
+  font-weight: 700;
+}
+
+[data-theme="dark"] .skill-highlight {
+  background: rgba(34, 211, 238, 0.3);
+}


### PR DESCRIPTION
## 📝 Description

- Adds an inline resume text preview pane that renders the raw extracted text after upload, with detected skill keywords visually highlighted in place.
- Users can now see exactly where each skill appears in their resume instead of just seeing a flat list of detected skills.

## 🔗 Related Issue

Closes #43 

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [x] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- Uploaded a real resume PDF — preview pane renders extracted text with matched keywords highlighted in green (light mode) / cyan (dark mode)
- Uploaded a PDF with no technical keywords — preview pane renders plain text with no highlights, no crash, no blank state
- Selected a history entry (no resume_text) — preview pane is hidden gracefully, no errors
- Verified word-boundary regex prevents partial matches (e.g. "c" inside "coders" is not highlighted)
- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)

<!-- Drag & drop screenshots or a GIF here. -->

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the Code of Conduct

## 📌 Changes Made

- `backend/analyzer/services.py` — returns `resume_text` (original case) in the API response; skill detection now uses word-boundary regex to prevent false positives on short tokens like `c` or `go`; expanded SKILLS list to cover Node.js, Express.js, TensorFlow, Keras, OpenCV, Firebase, Postman, Jupyter and more
- `backend/resume_analyzer/settings.py` — added `localhost:5173` to `CORS_ALLOWED_ORIGINS` for local development
- `frontend/src/App.tsx` — added `resumeText` state; added `highlightSkills()` helper and `ResumePreview` component with case-insensitive word-boundary highlighting
- `frontend/src/index.css` — added `.resume-preview__body` and `.skill-highlight` styles with dark mode support
