### PR TITLE
feat: implement authentication modal with password strength validation and styling

### DIFF
--- a/frontend/src/AuthModal.tsx
+++ b/frontend/src/AuthModal.tsx
@@ -50,6 +50,52 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
             onChange={(e) => setPassword(e.target.value)}
             required
           />
+          {mode === "signup" && password && (() => {
+            const hasMinLength = password.length >= 8;
+            const hasMixedCase = /[a-z]/.test(password) && /[A-Z]/.test(password);
+            const hasNumber = /[0-9]/.test(password);
+            const hasSymbol = /[^A-Za-z0-9]/.test(password);
+            
+            let score = 0;
+            if (hasMinLength) score++;
+            if (hasMixedCase) score++;
+            if (hasNumber) score++;
+            if (hasSymbol) score++;
+
+            let strengthLabel = "Weak";
+            let strengthLevel = "weak";
+            let filledCount = 1;
+
+            if (password.length >= 6) {
+              if (score <= 1) {
+                strengthLabel = "Weak";
+                strengthLevel = "weak";
+                filledCount = 1;
+              } else if (score <= 3) {
+                strengthLabel = "Medium";
+                strengthLevel = "medium";
+                filledCount = 2;
+              } else {
+                strengthLabel = "Strong";
+                strengthLevel = "strong";
+                filledCount = 3;
+              }
+            }
+
+            return (
+              <div className="password-strength-container">
+                <div className="password-strength-label">
+                  <span>Password Strength:</span>
+                  <span className={`strength-val ${strengthLevel}`}>{strengthLabel}</span>
+                </div>
+                <div className="password-strength-bar-container">
+                  <div className={`password-strength-segment ${filledCount >= 1 ? `${strengthLevel}-filled` : ""}`} />
+                  <div className={`password-strength-segment ${filledCount >= 2 ? `${strengthLevel}-filled` : ""}`} />
+                  <div className={`password-strength-segment ${filledCount >= 3 ? `${strengthLevel}-filled` : ""}`} />
+                </div>
+              </div>
+            );
+          })()}
           {error && <p className="auth-error">{error}</p>}
           <button className="auth-submit-btn" type="submit" disabled={loading}>
             {loading ? "⏳ Please wait..." : mode === "login" ? "Login" : "Create Account"}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -784,4 +784,84 @@ border:0;
     opacity: 1;
     transform: translateX(-50%) translateY(-10px);
   }
+
 }
+
+/* Password Strength Indicator */
+.password-strength-container {
+  margin-top: -6px;
+  margin-bottom: 14px;
+  text-align: left;
+  animation: fadeInStrength 0.2s ease-out;
+}
+
+.password-strength-label {
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 5px;
+  display: flex;
+  justify-content: space-between;
+  color: var(--color-neutral);
+}
+
+.password-strength-label span.strength-val {
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  transition: color 0.2s ease;
+}
+
+.password-strength-label span.strength-val.weak {
+  color: var(--color-danger);
+}
+
+.password-strength-label span.strength-val.medium {
+  color: #f59e0b; /* Amber */
+}
+
+.password-strength-label span.strength-val.strong {
+  color: var(--color-accent);
+}
+
+.password-strength-bar-container {
+  display: flex;
+  gap: 4px;
+  height: 4px;
+  width: 100%;
+}
+
+.password-strength-segment {
+  flex: 1;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 2px;
+  transition: background-color 0.2s ease;
+}
+
+[data-theme="dark"] .password-strength-segment {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.password-strength-segment.weak-filled {
+  background: var(--color-danger);
+}
+
+.password-strength-segment.medium-filled {
+  background: #f59e0b;
+}
+
+.password-strength-segment.strong-filled {
+  background: var(--color-accent);
+}
+
+@keyframes fadeInStrength {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+


### PR DESCRIPTION
## 📝 Description

Added a password strength indicator below the password field in the Sign Up modal.

## 🔗 Related Issue

Fixes #135 

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

<!-- Describe the steps you took to verify your change. -->
- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)

<img width="377" height="406" alt="image" src="https://github.com/user-attachments/assets/3b330b96-bb69-4fbe-887a-ddd25fb3fe42" />


## 📋 Checklist

- [x] My code follows the project's style and conventions
- x ] I have linked the related issue above
- [x]  I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
