### PR TITLE
feat: add responsive hamburger nav below 1024px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Responsive hamburger navigation menu below 1024px with slide-in animation, backdrop overlay, Escape key dismiss, and auto-close on resize (#245).
 - Custom-styled career track dropdown arrow conforming to design theme (#261).
 - Automatic issue keyword auto-labeler GitHub Action workflow (#210).
 - Test coverage reporting for backend (coverage.py) and frontend (Vitest), initial coverage badges in README, and documented thresholds (#214).

--- a/frontend/src/components/Navbar.test.tsx
+++ b/frontend/src/components/Navbar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
 import { Navbar } from './Navbar'
 
 describe('Navbar Component right-side cluster (#244)', () => {
@@ -40,5 +40,101 @@ describe('Navbar Component right-side cluster (#244)', () => {
 
     expect(screen.getByText(/testuser/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument()
+  })
+})
+
+describe('Navbar responsive hamburger (#245)', () => {
+  it('renders the hamburger toggle button', () => {
+    render(
+      <Navbar
+        theme="light"
+        toggleTheme={() => {}}
+        user={null}
+        onLogin={() => {}}
+        onLogout={() => {}}
+        onHistoryClick={() => {}}
+      />
+    )
+
+    const toggle = screen.getByRole('button', { name: /toggle navigation/i })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(toggle).toHaveAttribute('aria-controls', 'navbar-menu')
+  })
+
+  it('toggles mobile menu open and closed on click', () => {
+    render(
+      <Navbar
+        theme="light"
+        toggleTheme={() => {}}
+        user={null}
+        onLogin={() => {}}
+        onLogout={() => {}}
+        onHistoryClick={() => {}}
+      />
+    )
+
+    const toggle = screen.getByRole('button', { name: /toggle navigation/i })
+    const menu = document.getElementById('navbar-menu')!
+
+    expect(menu.className).not.toContain('mobile-open')
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(menu.className).toContain('mobile-open')
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(menu.className).not.toContain('mobile-open')
+  })
+
+  it('closes menu when a nav link is clicked', () => {
+    const onHistoryClick = vi.fn()
+    render(
+      <Navbar
+        theme="light"
+        toggleTheme={() => {}}
+        user={null}
+        onLogin={() => {}}
+        onLogout={() => {}}
+        onHistoryClick={onHistoryClick}
+      />
+    )
+
+    const toggle = screen.getByRole('button', { name: /toggle navigation/i })
+    const menu = document.getElementById('navbar-menu')!
+
+    fireEvent.click(toggle)
+    expect(menu.className).toContain('mobile-open')
+
+    const historyLink = screen.getByText('History')
+    fireEvent.click(historyLink)
+    expect(menu.className).not.toContain('mobile-open')
+    expect(onHistoryClick).toHaveBeenCalled()
+  })
+
+  it('renders a backdrop element for dismissing the menu', () => {
+    render(
+      <Navbar
+        theme="light"
+        toggleTheme={() => {}}
+        user={null}
+        onLogin={() => {}}
+        onLogout={() => {}}
+        onHistoryClick={() => {}}
+      />
+    )
+
+    const backdrop = document.querySelector('.navbar-backdrop') as HTMLElement
+    expect(backdrop).toBeInTheDocument()
+    expect(backdrop.className).not.toContain('visible')
+
+    const toggle = screen.getByRole('button', { name: /toggle navigation/i })
+    fireEvent.click(toggle)
+    expect(backdrop.className).toContain('visible')
+
+    fireEvent.click(backdrop)
+    const menu = document.getElementById('navbar-menu')!
+    expect(menu.className).not.toContain('mobile-open')
   })
 })

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import type { AuthUser } from '../hooks/useAuth'
 
 interface NavbarProps {
@@ -10,6 +10,8 @@ interface NavbarProps {
   onHistoryClick: () => void
 }
 
+const MOBILE_BREAKPOINT = 1024
+
 export const Navbar: React.FC<NavbarProps> = ({
   theme,
   toggleTheme,
@@ -20,13 +22,33 @@ export const Navbar: React.FC<NavbarProps> = ({
 }) => {
   const [mobileOpen, setMobileOpen] = useState(false)
 
+  const closeMenu = useCallback(() => setMobileOpen(false), [])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMenu()
+    }
+    if (mobileOpen) {
+      document.addEventListener('keydown', handleKeyDown)
+      return () => document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [mobileOpen, closeMenu])
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth > MOBILE_BREAKPOINT) closeMenu()
+    }
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [closeMenu])
+
   return (
     <nav className="navbar">
       <div className="navbar-brand">🚀 AI Resume Analyzer</div>
 
       <button
         className="navbar-toggle"
-        onClick={() => setMobileOpen(!mobileOpen)}
+        onClick={() => setMobileOpen((prev) => !prev)}
         aria-expanded={mobileOpen}
         aria-controls="navbar-menu"
         aria-label="Toggle navigation"
@@ -34,14 +56,20 @@ export const Navbar: React.FC<NavbarProps> = ({
         ☰
       </button>
 
-      <div id="navbar-menu" className={`navbar-menu ${mobileOpen ? 'mobile-open' : ''}`}>
+      <div
+        className={`navbar-backdrop${mobileOpen ? ' visible' : ''}`}
+        onClick={closeMenu}
+        aria-hidden="true"
+      />
+
+      <div id="navbar-menu" className={`navbar-menu${mobileOpen ? ' mobile-open' : ''}`}>
         <div className="navbar-links">
           <a
             href="#"
             onClick={(e) => {
               e.preventDefault()
               window.scrollTo({ top: 0, behavior: 'smooth' })
-              setMobileOpen(false)
+              closeMenu()
             }}
           >
             Home
@@ -50,14 +78,13 @@ export const Navbar: React.FC<NavbarProps> = ({
             href="#ats-score"
             onClick={(e) => {
               e.preventDefault()
-              // Scroll down slightly or just let user know
               const atsSection = document.getElementById('ats-score')
               if (atsSection) {
                 atsSection.scrollIntoView({ behavior: 'smooth', block: 'center' })
               } else {
                 window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' })
               }
-              setMobileOpen(false)
+              closeMenu()
             }}
           >
             ATS Score
@@ -68,7 +95,7 @@ export const Navbar: React.FC<NavbarProps> = ({
             onClick={(e) => {
               e.preventDefault()
               onHistoryClick()
-              setMobileOpen(false)
+              closeMenu()
             }}
           >
             History
@@ -81,7 +108,7 @@ export const Navbar: React.FC<NavbarProps> = ({
             className="app-btn app-btn--secondary theme-toggle-btn theme-toggle-navbar"
             onClick={() => {
               toggleTheme()
-              setMobileOpen(false)
+              closeMenu()
             }}
             aria-label="Toggle theme"
             aria-pressed={theme === 'dark'}
@@ -96,7 +123,7 @@ export const Navbar: React.FC<NavbarProps> = ({
                 className="auth-bar-btn"
                 onClick={() => {
                   onLogout()
-                  setMobileOpen(false)
+                  closeMenu()
                 }}
               >
                 Logout
@@ -107,7 +134,7 @@ export const Navbar: React.FC<NavbarProps> = ({
               className="auth-bar-btn"
               onClick={() => {
                 onLogin()
-                setMobileOpen(false)
+                closeMenu()
               }}
             >
               🔐 Login / Sign Up

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1163,6 +1163,7 @@ h3 { font-size: var(--text-md); }
   justify-content: space-between;
   align-items: center;
   transition: background 0.3s ease, color 0.3s ease;
+  overflow-x: hidden;
 }
 
 .navbar-brand {
@@ -1180,6 +1181,13 @@ h3 { font-size: var(--text-md); }
   color: var(--card-text);
   font-size: var(--text-lg);
   cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  transition: background 0.2s ease;
+}
+
+.navbar-toggle:hover {
+  background: var(--btn-secondary-bg);
 }
 
 .navbar-menu {
@@ -1187,6 +1195,10 @@ h3 { font-size: var(--text-md); }
   align-items: center;
   gap: 28px;
   flex-shrink: 0;
+}
+
+.navbar-backdrop {
+  display: none;
 }
 
 .navbar-links {
@@ -1220,11 +1232,11 @@ h3 { font-size: var(--text-md); }
   flex-shrink: 0;
 }
 
-@media (max-width: 768px) {
-  .navbar { padding: 12px 68px 12px 20px; }
+@media (max-width: 1024px) {
+  .navbar { padding: 12px 56px 12px 20px; }
   .navbar-toggle { display: block; }
   .navbar-menu {
-    display: none;
+    display: flex;
     flex-direction: column;
     position: absolute;
     top: 100%;
@@ -1232,19 +1244,44 @@ h3 { font-size: var(--text-md); }
     width: 100%;
     background: var(--card-bg);
     backdrop-filter: blur(16px);
-    padding: 20px;
+    padding: 0 20px;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: max-height 0.3s ease, opacity 0.25s ease, padding 0.3s ease;
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-    gap: 20px;
+    gap: 0;
     border-top: 1px solid rgba(255,255,255,0.1);
   }
 
-  .navbar-menu.mobile-open { display: flex; }
+  .navbar-menu.mobile-open {
+    max-height: 400px;
+    opacity: 1;
+    padding: 20px;
+    gap: 20px;
+  }
 
   .navbar-links, .navbar-actions {
     flex-direction: column;
     align-items: flex-start;
     width: 100%;
     gap: 15px;
+  }
+
+  .navbar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 998;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+  }
+
+  .navbar-backdrop.visible {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 


### PR DESCRIPTION
## Summary

The navbar currently overflows well before mobile width due to too many items (Home, ATS Score, History, Light Mode toggle, Login/Signup) competing for horizontal space. This PR replaces the existing 768px hamburger with a proper responsive collapsible menu that activates at 1024px, with smooth animations, backdrop dismiss, and keyboard support.

Closes #245

---

## Changes

### `frontend/src/index.css`
- Raised hamburger breakpoint from `768px` → `1024px` to prevent overflow on tablets and small laptops
- Replaced `display: none / flex` toggle with `max-height` + `opacity` CSS transition for a smooth slide-in animation
- Added `.navbar-backdrop` styles — fixed semi-transparent overlay that fades in/out
- Added `overflow-x: hidden` on `.navbar` to prevent horizontal scroll at any viewport width
- Added hover state on `.navbar-toggle` button for better interactivity feedback

### `frontend/src/components/Navbar.tsx`
- Added **Escape key** handler — pressing Escape closes the mobile menu
- Added **window resize** listener — menu auto-closes when viewport exceeds 1024px
- Added **backdrop overlay** element — tapping outside the menu dismisses it
- Extracted `closeMenu` callback to reduce repetition across handlers
- Improved class name concatenation for consistency

### `frontend/src/components/Navbar.test.tsx`
- Added 4 new tests in a `Navbar responsive hamburger (#245)` describe block:
  - Hamburger toggle renders with correct `aria-expanded` and `aria-controls`
  - Menu opens and closes on hamburger click
  - Menu closes when a nav link is clicked (verifies `onHistoryClick` fires)
  - Backdrop appears when menu opens and dismisses menu on click

### `CHANGELOG.md`
- Added entry under `[Unreleased] > Added`

---

## Acceptance Criteria

| Criterion | Status |
|---|---|
| Header collapses into hamburger menu below ~1024px | ✅ Breakpoint raised from 768px to 1024px |
| All nav items remain accessible inside the collapsed menu | ✅ Home, ATS Score, History, Theme Toggle, Login/Signup all present |
| No horizontal overflow/scroll at any viewport width | ✅ `overflow-x: hidden` on navbar, `flex-shrink: 0` on menu children |

---

## How to Test

1. Run `cd frontend && npm install && npm test` — all 12 tests should pass
2. Run `cd frontend && npm run dev`
3. Resize browser window below 1024px — hamburger icon appears, nav items collapse into dropdown
4. Click hamburger — menu slides in with animation, backdrop appears
5. Click backdrop or press Escape — menu closes
6. Click a nav link — menu closes and action fires
7. Resize back above 1024px — menu auto-closes, full nav restores
8. Verify no horizontal scrollbar at any width (especially 768px–1024px range)

---


## Checklist

- [x] Code builds successfully
- [x] No unnecessary files included
- [x] Code follows project conventions (functional components, clean JSX)
- [x] Lint passes on changed files (0 errors)
- [x] All tests pass (12/12)
- [x] Documentation updated (CHANGELOG.md)
- [x] Issue linked (Closes #245)
- [x] Merge conflicts resolved
- [x] Commit messages are meaningful