### PR TITLE
Fix: rewrite footer tagline in plain clear language (#248)

### DIFF
--- a/frontend/src/Footer.tsx
+++ b/frontend/src/Footer.tsx
@@ -49,8 +49,7 @@ export const Footer: React.FC = () => {
               margin: 0,
             }}
           >
-            Optimizing application structural profiles against automated parsing matrices with fluid
-            data visualization pipelines.
+            Helping you beat ATS filters and land more interviews.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
Resolves #248 by replacing the AI-generated buzzword footer tagline with a concise, plain-language description of the application's core value proposition.

## Changes Made
- Updated [Footer.tsx](file:///c:/Users/Moiz/Desktop/AI%20Resume%20Analysier/AI-Resume-Analyzer/frontend/src/Footer.tsx#L52) tagline text to: `"Helping you beat ATS filters and land more interviews."`
- Align tone and messaging with the hero section title (`"Beat ATS Filters. Land More Interviews."`).

## Verification
- Rebased on `origin/main` (0 merge conflicts).
- Verified build and TypeScript type-checking using `npm run build` (`tsc -b && vite build` passed with zero errors).

## Notes
Closes #248 