### PR TITLE
feat: add standard security headers via Vercel and Django config (#319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,28 @@ When the limit is exceeded, the API returns:
 
 ---
 
+## Security Configuration & Headers
+
+Standard security headers are configured for both the frontend (client) and backend (server) environments to mitigate common vulnerabilities:
+
+### Configured Headers
+
+1. **Content-Security-Policy (CSP):** Limits the resources (scripts, styles, connections) the browser is allowed to load.
+   - *Client:* Allows `'self'` resources, inline scripts/styles for React/Bootstrap, and local/production backend API connections.
+   - *Server (API):* Uses a strict `default-src 'none';` for JSON API responses, and standard self-hosting for Django admin.
+2. **X-Frame-Options (`DENY`):** Prevents the app from being embedded in `<iframe>` tags, mitigating Clickjacking attacks.
+3. **X-Content-Type-Options (`nosniff`):** Disables MIME-type sniffing to prevent MIME-based attacks.
+4. **Referrer-Policy (`strict-origin-when-cross-origin`):** Protects privacy by stripping referrer paths when making cross-origin requests.
+
+### Local Development Parity
+
+To ensure parity between local development and production environments, the headers are applied in both locations:
+- **Production (Vercel):** Configured via [vercel.json](file:///e:/ECSOC-26/AI-Resume-Analyzer/frontend/vercel.json) files in the root and frontend directories.
+- **Local Development (Vite):** Preconfigured in [vite.config.ts](file:///e:/ECSOC-26/AI-Resume-Analyzer/frontend/vite.config.ts) to send headers when running the local dev server (`npm run dev`).
+- **Django Backend:** Applied dynamically in all environments via Django settings and a custom middleware in [middleware.py](file:///e:/ECSOC-26/AI-Resume-Analyzer/backend/resume_analyzer/middleware.py).
+
+---
+
 ## Roadmap
 
 - [ ] **DOCX Document Parsing** — Integrate `python-docx` to support Word resume parser pipelines.

--- a/backend/analyzer/tests.py
+++ b/backend/analyzer/tests.py
@@ -287,3 +287,48 @@ class UrlFetcherTests(TestCase):
             download_and_validate_url("ftp://example.com/file.pdf")
         self.assertIn("valid URL starting with http", str(ctx.exception))
 
+
+class SecurityHeadersTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_security_headers_are_present_on_api_responses(self):
+        # Trigger an API request
+        resp = self.client.get("/api/compare/")
+        
+        # Check that Content-Security-Policy is present and configured for APIs
+        self.assertIn("Content-Security-Policy", resp)
+        self.assertEqual(
+            resp["Content-Security-Policy"],
+            "default-src 'none'; frame-ancestors 'none';"
+        )
+        
+        # Check standard secure headers
+        self.assertIn("X-Frame-Options", resp)
+        self.assertEqual(resp["X-Frame-Options"], "DENY")
+        
+        self.assertIn("X-Content-Type-Options", resp)
+        self.assertEqual(resp["X-Content-Type-Options"], "nosniff")
+        
+        self.assertIn("Referrer-Policy", resp)
+        self.assertEqual(resp["Referrer-Policy"], "strict-origin-when-cross-origin")
+
+    def test_security_headers_are_present_on_html_responses(self):
+        # Trigger an HTML view request
+        resp = self.client.get("/admin/login/")
+        
+        # Check that Content-Security-Policy is configured for HTML/Admin
+        self.assertIn("Content-Security-Policy", resp)
+        self.assertIn("default-src 'self'", resp["Content-Security-Policy"])
+        
+        # Check standard secure headers
+        self.assertIn("X-Frame-Options", resp)
+        self.assertEqual(resp["X-Frame-Options"], "DENY")
+        
+        self.assertIn("X-Content-Type-Options", resp)
+        self.assertEqual(resp["X-Content-Type-Options"], "nosniff")
+        
+        self.assertIn("Referrer-Policy", resp)
+        self.assertEqual(resp["Referrer-Policy"], "strict-origin-when-cross-origin")
+
+

--- a/backend/resume_analyzer/middleware.py
+++ b/backend/resume_analyzer/middleware.py
@@ -1,0 +1,32 @@
+class ContentSecurityPolicyMiddleware:
+    """Middleware to add Content-Security-Policy (CSP) headers to all Django responses.
+
+    Differentiates between API responses (JSON) and HTML/Admin views to
+    maximize security.
+    """
+
+    def __init__(self, get_response):
+        """Initialize the middleware with get_response handler."""
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """Inject the Content-Security-Policy header based on response content type."""
+        response = self.get_response(request)
+        content_type = response.get("Content-Type", "")
+
+        if content_type and content_type.startswith("application/json"):
+            # API requests don't need to load scripts, styles, or frame other websites
+            response["Content-Security-Policy"] = (
+                "default-src 'none'; frame-ancestors 'none';"
+            )
+        else:
+            # HTML pages (like Django Admin) need standard resources from self
+            response["Content-Security-Policy"] = (
+                "default-src 'self'; "
+                "script-src 'self' 'unsafe-inline'; "
+                "style-src 'self' 'unsafe-inline'; "
+                "img-src 'self' data:; "
+                "frame-ancestors 'none';"
+            )
+
+        return response

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'resume_analyzer.middleware.ContentSecurityPolicyMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',   # ← Add this line
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -133,3 +134,10 @@ REST_FRAMEWORK = {
 
 # Rate limiting: resume upload endpoint
 RESUME_UPLOAD_RATE = os.environ.get('RESUME_UPLOAD_RATE', '10/hour')
+
+# Security Headers Configuration (Issue #319)
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_REFERRER_POLICY = 'strict-origin-when-cross-origin'
+X_FRAME_OPTIONS = 'DENY'
+

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,25 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' http://127.0.0.1:8000 http://localhost:8000 https://ai-resume-analyzer-nine-brown.vercel.app https://*.vercel.app; frame-ancestors 'none'; form-action 'self';"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,15 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    headers: {
+      'Content-Security-Policy':
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' http://127.0.0.1:8000 http://localhost:8000 https://ai-resume-analyzer-nine-brown.vercel.app https://*.vercel.app; frame-ancestors 'none'; form-action 'self';",
+      'X-Frame-Options': 'DENY',
+      'X-Content-Type-Options': 'nosniff',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
+    },
+  },
   // @ts-expect-error vitest options
   test: {
     globals: true,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,25 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' http://127.0.0.1:8000 http://localhost:8000 https://ai-resume-analyzer-nine-brown.vercel.app https://*.vercel.app; frame-ancestors 'none'; form-action 'self';"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description
Addresses #319 by configuring standard security headers (`Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`) for both the frontend client and backend server environments.

### Changes
- **Frontend Security (Vercel & Vite)**: 
  - Added `vercel.json` configuration files in the root and `frontend/` directory to serve the headers on the deployed app.
  - Updated `frontend/vite.config.ts` to add matching headers for local development parity.
- **Backend Security (Django)**:
  - Added a custom `ContentSecurityPolicyMiddleware` in `backend/resume_analyzer/middleware.py` which dynamically adjusts CSP rules (using strict `default-src 'none'` for JSON API endpoints, and standard rules for HTML pages like Django Admin).
  - Set standard Django secure header settings (`SECURE_BROWSER_XSS_FILTER`, `SECURE_CONTENT_TYPE_NOSNIFF`, `SECURE_REFERRER_POLICY`, and `X_FRAME_OPTIONS`) in `backend/resume_analyzer/settings.py`.
- **Tests & Docs**:
  - Added `SecurityHeadersTests` in `backend/analyzer/tests.py` to assert correct header injection.
  - Added details to the `README.md` file.
