### PR TITLE
feat: update tab title when analysis completes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,10 @@ import { requestNotificationPermission, sendAnalysisCompleteNotification } from 
 
 type Theme = "light" | "dark";
 
+const DEFAULT_TITLE = "AI Resume Analyzer";
+const READY_TITLE = "✅ Analysis Ready — AI Resume Analyzer";
+
+
 function getInitialTheme(): Theme {
   try {
     const saved = localStorage.getItem("theme");
@@ -237,6 +241,24 @@ function App() {
     } catch { }
   }, [theme]);
 
+  useEffect(() => {
+  const handleVisibilityChange = () => {
+    if (!document.hidden) {
+      document.title = DEFAULT_TITLE;
+    }
+  };
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+
+  return () => {
+    document.removeEventListener(
+      "visibilitychange",
+      handleVisibilityChange
+    );
+  };
+}, []);
+
+
   // Reset analysis helper
   const resetAnalysis = useCallback(() => {
     setFile(null);
@@ -318,6 +340,11 @@ function App() {
       setMissingSkills(res.data.missing_skills || []);
       setResumeText(res.data.resume_text || "");
       setActiveFileName(fileToAnalyze.name);
+
+      // Change the browser tab title only if the user is on another tab
+      if (document.hidden) {
+         document.title = READY_TITLE;
+      }
 
       setLoading(false);
 


### PR DESCRIPTION
## 📝 Description

Updates the browser tab title when resume analysis completes while the user is on another browser tab. The title changes to "✅ Analysis Ready — AI Resume Analyzer" when analysis finishes in the background and automatically resets to the default title once the user returns to the application.

## 🔗 Related Issue

Closes #137

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [ ] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser by switching to another tab during resume analysis and verifying the page title updates when analysis completes and resets after returning to the tab.

> **Note:** The current upstream branch contains existing lint/build issues unrelated to this change.

## 📸 Screenshots (if applicable)

N/A

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)