### PR TITLE
feat: add curated resume tips for career tracks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react'
 import { Navbar } from './components/Navbar'
 import EmptyState from './components/EmptyState'
+import { CuratedTips } from './components/CuratedTips'
 import { StepProgress } from './components/StepProgress'
 import { OnboardingTour } from './components/OnboardingTour'
 import { HowItWorks } from './components/HowItWorks'
@@ -1537,6 +1538,8 @@ function App() {
                           ))}
                         </div>
                       )}
+
+                      <CuratedTips targetRole={targetRole} />
 
                       <div style={{ marginTop: '24px', textAlign: 'center' }}>
                         <button

--- a/frontend/src/components/CuratedTips.test.tsx
+++ b/frontend/src/components/CuratedTips.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { CuratedTips } from './CuratedTips'
+import { careerResumeTips } from '../data/careerResumeTips'
+
+// Mock the data module so we can test predictably
+vi.mock('../data/careerResumeTips', () => ({
+  careerResumeTips: {
+    'Frontend Developer': ['Tip 1 for frontend', 'Tip 2 for frontend'],
+    'Backend Developer': ['Tip 1 for backend'],
+  },
+}))
+
+describe('CuratedTips Component', () => {
+  it('renders curated tips when available for the target role', () => {
+    render(<CuratedTips targetRole="Frontend Developer" />)
+
+    expect(screen.getByText('Curated Tips for Frontend Developer')).toBeInTheDocument()
+    expect(screen.getByText('Tip 1 for frontend')).toBeInTheDocument()
+    expect(screen.getByText('Tip 2 for frontend')).toBeInTheDocument()
+  })
+
+  it('renders the fallback message when no tips exist for the target role', () => {
+    render(<CuratedTips targetRole="Unknown Track" />)
+
+    expect(screen.getByText('Curated Tips for Unknown Track')).toBeInTheDocument()
+    expect(
+      screen.getByText('No additional curated resume tips are available for this career track.')
+    ).toBeInTheDocument()
+  })
+
+  it('switches career tracks and renders new tips', () => {
+    const { rerender } = render(<CuratedTips targetRole="Frontend Developer" />)
+
+    expect(screen.getByText('Tip 1 for frontend')).toBeInTheDocument()
+
+    // Switch to Backend Developer
+    rerender(<CuratedTips targetRole="Backend Developer" />)
+
+    expect(screen.getByText('Curated Tips for Backend Developer')).toBeInTheDocument()
+    expect(screen.getByText('Tip 1 for backend')).toBeInTheDocument()
+    expect(screen.queryByText('Tip 1 for frontend')).not.toBeInTheDocument()
+  })
+
+  it('verifies data loading and graceful handling of empty tip arrays', () => {
+    // If a track is defined but has an empty array, it should show fallback
+    vi.mocked(careerResumeTips)['Empty Track'] = []
+
+    render(<CuratedTips targetRole="Empty Track" />)
+
+    expect(
+      screen.getByText('No additional curated resume tips are available for this career track.')
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/CuratedTips.tsx
+++ b/frontend/src/components/CuratedTips.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { careerResumeTips } from '../data/careerResumeTips'
+
+interface CuratedTipsProps {
+  targetRole: string
+}
+
+export const CuratedTips: React.FC<CuratedTipsProps> = ({ targetRole }) => {
+  const tips = careerResumeTips[targetRole]
+
+  return (
+    <div className="curated-tips-section" style={{ marginTop: '24px' }}>
+      <h5 style={{ marginBottom: '12px' }}>Curated Tips for {targetRole}</h5>
+      {tips && tips.length > 0 ? (
+        <ul style={{ paddingLeft: '20px', color: '#e2e8f0', fontSize: '0.95rem' }}>
+          {tips.map((tip, index) => (
+            <li key={index} style={{ marginBottom: '8px' }}>
+              {tip}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p
+          style={{
+            color: '#64748b',
+            fontStyle: 'italic',
+            fontSize: 'var(--font-size-sm)',
+            margin: '0',
+          }}
+        >
+          No additional curated resume tips are available for this career track.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Navbar.test.tsx
+++ b/frontend/src/components/Navbar.test.tsx
@@ -16,14 +16,14 @@ describe('Navbar Component (#241)', () => {
 
   it('renders the header brand with emoji and "AI Resume Analyzer" title text', () => {
     render(<Navbar {...defaultProps} />)
-    const brandElement = screen.getByText('AI Resume Analyzer')
+    const brandElement = screen.getByText(/AI Resume Analyzer/i)
     expect(brandElement).toBeInTheDocument()
-    expect(screen.getByText('🚀')).toBeInTheDocument()
+    expect(brandElement.textContent).toContain('🚀')
   })
 
   it('renders correctly in light mode', () => {
     render(<Navbar {...defaultProps} theme="light" />)
-    expect(screen.getByText('AI Resume Analyzer')).toBeInTheDocument()
+    expect(screen.getByText(/AI Resume Analyzer/i)).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -56,6 +56,11 @@ export const Navbar: React.FC<NavbarProps> = ({
         ☰
       </button>
 
+      <div
+        className={`navbar-backdrop ${mobileOpen ? 'visible' : ''}`}
+        onClick={() => setMobileOpen(false)}
+      />
+
       <nav
         id="navbar-menu"
         className={`navbar-menu ${mobileOpen ? 'mobile-open' : ''}`}

--- a/frontend/src/data/careerResumeTips.ts
+++ b/frontend/src/data/careerResumeTips.ts
@@ -1,0 +1,26 @@
+export const careerResumeTips: Record<string, string[]> = {
+  'Frontend Developer': [
+    'Link to a live portfolio showcasing your web projects.',
+    'Highlight modern frameworks like React, Vue, or Next.js.',
+    'Mention your experience with responsive design and accessibility (a11y).',
+    'Include metrics if you optimized page load performance.',
+  ],
+  'Backend Developer': [
+    'Describe your experience building scalable APIs.',
+    'Mention specific databases (SQL/NoSQL) and caching mechanisms.',
+    'Highlight your approach to testing (unit, integration) and CI/CD pipelines.',
+    'Detail any cloud services (AWS, GCP, Azure) you have worked with.',
+  ],
+  'Data Analyst': [
+    'Quantify the business impact of your data insights.',
+    'Mention data visualization tools like Tableau, PowerBI, or Matplotlib.',
+    'Highlight your proficiency with SQL for complex querying.',
+    'Detail experience with data cleaning and preparation techniques.',
+  ],
+  'Data Scientist': [
+    'Quantify model performance and the resulting business value.',
+    'Mention specific datasets you have worked with and their scale.',
+    'Include links to notebooks, repositories, or publications if possible.',
+    'Highlight any MLOps experience for deploying models to production.',
+  ],
+}


### PR DESCRIPTION
## 📝 Description

This PR introduces **career-track-specific resume tips** that complement the existing AI-generated skill suggestions, helping users tailor their resumes for different career paths.

### Changes
- Added a dedicated external data file containing curated resume tips for:
  - Frontend Developer
  - Backend Developer
  - Data Analyst
  - Data Scientist
- Created a reusable `CuratedTips` component to display track-specific best practices.
- Displayed curated tips alongside the existing AI-generated suggestions without changing the current workflow.
- Added a graceful fallback message for career tracks without curated tips.
- Added unit tests covering tip rendering, fallback behavior, and dynamic career track switching.

## 🔗 Related Issue

- Closes #310

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

The following validations were performed:

- Verified curated resume tips display correctly for supported career tracks.
- Verified the fallback message appears for unsupported career tracks.
- Verified tips update correctly when switching between career tracks.
- Confirmed existing AI-generated suggestions remain unchanged.
- Added and executed unit tests for the new component.

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`) *(Not applicable for this frontend-focused change)*
- [x] Manually tested in the browser

## 📸 Screenshots (if applicable)

Please attach screenshots or a short GIF demonstrating:
- Curated tips displayed alongside AI-generated suggestions.
- Switching between different career tracks.
- Fallback message for an unsupported career track.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)