### PR TITLE
docs: add CODEOWNERS file and document it in README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo
+# Any PR that changes any file will automatically request a review from below
+* @Muskankr

--- a/README.md
+++ b/README.md
@@ -333,6 +333,17 @@ Please review active issues before creating duplicates, and always link open iss
 
 ---
 
+## Code Owners
+
+This repository uses a [`CODEOWNERS`](.github/CODEOWNERS) file to automatically request reviews from maintainers whenever a Pull Request is opened.
+
+- The file lives at `.github/CODEOWNERS`.
+- Currently, all files (`*`) are owned by [@Muskankr](https://github.com/Muskankr).
+- When you open a PR, GitHub will automatically add the code owner as a reviewer.
+- As the project grows, ownership can be split by folder (e.g. `/frontend/` → frontend maintainers, `/backend/` → backend maintainers).
+
+---
+
 ## Contributors
 
 ### Maintainer


### PR DESCRIPTION
## What this PR does
Closes #73

- Adds a `.github/CODEOWNERS` file to enable automatic review requests
- Sets default ownership for the entire repository to @Muskankr
- Adds a new "Code Owners" section in the README explaining what the file does and how it works

## Why
GitHub can automatically request reviews from maintainers when a PR is opened, but only if a CODEOWNERS file exists. This makes sure PRs don't go unnoticed and reviewers are assigned without manual effort.

## Changes
- `.github/CODEOWNERS` (new file) — sets `* @Muskankr` as the default owner for all files
- `README.md` — added a "Code Owners" section right after the Contributing section

## Testing
- Verified the file is placed correctly at `.github/CODEOWNERS`
- Confirmed the README renders correctly with the new section
- 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PRs. 

Hi @Muskankr , could you please review this merged PR for a potential bonus label based on the metrics below? Thanks! 
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/60bad6ab-0e23-4abe-85b5-58c0adacc406" />
