### PR TITLE
docs: add GitHub Projects board documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,21 @@ AI-Resume-Analyzer
 
 ---
 
+# Project Board
+
+Track development progress using our GitHub Project:
+
+<Project URL>
+
+_Project Columns to create:_
+
+- _To Do_
+- _In Progress_
+- _In Review_
+- _Done_
+
+---
+
 # Branch Naming Convention
 
 Use meaningful branch names.
@@ -223,7 +238,6 @@ When your pull request includes a notable change:
   - **Removed** – Removed or deprecated functionality.
 - Keep entries concise and user-focused.
 - When a new release is created, move entries from **Unreleased** into a versioned release section.
-
 
 Example:
 


### PR DESCRIPTION
## 📝 Description

This PR improves contributor documentation by introducing guidance for a GitHub Projects board to help track issue progress across contributors.

### Changes
- Added a **Project Board** section to `CONTRIBUTING.md`.
- Documented the recommended workflow using the following project statuses:
  - **To Do**
  - **In Progress**
  - **In Review**
  - **Done**
- Included a placeholder for the GitHub Project URL, which can be updated once a maintainer creates the repository project.

> **Note:** Creating and configuring a GitHub Projects (Projects v2) board requires repository-level permissions. This PR prepares the documentation for the project board, and the project link can be added after the board is created by a maintainer.

## 🔗 Related Issue

- Closes #307

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [ ] Frontend builds (`npm run build`) and lints (`npm run lint`) clean *(Not applicable for documentation-only changes)*
- [ ] Backend tests pass (`python manage.py test analyzer`) *(Not applicable for documentation-only changes)*
- [x] Manually reviewed the documentation changes for clarity and formatting.

## 📸 Screenshots (if applicable)

Not applicable.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)