### PR TITLE
style: add color palette design tokens and apply to buttons/indicators

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,11 @@
 :root{
+  /* ── Design Tokens: Color Palette ───────── */
+  --color-primary: #3b82f6;   /* blue — main interactive/accent color */
+  --color-secondary: #764ba2; /* purple — brand gradient color */
+  --color-accent: #22c55e;    /* green — success / positive states */
+  --color-neutral: #64748b;   /* slate gray — neutral text/borders */
+  --color-danger: #ef4444;    /* red — errors, destructive actions */
+
   color-scheme: light;
   --body-bg: linear-gradient(135deg,#667eea,#764ba2);
   --card-bg: rgba(255,255,255,0.15);
@@ -22,9 +29,9 @@
   --btn-secondary-text: #ffffff;
   --btn-secondary-border: rgba(255,255,255,0.3);
   --btn-secondary-hover-bg: rgba(255,255,255,0.25);
-  --btn-accent-bg: #3b82f6;
+  --btn-accent-bg: var(--color-primary);
   --btn-accent-hover-bg: #2563eb;
-  --btn-success-bg: #22c55e;
+  --btn-success-bg: var(--color-accent);
   --btn-accent-text: #ffffff;
   --footer-text: rgba(255,255,255,0.85);
   --footer-link: #ffffff;
@@ -54,9 +61,9 @@
   --btn-secondary-text: #e2e8f0;
   --btn-secondary-border: rgba(255,255,255,0.15);
   --btn-secondary-hover-bg: rgba(255,255,255,0.16);
-  --btn-accent-bg: #3b82f6;
+  --btn-accent-bg: var(--color-primary);
   --btn-accent-hover-bg: #60a5fa;
-  --btn-success-bg: #22c55e;
+  --btn-success-bg: var(--color-accent);
   --btn-accent-text: #ffffff;
   --footer-text: rgba(226,232,240,0.85);
   --footer-link: #e2e8f0;
@@ -311,7 +318,7 @@ border:0;
   position: absolute;
   top: -4px;
   right: -4px;
-  background: #ef4444;
+  background: var(--color-danger);
   color: #fff;
   font-size: 11px;
   font-weight: 700;
@@ -360,7 +367,7 @@ border:0;
 
 .history-clear-btn {
   background: rgba(239,68,68,0.2);
-  color: #ef4444;
+  color: var(--color-danger);
   border: 1px solid rgba(239,68,68,0.4);
   padding: 4px 10px;
   border-radius: 6px;
@@ -534,11 +541,10 @@ border:0;
 .auth-input::placeholder { opacity: 0.6; }
 
 .auth-error {
-  color: #f87171;
+  color: var(--color-danger);
   font-size: 13px;
   margin-bottom: 10px;
 }
-
 .auth-submit-btn {
   width: 100%;
   padding: 10px;


### PR DESCRIPTION
## What this PR does
Closes #65

- Defines a small, consistent color palette as CSS variables in `src/index.css`: `--color-primary`, `--color-secondary`, `--color-accent`, `--color-neutral`, `--color-danger`
- Unifies `--btn-accent-bg` (light and dark theme) to use `--color-primary` instead of a hardcoded hex value repeated in two places
- Applies `--color-danger` consistently to `.history-badge`, `.history-clear-btn`, and `.auth-error`

## Why
Colors were being picked ad-hoc per component instead of from a shared source. Notably, `.history-badge`/`.history-clear-btn` used `#ef4444` for "danger/error" while `.auth-error` used a different red, `#f87171`, for the same meaning. This PR consolidates them into one `--color-danger` token so error/destructive states look consistent across the app.

## Changes
- `frontend/src/index.css`
  - Added a "Design Tokens: Color Palette" block in `:root`
  - `--btn-accent-bg` now references `var(--color-primary)` in both light and dark theme blocks
  - `.history-badge`, `.history-clear-btn`, `.auth-error` now use `var(--color-danger)`

## Note on visual change
`.auth-error` text color shifts slightly from `#f87171` to `#ef4444` — both reds, very close in shade. This is intentional: it's the exact inconsistency this issue asks to fix, not a bug.

## Testing
- Ran `npm run dev` and checked the accent button, history badge/clear button, and the auth error message — colors now draw from the same shared tokens

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PRs.
Hi @Muskankr , could you please review this merged PR for a potential bonus label based on the metrics below? Thanks! 
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/b25cde1a-dd05-496a-8da7-aafff8c5523a" />
