### PR TITLE
feat(auth): add 'Remember Me' checkbox to login screen (fixes #139)

### DIFF
--- a/frontend/src/AuthModal.tsx
+++ b/frontend/src/AuthModal.tsx
@@ -3,12 +3,13 @@ import { Lock, FileSignature, Loader2 } from 'lucide-react'
 
 interface AuthModalProps {
   onSignup: (username: string, password: string) => Promise<void>
-  onLogin: (username: string, password: string) => Promise<void>
+  onLogin: (username: string, password: string, rememberMe: boolean) => Promise<void>
   onClose: () => void
 }
 
 export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose }) => {
   const [mode, setMode] = useState<'login' | 'signup'>('login')
+  const [rememberMe, setRememberMe] = useState(true)
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -20,7 +21,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
     setLoading(true)
     try {
       if (mode === 'signup') await onSignup(username, password)
-      else await onLogin(username, password)
+      else await onLogin(username, password, rememberMe)
       onClose()
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Authentication failed'
@@ -115,6 +116,17 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
                 </div>
               )
             })()}
+          {mode === 'login' && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '16px' }}>
+              <input
+                type="checkbox"
+                id="rememberMe"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+              />
+              <label htmlFor="rememberMe" style={{ fontSize: '0.9rem', color: '#666' }}>Remember me</label>
+            </div>
+          )}
           {error && <p className="auth-error">{error}</p>}
           <button className="auth-submit-btn" type="submit" disabled={loading}>
             {loading ? (

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -10,7 +10,7 @@ export interface AuthUser {
 
 function loadUser(): AuthUser | null {
   try {
-    const raw = localStorage.getItem('auth_user')
+    const raw = localStorage.getItem('auth_user') || sessionStorage.getItem('auth_user')
     return raw ? JSON.parse(raw) : null
   } catch {
     return null
@@ -20,11 +20,21 @@ function loadUser(): AuthUser | null {
 export function useAuth() {
   const [user, setUser] = useState<AuthUser | null>(loadUser)
 
-  const persist = (u: AuthUser | null) => {
+    const persist = (u: AuthUser | null, remember: boolean = true) => {
     setUser(u)
     try {
-      if (u) localStorage.setItem('auth_user', JSON.stringify(u))
-      else localStorage.removeItem('auth_user')
+      if (u) {
+        if (remember) {
+          localStorage.setItem('auth_user', JSON.stringify(u))
+          sessionStorage.removeItem('auth_user')
+        } else {
+          sessionStorage.setItem('auth_user', JSON.stringify(u))
+          localStorage.removeItem('auth_user')
+        }
+      } else {
+        localStorage.removeItem('auth_user')
+        sessionStorage.removeItem('auth_user')
+      }
     } catch {
       /* ignore */
     }
@@ -33,12 +43,12 @@ export function useAuth() {
   const signup = useCallback(async (username: string, password: string) => {
     await axios.post(`${BACKEND}/api/auth/signup/`, { username, password })
     const res = await axios.post(`${BACKEND}/api/auth/login/`, { username, password })
-    persist({ username, token: res.data.access })
+    persist({ username, token: res.data.access }, true)
   }, [])
 
-  const login = useCallback(async (username: string, password: string) => {
+  const login = useCallback(async (username: string, password: string, rememberMe: boolean = true) => {
     const res = await axios.post(`${BACKEND}/api/auth/login/`, { username, password })
-    persist({ username, token: res.data.access })
+    persist({ username, token: res.data.access }, rememberMe)
   }, [])
 
   const logout = useCallback(() => persist(null), [])


### PR DESCRIPTION
## Summary
Added a "Remember Me" checkbox to the login modal and integrated it with the authentication state persistence logic (fixes #139).

## Motivation
Closes #139. Users requested the ability to choose whether their login session persists across browser restarts. By adding a "Remember Me" checkbox to the login screen and updating `useAuth` to toggle between `localStorage` (persistent) and `sessionStorage` (session-only), we enhance security and user preference for session management.

## Changes
- Modified `frontend/src/AuthModal.tsx`: Added a "Remember Me" checkbox to the login view and updated `onLogin` invocation to pass the `rememberMe` state.
- Modified `frontend/src/hooks/useAuth.ts`: Updated `persist` function to conditionally use `sessionStorage` instead of `localStorage` when `rememberMe` is false. Adjusted `loadUser` to check both storage locations.

## Acceptance Criteria
- [x] Add "Remember me" checkbox on login modal
- [x] Unchecked: Store token in session storage
- [x] Checked: Store token in local storage

## Impact & Side Effects
Session storage support is introduced. The application will seamlessly load user tokens from either storage depending on user preference, with no breaking changes to the UI flow.

## How to Test
1. Start the frontend application.
2. Open the login modal.
3. Check the "Remember Me" box, login, and verify the token is in `localStorage`.
4. Log out, uncheck the box, login, and verify the token is in `sessionStorage`.

## Quality Checklist
- [x] Code passes linting
- [x] TypeScript compilation succeeds
- [x] Tested locally
