### PR TITLE
fix: restore full opacity/contrast for faded text elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Improved frontend performance and usability.
 
 ### Fixed
+- Fixed widespread low-opacity/faded text across stats, How It Works cards, upload zone, and footer (#242).
 - Minor UI and styling fixes across multiple frontend components.
 - Improved responsiveness and consistency across the application.
 - Various bug fixes related to resume analysis and UI rendering.

--- a/frontend/src/Footer.tsx
+++ b/frontend/src/Footer.tsx
@@ -12,7 +12,7 @@ export const Footer: React.FC = () => {
       style={{
         marginTop: '80px',
         borderTop: '1px solid rgba(255, 255, 255, 0.05)',
-        background: 'rgba(30, 30, 47, 0.4)',
+        background: 'rgba(30, 30, 47, 0.8)',
         padding: '40px 20px 20px',
       }}
     >
@@ -44,7 +44,7 @@ export const Footer: React.FC = () => {
           <p
             style={{
               fontSize: 'var(--font-size-sm)',
-              color: '#94a3b8',
+              color: 'var(--footer-text)',
               lineHeight: '1.6',
               margin: 0,
             }}
@@ -225,10 +225,10 @@ export const Footer: React.FC = () => {
           gap: '12px',
         }}
       >
-        <p style={{ fontSize: '12px', color: '#64748b', margin: 0 }}>
+        <p style={{ fontSize: '12px', color: '#94a3b8', margin: 0 }}>
           &copy; {currentYear} AI Resume Analyzer. All architectural systems operational.
         </p>
-        <p style={{ fontSize: '12px', color: '#64748b', margin: 0 }}>
+        <p style={{ fontSize: '12px', color: '#94a3b8', margin: 0 }}>
           Built with React & TypeScript
         </p>
       </div>

--- a/frontend/src/components/HowItWorks.tsx
+++ b/frontend/src/components/HowItWorks.tsx
@@ -57,7 +57,6 @@ export const HowItWorks: React.FC = () => {
               style={{
                 margin: 0,
                 fontSize: 'var(--font-size-sm, 0.875rem)',
-                opacity: 0.8,
                 lineHeight: '1.5',
               }}
             >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,7 +53,7 @@
   --btn-accent-hover-bg: #2563eb;
   --btn-success-bg: var(--color-accent);
   --btn-accent-text: #ffffff;
-  --footer-text: rgba(255,255,255,0.85);
+  --footer-text: #ffffff;
   --footer-link: #ffffff;
 
   /* Standardized Border Radius Tokens */
@@ -97,7 +97,7 @@
   --btn-accent-hover-bg: #60a5fa;
   --btn-success-bg: var(--color-accent);
   --btn-accent-text: #ffffff;
-  --footer-text: rgba(226,232,240,0.85);
+  --footer-text: #e2e8f0;
   --footer-link: #e2e8f0;
 }
 
@@ -136,13 +136,13 @@ body {
     margin:50px 0;
 }
 
-.hero-stat h2{
+.hero-stats h2{
     font-size:3rem;
     color:white;
     margin-bottom:8px;
 }
 
-.hero-stat p{
+.hero-stats p{
     color:#94a3b8;
 }
 
@@ -267,6 +267,7 @@ h3 { font-size: var(--text-md); }
   cursor: pointer;
   font-weight: 500;
   font-size: var(--text-base);
+  color: var(--card-text);
 }
 
 .analyze-btn {
@@ -852,7 +853,6 @@ h3 { font-size: var(--text-md); }
 
 .app-footer__copy {
   margin: 0;
-  opacity: 0.85;
 }
 
 /* ── Resume Preview Pane ────────────────── */


### PR DESCRIPTION
## Root Cause

No scroll-reveal animation or IntersectionObserver exists in the codebase. The faded text was caused by hardcoded low-opacity values and low-contrast color choices across four areas.

| Area | Cause | File |
|---|---|---|
| Stats ("50K+", "95%", "24/7") | Dead CSS rule `.hero-stat h2` (singular) never matched DOM `.hero-stats > div > h2` (plural) — stat numbers had no color | `index.css:139` |
| How It Works cards | Hardcoded `opacity: 0.8` inline style on every card description `<p>` | `HowItWorks.tsx:60` |
| Upload zone | `<label>` had no `color` — inherited Bootstrap's dark body color on dark bg | `index.css:266`, `App.tsx:940` |
| Footer | Triple compounding: `--footer-text` alpha 0.85 + `.app-footer__copy` opacity 0.85 + `#94a3b8` tagline + 40% opaque bg | `index.css:100,855`, `Footer.tsx:15,47` |

Closes #242

## Changes

### `index.css`
- Fixed selector `.hero-stat h2` → `.hero-stat h2` → `.hero-stats h2` so stat numbers get `color: white`
- Added `color: var(--card-text)` to `.upload-label` for proper theme-aware text color
- Removed baked-in alpha from `--footer-text` variables (light: `#ffffff`, dark: `#e2e8f0`)
- Removed compounding `opacity: 0.85` from `.app-footer__copy`

### `HowItWorks.tsx`
- Removed `opacity: 0.8` inline style from card description `<p>` elements

### `Footer.tsx`
- Increased footer background opacity from `0.4` → `0.8`
- Changed tagline color from `#94a3b8` → `var(--footer-text)` for theme consistency
- Brightened copyright text from `#64748b` → `#94a3b8`

### `CHANGELOG.md`
- Added entry under `[Unreleased] > Fixed`

## Verification
- Lint: 0 new errors (1 pre-existing in Footer.tsx import)
- Tests: 12/12 passing