### PR TITLE
Add friendly empty state before resume upload

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { Footer } from "./Footer";
 import AnalysisSkeleton from "./components/AnalysisSkeleton/AnalysisSkeleton";
 import { InfoTooltip } from "./components/InfoTooltip";
 import { Navbar } from "./components/Navbar";
+import EmptyState from "./components/EmptyState";
 
 type Theme = "light" | "dark";
 
@@ -437,6 +438,9 @@ function App() {
 
           {/* Loading skeleton — shown while the resume is being analyzed */}
           {loading && <AnalysisSkeleton />}
+          {score === null && !loading && (
+  <EmptyState />
+)}
 
           {/* Results */}
           {score !== null && (

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,21 @@
+export default function EmptyState() {
+  return (
+    <div
+      className="mt-5 p-5 text-center"
+      style={{
+        border: "2px dashed #d1d5db",
+        borderRadius: "12px",
+        color: "#6b7280",
+      }}
+    >
+      <div style={{ fontSize: "48px" }}>📄</div>
+
+      <h3 className="mt-3">No resume uploaded yet</h3>
+
+      <p>
+        Upload a resume to see your ATS score, skills analysis,
+        and personalized suggestions.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Added a friendly empty state for the results area before a resume is uploaded.
- Displays an icon and short message prompting users to upload a resume.
- The empty state automatically disappears after a resume is uploaded.
- Matches the existing application style.

## Changes
- Added `EmptyState` component.
- Rendered the empty state when no analysis result is available.
- Kept existing analysis flow unchanged.

Fixes #28 