### PR TITLE
feat: add branded 404 page with catch-all routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { Routes, Route } from "react-router-dom";
+import NotFound from "./components/NotFound";
 import axios from "axios";
 import "./index.css";
 import { AtsScore } from "./AtsScore";
@@ -235,6 +237,8 @@ function App() {
   const [score, setScore] = useState<number | null>(null);
   const [skills, setSkills] = useState<string[]>([]);
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [undoState, setUndoState] = useState<any>(null);
+  const [showUndoToast, setShowUndoToast] = useState(false);
 
   // Validation States
   const [fileError, setFileError] = useState<string | null>(null);
@@ -693,7 +697,8 @@ function App() {
         onLogout={handleLogout}
         onHistoryClick={() => setHistoryOpen(true)}
       />
-
+<Routes>
+  <Route path="/" element={
       <div className="container mt-5 px-3">
         <div
           className="main-card text-center mx-auto"
@@ -1293,7 +1298,9 @@ function App() {
           )}
         </div>
       </div>
-
+      } />
+      <Route path="*" element={<NotFound />} />
+      </Routes>
       {/* Floating Back to Top Button */}
       <button
         type="button"

--- a/frontend/src/components/NotFound.tsx
+++ b/frontend/src/components/NotFound.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Target } from "lucide-react";
+
+export function NotFound() {
+  return (
+    <div 
+      className="container mt-5 px-3" 
+      style={{ 
+        minHeight: "70vh", 
+        display: "flex", 
+        alignItems: "center", 
+        justifyContent: "center" 
+      }}
+    >
+      <div 
+        className="main-card text-center mx-auto p-5" 
+        style={{ width: "100%", maxWidth: "600px" }}
+      >
+        <div style={{ fontSize: "4rem", marginBottom: "16px" }}>
+          <Target size={64} style={{ color: "#6366f1" }} />
+        </div>
+
+        <h1 
+          className="mb-3 app-main-title" 
+          style={{ fontSize: "calc(1.5rem + 1vw)", wordBreak: "break-word" }}
+        >
+          404 — Page Not Found
+        </h1>
+
+        {/* Using actual existing CSS variables like var(--card-text) */}
+        <p className="hero-description mb-4" style={{ color: "var(--card-text)", opacity: 0.8, fontSize: "var(--font-size-base)" }}>
+          Oops! It looks like you've navigated off the tracking path. The page you are looking for doesn't exist or has been moved.
+        </p>
+
+        <div>
+          <a
+            href="/"
+            className="analyze-btn"
+            style={{
+              display: "inline-block",
+              padding: "12px 32px",
+              fontSize: "var(--font-size-base)",
+              fontWeight: "700",
+              backgroundColor: "#6366f1",
+              color: "#fff",
+              textDecoration: "none",
+              borderRadius: "var(--radius-md)",
+              boxShadow: "var(--shadow-card)",
+              transition: "transform 0.2s ease, background-color 0.2s ease",
+            }}
+          >
+             Back to Home
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default NotFound;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,10 +4,14 @@ import './index.css'
 import App from './App.tsx'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import ErrorBoundary from './components/ErrorBoundary'
+import { BrowserRouter } from "react-router-dom";
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ErrorBoundary>
   </StrictMode>
 )


### PR DESCRIPTION
## 📝 Description

This PR introduces a branded, theme-aware 404 Page Not Found component with a fallback catch-all route. It ensures that any invalid URL or client-side routing miss gracefully renders a polished page matching the application's design system while preserving the persistent navigation bar, theme toggle, and footer.

## 🔗 Related Issue
Closes #182 

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [X] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [X] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`)
- [X] Manually tested in the browser / API client
- [X] Manually tested in the browser by navigating to invalid routes (e.g., /nonexistent-path) to verify the catch-all routing and theme synchronization.

## 📸 Screenshots (if applicable)
<img width="1505" height="722" alt="Screenshot 2026-07-21 045635" src="https://github.com/user-attachments/assets/acd64bc4-c376-42b9-8fa8-431619c9141f" />


## 📋 Checklist

- [X] My code follows the project's style and conventions
- [X] I have linked the related issue above
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
