### PR TITLE
feat: add a "Back to top" floating button on long results pages #35

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,6 +63,7 @@ function App() {
   const [score, setScore] = useState<number | null>(null);
   const [skills, setSkills] = useState<string[]>([]);
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [showBackToTop, setShowBackToTop] = useState(false);
 
   // Component States
   const [targetRole, setTargetRole] = useState("Frontend Developer");
@@ -149,9 +150,29 @@ function App() {
       // persistence is best-effort; ignore if storage is unavailable
     }
   }, [theme]);
+  
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.scrollY > 400) {
+        setShowBackToTop(true);
+      } else {
+        setShowBackToTop(false);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
   const toggleTheme = () => {
     setTheme((prev) => (prev === "light" ? "dark" : "light"));
+  };
+  
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
   };
 
   const runAnalysis = async (fileToAnalyze: File, source: "sample" | "upload") => {
@@ -178,7 +199,7 @@ function App() {
 
       if (user) {
         await fetchDbHistory(user.token);
-        }
+      }
       else {
         addEntry({
           score: res.data.score,
@@ -189,7 +210,7 @@ function App() {
           targetRole: targetRole,
           fileName: fileToAnalyze.name,
         });
-    }
+      }
     } catch (error: unknown) {
       console.error(error);
 
@@ -288,9 +309,9 @@ function App() {
     setHistoryOpen(false);
   };
   const handleLogout = () => {
-  logout();           
-  clearHistory();
-};
+    logout();          
+    clearHistory();
+  };
   return (
     <>
       <HistorySidebar
@@ -468,6 +489,7 @@ function App() {
                     </button>
                   )}
                 </div>
+                
 
                 {suggestions.map((s: string, i: number) => (
                   <div key={i} className="suggestion-item">📌 {s}</div>
@@ -491,8 +513,37 @@ function App() {
 
       <Footer />  {/* footer should be outside main container */}
 
+      {/* RENDER FLOATING BACK TO TOP BUTTON */}
+      {showBackToTop && (
+        <button
+          onClick={scrollToTop}
+          style={{
+            position: "fixed",
+            bottom: "30px",
+            right: "30px",
+            backgroundColor: "#6366f1",
+            color: "#fff",
+            border: "none",
+            borderRadius: "50%",
+            width: "50px",
+            height: "50px",
+            fontSize: "20px",
+            cursor: "pointer",
+            boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+            zIndex: 1000,
+            transition: "all 0.3s ease",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center"
+          }}
+          title="Back to Top"
+          aria-label="Back to Top"
+        >
+          ▲
+        </button>
+      )}
     </>
-  ); {/* closes the return fragment */ }
-} {/* closes App function */ }
+  ); /* closes the return fragment */
+} /* closes App function */
 
 export default App;


### PR DESCRIPTION
## 📝 Description
This PR implements a responsive, floating "Back to Top" navigation element for the core analysis dashboard page, successfully addressing user experience friction on prolonged result pages described in issue #35.

Key adjustments include:
* **Scroll Lifecycle Integration (`App.tsx`):** Added a optimized window scroll tracking effect listener targeting a layout viewport threshold of `400px` to toggle state visibility values.
* **Smooth Animation Motion:** Implemented native structural layout window targeting (`window.scrollTo`) utilizing explicit `behavior: "smooth"` attributes to guarantee fluid scrolling.
* **Accessible Component Overlay:** Configured a fixed positional layout wrapper containing detailed floating layout styles, high z-index depth properties, and explicit aria-label parameters for accessibility compliance.

---

## 🔗 Related Issue
Closes #35

---

## ✅ Type of Change
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [x] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)

---

## Screenshot: 

https://github.com/user-attachments/assets/6a550cb0-6a7c-4e0d-8e3b-39556d3000f6

---

## 🧪 How Has This Been Tested?
- [x] Verified floating component mounts cleanly precisely when viewport scrolling meets or exceeds 400px.
- [x] Confirmed button unmounts properly as viewport orientation approaches header coordinates.
- [x] Validated click actions accurately trigger smooth window transitions.

---

## 📋 Checklist
- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] My branch has been pushed to the remote repository fork