### PR TITLE
ci: add GitHub stale workflow for inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,56 @@
+name: Mark and close stale issues and pull requests
+
+on:
+  schedule:
+    # Runs every day at 1:00 UTC
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues
+          days-before-issue-stale: 21
+          days-before-issue-close: 7
+
+          # Pull Requests
+          days-before-pr-stale: 21
+          days-before-pr-close: 7
+
+          stale-issue-label: stale
+          stale-pr-label: stale
+
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has had
+            no activity for 21 days. If this is still relevant, simply leave a
+            comment or push an update to keep it active.
+
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has had no activity for 21 days. If you're still working on it,
+            please leave a comment or push new commits.
+
+          close-issue-message: >
+            Closing this issue due to prolonged inactivity. Feel free to reopen
+            it if more work is needed.
+
+          close-pr-message: >
+            Closing this pull request due to prolonged inactivity. It can be
+            reopened if work resumes.
+
+          exempt-issue-labels: >
+            pinned,priority,high-priority,security,good first issue,help wanted
+
+          exempt-pr-labels: >
+            pinned,priority,high-priority,work-in-progress
+
+          remove-stale-when-updated: true
+          operations-per-run: 100


### PR DESCRIPTION
## 📝 Description

This PR adds a GitHub Actions workflow to automatically manage stale issues and pull requests using the `actions/stale` action.

### Changes made
- Added `.github/workflows/stale.yml`.
- Configured issues and pull requests to be marked as **stale** after **21 days** of inactivity.
- Configured stale issues and pull requests to be **automatically closed after 7 additional days** if no further activity occurs.
- Added friendly notification messages when items are marked stale or closed.
- Configured exempt labels (e.g., `pinned`, `priority`, `security`, `good first issue`, and `help wanted`) to prevent important issues or PRs from being automatically closed.
- Enabled automatic removal of the `stale` label when new activity occurs.

This helps keep the issue tracker organized while ensuring important or actively maintained work is not closed unintentionally.

## 🔗 Related Issue

Closes #209 

## ✅ Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [x] Verified the workflow file is syntactically valid.
- [x] Confirmed the workflow triggers on both a scheduled cron job and manual execution (`workflow_dispatch`).
- [x] Reviewed the configured inactivity periods, labels, exemption rules, and notification messages against the issue requirements.

## 📸 Screenshots (if applicable)

N/A

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)