### PR TITLE
feat: add resume file preview before analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Skill matching and missing skills visualization enhancements.
 - Resume history tracking improvements.
 - Authentication modal enhancements.
-
+- Resume thumbnail/file preview (name, size, type icon) shown immediately after file selection, before analysis (#140).
 ### Changed
 - Improved onboarding experience and user interface consistency.
 - Enhanced visual styling across the application.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import {
 } from './utils/notification'
 import { ProgressBar } from './components/ProgressBar/ProgressBar'
 import { UndoToast } from './components/UndoToast/UndoToast'
+import { FilePreview } from './components/FilePreview/FilePreview'
 type Theme = 'light' | 'dark'
 
 interface UndoState {
@@ -996,79 +997,78 @@ function App() {
                         >
                           🔗 Import via Link
                         </button>
-
-                    </div>
-
-                    {uploadMode === 'file' ? (
-                      <div
-                        className={`upload-box mb-3 ${isDragging ? 'dragging' : ''}`}
-                        style={{ width: '100%', maxWidth: '100%' }}
-                        onDragOver={handleDragOver}
-                        onDragLeave={handleDragLeave}
-                        onDrop={handleDrop}
-                      >
-                        <input
-                          type="file"
-                          id="fileUpload"
-                          hidden
-                          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                            if (e.target.files && e.target.files[0]) {
-                              setFile(e.target.files[0])
-                              setFileError(null)
-                            }
-                          }}
-                        />
-                        <label htmlFor="fileUpload" className="upload-label">
-                          <div className="upload-icon-wrapper" aria-hidden="true">
-                            {file ? (
-                              <svg
-                                width="28"
-                                height="28"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                              >
-                                <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-                                <polyline points="14 2 14 8 20 8" />
-                                <path d="M9 15l2 2 4-4" />
-                              </svg>
-                            ) : (
-                              <svg
-                                width="28"
-                                height="28"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                              >
-                                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                                <polyline points="17 8 12 3 7 8" />
-                                <line x1="12" y1="3" x2="12" y2="15" />
-                              </svg>
-                            )}
-                          </div>
-                          <div style={{ textAlign: 'center' }}>
-                            {file ? (
-                              <strong className="upload-file-name">{file.name}</strong>
-                            ) : (
-                              <>
-                                <span className="upload-text-primary">
-                                  Drag &amp; Drop Resume or{' '}
-                                  <span className="upload-text-browse">Click to Browse</span>
-                                </span>
-                                <span className="upload-text-secondary">
-                                  Supports PDF, DOCX, TXT up to 10MB
-                                </span>
-                              </>
-                            )}
-                          </div>
-                        </label>
                       </div>
+
+                      {uploadMode === 'file' ? (
+                        <div
+                          className={`upload-box mb-3 ${isDragging ? 'dragging' : ''}`}
+                          style={{ width: '100%', maxWidth: '100%' }}
+                          onDragOver={handleDragOver}
+                          onDragLeave={handleDragLeave}
+                          onDrop={handleDrop}
+                        >
+                          <input
+                            type="file"
+                            id="fileUpload"
+                            hidden
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                              if (e.target.files && e.target.files[0]) {
+                                setFile(e.target.files[0])
+                                setFileError(null)
+                              }
+                            }}
+                          />
+                          <label htmlFor="fileUpload" className="upload-label">
+                            <div className="upload-icon-wrapper" aria-hidden="true">
+                              {file ? (
+                                <svg
+                                  width="28"
+                                  height="28"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="2"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                >
+                                  <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+                                  <polyline points="14 2 14 8 20 8" />
+                                  <path d="M9 15l2 2 4-4" />
+                                </svg>
+                              ) : (
+                                <svg
+                                  width="28"
+                                  height="28"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="2"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                >
+                                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                                  <polyline points="17 8 12 3 7 8" />
+                                  <line x1="12" y1="3" x2="12" y2="15" />
+                                </svg>
+                              )}
+                            </div>
+                            <div style={{ textAlign: 'center' }}>
+                              {file ? (
+                                <strong className="upload-file-name">{file.name}</strong>
+                              ) : (
+                                <>
+                                  <span className="upload-text-primary">
+                                    Drag &amp; Drop Resume or{' '}
+                                    <span className="upload-text-browse">Click to Browse</span>
+                                  </span>
+                                  <span className="upload-text-secondary">
+                                    Supports PDF, DOCX, TXT up to 10MB
+                                  </span>
+                                </>
+                              )}
+                            </div>
+                          </label>
+                        </div>
                       ) : (
                         <div className="mb-3" style={{ textAlign: 'left' }}>
                           <label
@@ -1115,7 +1115,11 @@ function App() {
                           </span>
                         </div>
                       )}
-
+                      {file && uploadMode === 'file' && (
+                        <div className="mb-3">
+                          <FilePreview file={file} />
+                        </div>
+                      )}
                       {fileError && uploadMode === 'file' && (
                         <div
                           style={{

--- a/frontend/src/components/FilePreview/FilePreview.css
+++ b/frontend/src/components/FilePreview/FilePreview.css
@@ -1,0 +1,51 @@
+.file-preview {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3, 12px);
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  background: var(--upload-bg);
+  border: 1px solid var(--upload-border);
+  text-align: left;
+}
+
+.file-preview-thumbnail {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-md);
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--upload-icon-color);
+  overflow: hidden;
+}
+
+.file-preview-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.file-preview-details {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 2px;
+}
+
+.file-preview-name {
+  color: var(--upload-file-name);
+  font-size: var(--text-base);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file-preview-meta {
+  color: var(--upload-text-secondary);
+  font-size: var(--text-xs);
+}

--- a/frontend/src/components/FilePreview/FilePreview.test.tsx
+++ b/frontend/src/components/FilePreview/FilePreview.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { FilePreview } from './FilePreview'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function makeFile(name: string, size: number, type: string): File {
+  return new File([new Uint8Array(size)], name, { type })
+}
+
+describe('FilePreview component (#140)', () => {
+  it('shows the filename and a human-readable size', () => {
+    const file = makeFile('resume.pdf', 842 * 1024, 'application/pdf')
+    render(<FilePreview file={file} />)
+
+    expect(screen.getByText('resume.pdf')).toBeInTheDocument()
+    expect(screen.getByText(/842\.0 KB/)).toBeInTheDocument()
+  })
+
+  it('labels a PDF file correctly', () => {
+    const file = makeFile('resume.pdf', 1024, 'application/pdf')
+    render(<FilePreview file={file} />)
+    expect(screen.getByText(/PDF/)).toBeInTheDocument()
+  })
+
+  it('labels a DOCX file correctly', () => {
+    const file = makeFile(
+      'resume.docx',
+      2048,
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    )
+    render(<FilePreview file={file} />)
+    expect(screen.getByText(/Word document/)).toBeInTheDocument()
+  })
+
+  it('labels a plain text file correctly', () => {
+    const file = makeFile('resume.txt', 100, 'text/plain')
+    render(<FilePreview file={file} />)
+    expect(screen.getByText(/Text file/)).toBeInTheDocument()
+  })
+
+  it('renders an actual image thumbnail for image files', () => {
+    const createObjectURL = vi.fn(() => 'blob:mock-url')
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL: vi.fn() })
+
+    const file = makeFile('photo.png', 4096, 'image/png')
+    render(<FilePreview file={file} />)
+
+    const imgEl = document.querySelector('img.file-preview-image') as HTMLImageElement
+    expect(imgEl).toBeTruthy()
+    expect(imgEl.src).toContain('blob:mock-url')
+    expect(createObjectURL).toHaveBeenCalledWith(file)
+  })
+
+  it('replaces the preview content when a new file is passed in', () => {
+    const first = makeFile('first.pdf', 1024, 'application/pdf')
+    const { rerender } = render(<FilePreview file={first} />)
+    expect(screen.getByText('first.pdf')).toBeInTheDocument()
+
+    const second = makeFile('second.docx', 2048, 'application/msword')
+    rerender(<FilePreview file={second} />)
+
+    expect(screen.queryByText('first.pdf')).not.toBeInTheDocument()
+    expect(screen.getByText('second.docx')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/FilePreview/FilePreview.tsx
+++ b/frontend/src/components/FilePreview/FilePreview.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useMemo } from 'react'
+import { FileText, File as FileIcon, Image as ImageIcon } from 'lucide-react'
+import { formatFileSize } from '../../utils/formatFileSize'
+import './FilePreview.css'
+
+export interface FilePreviewProps {
+  file: File
+}
+
+type FileKind = 'pdf' | 'doc' | 'image' | 'text' | 'other'
+
+function getFileKind(file: File): FileKind {
+  const name = file.name.toLowerCase()
+  const type = file.type.toLowerCase()
+
+  if (type.startsWith('image/')) return 'image'
+  if (type === 'application/pdf' || name.endsWith('.pdf')) return 'pdf'
+  if (
+    type === 'application/msword' ||
+    type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+    name.endsWith('.doc') ||
+    name.endsWith('.docx')
+  ) {
+    return 'doc'
+  }
+  if (type === 'text/plain' || name.endsWith('.txt')) return 'text'
+  return 'other'
+}
+
+const KIND_LABEL: Record<FileKind, string> = {
+  pdf: 'PDF',
+  doc: 'Word document',
+  image: 'Image',
+  text: 'Text file',
+  other: 'File',
+}
+
+/**
+ * Shown immediately after a resume file is selected (drag/drop or browse),
+ * before the user clicks Analyze, so they can confirm they picked the right
+ * file. Renders an actual image thumbnail when the selected file is an
+ * image; every other supported type (PDF/DOC/TXT) falls back to a type icon
+ * -- true first-page PDF rendering is left as a follow-up since it needs a
+ * PDF-rendering dependency this repo doesn't otherwise pull in.
+ */
+export function FilePreview({ file }: FilePreviewProps) {
+  const kind = getFileKind(file)
+  // Recomputed whenever `file` (or its kind) changes, so a newly selected
+  // file always replaces the previous preview instead of stacking with it.
+  const imageUrl = useMemo(
+    () => (kind === 'image' ? URL.createObjectURL(file) : null),
+    [file, kind]
+  )
+
+  useEffect(() => {
+    return () => {
+      if (imageUrl) URL.revokeObjectURL(imageUrl)
+    }
+  }, [imageUrl])
+
+  return (
+    <div className="file-preview" data-testid="file-preview">
+      <div className="file-preview-thumbnail" aria-hidden="true">
+        {imageUrl ? (
+          <img src={imageUrl} alt="" className="file-preview-image" />
+        ) : kind === 'pdf' || kind === 'doc' ? (
+          <FileText size={22} />
+        ) : kind === 'image' ? (
+          <ImageIcon size={22} />
+        ) : (
+          <FileIcon size={22} />
+        )}
+      </div>
+      <div className="file-preview-details">
+        <span className="file-preview-name" title={file.name}>
+          {file.name}
+        </span>
+        <span className="file-preview-meta">
+          {KIND_LABEL[kind]} · {formatFileSize(file.size)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default FilePreview

--- a/frontend/src/utils/formatFileSize.test.ts
+++ b/frontend/src/utils/formatFileSize.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { formatFileSize } from './formatFileSize'
+
+describe('formatFileSize', () => {
+  it('formats zero bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B')
+  })
+
+  it('formats plain bytes with no decimal', () => {
+    expect(formatFileSize(512)).toBe('512 B')
+  })
+
+  it('formats kilobytes with one decimal', () => {
+    expect(formatFileSize(842 * 1024)).toBe('842.0 KB')
+  })
+
+  it('formats megabytes with one decimal', () => {
+    expect(formatFileSize(2.4 * 1024 * 1024)).toBe('2.4 MB')
+  })
+
+  it('formats gigabytes', () => {
+    expect(formatFileSize(1.5 * 1024 * 1024 * 1024)).toBe('1.5 GB')
+  })
+
+  it('treats negative or non-finite input as 0 B', () => {
+    expect(formatFileSize(-5)).toBe('0 B')
+    expect(formatFileSize(NaN)).toBe('0 B')
+  })
+})

--- a/frontend/src/utils/formatFileSize.ts
+++ b/frontend/src/utils/formatFileSize.ts
@@ -1,0 +1,16 @@
+/**
+ * Format a byte count as a short human-readable string, e.g. `842 KB`,
+ * `2.4 MB`. Used by the file preview shown right after selection so users
+ * can confirm they picked the right file before analyzing.
+ */
+export function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B'
+  if (bytes === 0) return '0 B'
+
+  const units = ['B', 'KB', 'MB', 'GB']
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  const value = bytes / Math.pow(1024, exponent)
+  const decimals = exponent === 0 ? 0 : 1
+
+  return `${value.toFixed(decimals)} ${units[exponent]}`
+}


### PR DESCRIPTION
## 📝 Description
Adds a small preview shown immediately after a resume file is selected (drag-drop or browse), before the user clicks Analyze, so users can confirm they picked the right file.

The preview shows the filename, file size (formatted as e.g. `842.0 KB`, `2.4 MB`), and a type indicator — PDF / Word document / Text file, each with a matching icon. If the selected file happens to be an image, it renders an actual image thumbnail instead of an icon.

True first-page PDF rendering was considered but left out of this PR — it would require adding `pdfjs-dist`, a new dependency, which felt heavier than this issue calls for. The acceptance criteria explicitly allow "file icon + name/size" as a valid v1, so that's the approach taken here (with a real thumbnail added for image files, since that's free to support with no new dependencies).

Note: `npm run lint` on this repo currently reports two pre-existing issues in files this PR does not touch (`EmptyState.tsx` — a stray line-ending, and `OnboardingTour.tsx` — a `finishTour` declared-after-use bug). Both exist identically on `main` and are unrelated to this change, so I left them out of scope per "keep the PR focused on one issue."

## 🔗 Related Issue
Closes #140

## ✅ Type of Change
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?
- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean — no new lint errors introduced by this change
- [ ] Backend tests pass (`python manage.py test analyzer`) — not applicable, this PR is frontend-only
- [x] Manually tested in the browser / API client — verified with PDF, DOCX, TXT, and image files: preview appears immediately after selection with correct filename/size/icon, and is replaced cleanly when a different file is chosen
- [x] Added automated tests: 12 new tests (`formatFileSize.test.ts`, `FilePreview.test.tsx`), all passing via `npm run test:coverage`

## 📸 Screenshots (if applicable)
<img width="2506" height="1410" alt="image" src="https://github.com/user-attachments/assets/ec0b91fe-a118-482d-87f1-e11a78f2cf70" />


## 📋 Checklist
- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)