### PR TITLE
feat: restyle target career track dropdown arrow (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Custom-styled career track dropdown arrow conforming to design theme (#261).
 - Automatic issue keyword auto-labeler GitHub Action workflow (#210).
 - Test coverage reporting for backend (coverage.py) and frontend (Vitest), initial coverage badges in README, and documented thresholds (#214).
 - First-time onboarding walkthrough for new users.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1666,3 +1666,86 @@ h3 { font-size: var(--text-md); }
     transform: translateX(-50%) translateY(-8px);
   }
 }
+
+/* ── Target Career Track Custom Select (#261) ───────────────── */
+.custom-select-container {
+  position: relative;
+  width: 100%;
+}
+
+.custom-select-element {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  width: 100%;
+  padding: 10px 40px 10px 16px;
+  font-size: var(--text-sm, 14px);
+  font-weight: 500;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--radius-md, 8px);
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s, background-color 0.2s;
+}
+
+[data-theme="light"] .custom-select-element {
+  color: #0f172a;
+  background: #ffffff;
+  border-color: #cbd5e1;
+}
+
+/* Hover and Focus States */
+.custom-select-element:hover {
+  border-color: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme="light"] .custom-select-element:hover {
+  border-color: #94a3b8;
+  background: #f8fafc;
+}
+
+.custom-select-element:focus-visible,
+.custom-select-element:focus {
+  border-color: var(--color-primary, #6366f1);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+[data-theme="light"] .custom-select-element:focus-visible,
+[data-theme="light"] .custom-select-element:focus {
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.2);
+}
+
+/* Custom dropdown chevron arrow matching Lucide styling */
+.custom-select-container::after {
+  content: "";
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='%23a5b4fc' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 24 24'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  transition: opacity 0.2s;
+}
+
+[data-theme="light"] .custom-select-container::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='%234f46e5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 24 24'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+}
+
+/* Option styling inside dropdown menu */
+.custom-select-element option {
+  background: #1e1b4b;
+  color: #fff;
+}
+
+[data-theme="light"] .custom-select-element option {
+  background: #ffffff;
+  color: #0f172a;
+}


### PR DESCRIPTION
### Summary of Changes

Conformed the **Target Career Track** dropdown component to the application's modern icon design theme by replacing the browser default generic select arrow with a customized modern chevron.

- **Cross-Browser Styles (`index.css`)**: Removed default browser dropdown arrows using vendor-prefixed `appearance: none` properties.
- **Custom Chevron Arrow**: Added a customized SVG inline data URL chevron-down using the `::after` pseudo-element on the select wrapper (`.custom-select-container`), designed to match the thin stroke style of Lucide react icons.
- **Accessibility & Interaction**: Retained the native `<select>` markup to preserve 100% of native keyboard navigation (`Tab`, `Space`, and `ArrowDown` select), mobile popover responsiveness, and screen reader announcements.
- **Theming**: Integrated custom hover, focus, and option background colors for both **Light** and **Dark** themes.

### Acceptance Criteria Checklist
- [x] Custom dropdown arrow icon matches the app's icon style
- [x] Dropdown remains keyboard accessible
- [x] Consistent appearance across major browsers (Chrome, Firefox, Safari)

Closes #261
