### PR TITLE
Fix #122: Improve History section button contrast in Light Mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -384,20 +384,21 @@ border:0;
   font-size: 18px;
 }
 
+/* Clear All button — stronger contrast */
 .history-clear-btn {
-  background: rgba(239,68,68,0.2);
-  color: var(--color-danger);
-  border: 1px solid rgba(239,68,68,0.4);
-  padding: 4px 10px;
+  background: var(--color-primary);   /* solid blue accent */
+  color: #fff;
+  border: none;
+  padding: 6px 12px;
   border-radius: 6px;
   cursor: pointer;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   transition: background 0.2s ease;
 }
 
 .history-clear-btn:hover {
-  background: rgba(239,68,68,0.35);
+  background: #2563eb; /* darker blue hover */
 }
 
 .history-empty {
@@ -441,29 +442,32 @@ border:0;
   color: var(--score-accent);
 }
 
+/* Delete button — strong red */
 .history-item-delete {
-  background: none;
+  background: var(--color-danger);
+  color: #fff;
   border: none;
   cursor: pointer;
   font-size: 14px;
-  opacity: 0.5;
-  padding: 0 2px;
-  transition: opacity 0.2s ease;
+  padding: 4px 6px;
+  border-radius: 4px;
+  opacity: 1; /* remove faint opacity */
+  transition: background 0.2s ease;
 }
 
 .history-item-delete:hover {
-  opacity: 1;
+  background: #d32f2f;
 }
 
 .history-item-role {
   font-size: 13px;
   font-weight: 600;
-  opacity: 0.9;
+  color: var(--color-neutral); /* stronger text */
 }
 
 .history-item-file {
   font-size: 12px;
-  opacity: 0.6;
+  color: var(--color-neutral); /* stronger text */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -471,13 +475,13 @@ border:0;
 
 .history-item-time {
   font-size: 11px;
-  opacity: 0.5;
+  color: var(--color-neutral); /* stronger text */
   margin-top: 2px;
 }
 
 .history-item-skills {
   font-size: 12px;
-  opacity: 0.7;
+  opacity: 0.85; /* slightly stronger */
   margin-top: 6px;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
## 📝 Description
This PR addresses Issue #122 by improving the visibility of History section buttons in Light Mode.  
The changes ensure that the **Clear All** and **Delete** buttons, as well as faint text elements (file, time, skills), have stronger contrast and are accessible across both Light and Dark modes.

## 🔗 Related Issue
Closes #122

## ✅ Type of Change
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 💅 UI/UX improvement

## 🧪 How Has This Been Tested?
- Verified styles manually in the browser (Light/Dark mode toggle).
- Confirmed that buttons and text are clearly visible in Light Mode.
- No functional logic was changed — only CSS.

## 📋 Checklist
- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have tested the changes manually

I am ECSoC'26 contributor. I am glad to work on this issue.