### PR TITLE
fix: Improve How It Works heading and step-card contrast for dark mode

### DIFF
--- a/frontend/src/components/HowItWorks.tsx
+++ b/frontend/src/components/HowItWorks.tsx
@@ -28,7 +28,7 @@ export const HowItWorks: React.FC = () => {
         borderTop: '1px solid var(--border-color, rgba(128, 128, 128, 0.2))',
       }}
     >
-      <h3 style={{ marginBottom: '1.5rem', fontSize: '1.2rem', fontWeight: '600' }}>
+      <h3 style={{ marginBottom: '1.5rem', fontSize: '1.2rem', fontWeight: '600', color: 'var(--card-text)' }}>
         How It Works
       </h3>
 
@@ -40,24 +40,25 @@ export const HowItWorks: React.FC = () => {
               flex: '1 1 250px',
               minWidth: '250px',
               padding: '24px 20px',
-              background: 'var(--card-bg, rgba(128, 128, 128, 0.05))',
+              background: 'var(--card-bg)',
               borderRadius: 'var(--radius-md, 8px)',
               border: '1px solid var(--border-color, rgba(128, 128, 128, 0.1))',
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
               textAlign: 'center',
+              color: 'var(--card-text)',
             }}
           >
             <div style={{ color: '#818cf8', marginBottom: '16px' }}>{step.icon}</div>
-            <h4 style={{ margin: '0 0 8px 0', fontSize: '1.05rem', fontWeight: '600' }}>
+            <h4 style={{ margin: '0 0 8px 0', fontSize: '1.05rem', fontWeight: '600', color: 'var(--card-text)' }}>
               {step.title}
             </h4>
             <p
               style={{
                 margin: 0,
                 fontSize: 'var(--font-size-sm, 0.875rem)',
-                opacity: 0.8,
+                color: 'var(--card-text)',
                 lineHeight: '1.5',
               }}
             >


### PR DESCRIPTION
Closes #276

## What was changed
Fixed the "How It Works" section text legibility on dark backgrounds:

- **Heading (`<h3>`)** — added `color: var(--card-text)` so it uses the theme-aware text color instead of inheriting a low-contrast default
- **Step titles (`<h4>`)** — same `var(--card-text)` fix for proper light/dark contrast
- **Step descriptions (`<p>`)** — removed `opacity: 0.8` that dimmed text to 80% opacity, added `var(--card-text)` for full WCAG AA compliant contrast
- **Step cards (`<div>`)** — used `var(--card-bg)` with `color: var(--card-text)` on the card itself so all text inherits theme-appropriate colors

## How it was tested
- TypeScript compilation passes (`tsc --noEmit` ✓)
- Changes are purely CSS — no logic or functionality affected
- All text now respects `--card-text` (light: `#0f172a`, dark: `#e2e8f0`) and card background uses `--card-bg` (light: `#ffffff`, dark: `rgba(2,6,23,0.6)`)

## Verification
- WCAG AA contrast ratio is satisfied in both light and dark themes
- Step icons remain visually consistent (unchanged)