### PR TITLE
feat: add "delete my account and data" feature with settings modal (#322)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/Muskankr/AI-Resume-Analyzer?style=for-the-badge&color=818cf8)](https://github.com/Muskankr/AI-Resume-Analyzer/graphs/contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge&color=38bdf8)](https://github.com/Muskankr/AI-Resume-Analyzer/pulls)
 [![ECSoC'26](https://img.shields.io/badge/Program-ECSoC'26-orange?style=for-the-badge)](https://github.com/Muskankr/AI-Resume-Analyzer)
+[![Uptime (Frontend)](https://img.shields.io/uptimerobot/status/m796245367-placeholder?style=for-the-badge&label=Frontend%20Uptime)](https://ai-resume-analyzer-nine-brown.vercel.app)
+[![Uptime (Backend)](https://img.shields.io/uptimerobot/status/m796245367-placeholder?style=for-the-badge&label=Backend%20Uptime)](https://ai-resume-analyzer-nine-brown.vercel.app)
+
 
 # AI Resume Analyzer
 
@@ -347,6 +350,28 @@ When the limit is exceeded, the API returns:
 
 ---
 
+## Uptime Monitoring
+
+Uptime monitoring is set up to continuously track the availability of the frontend application and backend API, alerting the maintainers if any downtime occurs.
+
+- **Frontend Monitor:** Tracks the main user interface.
+- **Backend Monitor:** Tracks the health and database connectivity via the dedicated health check endpoint: `/api/health/`.
+
+### Setting Up Free Uptime Monitoring (for Maintainers)
+
+To set up uptime monitoring for the deployed application (e.g. using UptimeRobot):
+
+1. **Sign Up:** Create a free account at [UptimeRobot](https://uptimerobot.com) or [Better Stack Uptime](https://betterstack.com/uptime).
+2. **Create Monitors:**
+   - **Frontend Monitor:** Add an HTTP(s) monitor pointing to your frontend URL (e.g. `https://ai-resume-analyzer-nine-brown.vercel.app`).
+   - **Backend Monitor:** Add an HTTP(s) monitor pointing to your backend health endpoint (e.g. `https://ai-resume-analyzer-backend.onrender.com/api/health/`).
+3. **Configure Alerting:**
+   - Enter your email address or configure a Discord/Slack webhook in the monitor's "Alert Contacts" to get instant notifications when the site goes down.
+4. **Status Badges:**
+   - In UptimeRobot, create a public status page or generate a badge.
+   - Replace the badge placeholders at the top of this `README.md` with your actual monitor ID to display live health status.
+
+---
 ## Roadmap
 
 - [ ] **DOCX Document Parsing** — Integrate `python-docx` to support Word resume parser pipelines.

--- a/backend/analyzer/tests.py
+++ b/backend/analyzer/tests.py
@@ -287,3 +287,24 @@ class UrlFetcherTests(TestCase):
             download_and_validate_url("ftp://example.com/file.pdf")
         self.assertIn("valid URL starting with http", str(ctx.exception))
 
+
+class HealthCheckTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_health_check_healthy(self):
+        resp = self.client.get("/api/health/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["status"], "healthy")
+        self.assertEqual(resp.data["services"]["api"], "up")
+        self.assertEqual(resp.data["services"]["database"], "up")
+
+    @patch("django.db.connection.cursor")
+    def test_health_check_unhealthy(self, mock_cursor):
+        # Mock database connection cursor to throw an exception
+        mock_cursor.side_effect = Exception("Database is down")
+        resp = self.client.get("/api/health/")
+        self.assertEqual(resp.status_code, 503)
+        self.assertEqual(resp.data["status"], "unhealthy")
+        self.assertEqual(resp.data["services"]["database"], "down")
+        self.assertIn("Database is down", resp.data["error"])

--- a/backend/analyzer/tests.py
+++ b/backend/analyzer/tests.py
@@ -286,6 +286,36 @@ class UrlFetcherTests(TestCase):
         with self.assertRaises(ValueError) as ctx:
             download_and_validate_url("ftp://example.com/file.pdf")
         self.assertIn("valid URL starting with http", str(ctx.exception))
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework.test import APIClient
+from unittest.mock import patch
+from types import SimpleNamespace
+from django.test import TestCase
+
+from analyzer.comparison import compare_versions
+from analyzer.models import ResumeAnalysis
+from analyzer.services import analyze_resume
+from analyzer.url_fetcher import convert_to_direct_download_url, download_and_validate_url
+
+
+def _fake_pdf(text):
+    return SimpleNamespace(pages=[SimpleNamespace(extract_text=lambda: text)])
+
+
+def _make_analysis(user, **overrides):
+    defaults = dict(
+        file_name="resume.pdf",
+        score=50,
+        skills_found=["python", "sql"],
+        suggestions=[],
+        matched_skills=["python"],
+        missing_skills=["react"],
+        target_role="Backend Developer",
+        resume_text="Python developer\nWorked with SQL",
+    )
+    defaults.update(overrides)
+    return ResumeAnalysis.objects.create(user=user, **defaults)
 
 
 class HealthCheckTests(TestCase):
@@ -308,3 +338,50 @@ class HealthCheckTests(TestCase):
         self.assertEqual(resp.data["status"], "unhealthy")
         self.assertEqual(resp.data["services"]["database"], "down")
         self.assertIn("Database is down", resp.data["error"])
+
+
+class DeleteAccountTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.username = "testuser"
+        self.password = "validpassword123"
+        self.user = User.objects.create_user(username=self.username, password=self.password)
+        
+        # Create some resume analyses to verify cascade deletion
+        _make_analysis(self.user, score=60, file_name="resume1.pdf")
+        _make_analysis(self.user, score=80, file_name="resume2.pdf")
+
+    def test_delete_account_requires_authentication(self):
+        resp = self.client.delete("/api/auth/delete-account/", {"password": self.password, "confirm_text": "DELETE"}, format="json")
+        self.assertEqual(resp.status_code, 401)
+        self.assertTrue(User.objects.filter(username=self.username).exists())
+
+    def test_delete_account_incorrect_password(self):
+        self.client.force_authenticate(user=self.user)
+        resp = self.client.delete("/api/auth/delete-account/", {"password": "wrongpassword", "confirm_text": "DELETE"}, format="json")
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Incorrect password", resp.data["error"])
+        self.assertTrue(User.objects.filter(username=self.username).exists())
+
+    def test_delete_account_incorrect_confirm_text(self):
+        self.client.force_authenticate(user=self.user)
+        resp = self.client.delete("/api/auth/delete-account/", {"password": self.password, "confirm_text": "DELET"}, format="json")
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("type 'DELETE' exactly", resp.data["error"])
+        self.assertTrue(User.objects.filter(username=self.username).exists())
+
+    def test_delete_account_success(self):
+        self.client.force_authenticate(user=self.user)
+        
+        # Check that the analyses exist beforehand
+        self.assertEqual(ResumeAnalysis.objects.filter(user=self.user).count(), 2)
+        
+        resp = self.client.delete("/api/auth/delete-account/", {"password": self.password, "confirm_text": "DELETE"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("permanently deleted", resp.data["detail"])
+        
+        # Check that user is deleted from the database
+        self.assertFalse(User.objects.filter(username=self.username).exists())
+        
+        # Check cascade deletion: related analyses must be deleted too
+        self.assertEqual(ResumeAnalysis.objects.filter(user_id=self.user.id).count(), 0)

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -12,9 +12,11 @@ from .views import (
     clear_user_history,
     compare_versions_view,
     suggestion_feedback,
+    health_check,
 )
 
 urlpatterns = [
+    path("health/", health_check),
     path("upload/", upload_resume),
 
     path("auth/signup/", signup),

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -13,6 +13,7 @@ from .views import (
     compare_versions_view,
     suggestion_feedback,
     health_check,
+    delete_account,
 )
 
 urlpatterns = [
@@ -22,6 +23,7 @@ urlpatterns = [
     path("auth/signup/", signup),
     path("auth/login/", TokenObtainPairView.as_view()),
     path("auth/refresh/", TokenRefreshView.as_view()),
+    path("auth/delete-account/", delete_account),
 
     path("history/", analysis_history),
     path("history/clear/", clear_user_history),

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -209,3 +209,34 @@ def suggestion_feedback(request):
         "vote": vote,
         "index": index,
     }, status=status.HTTP_200_OK)
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def health_check(request):
+    """Health check endpoint for uptime monitoring.
+
+    Verifies that the server is active and the database is accessible.
+    """
+    from django.db import connection
+
+    health_status = {
+        "status": "healthy",
+        "services": {
+            "api": "up",
+            "database": "down",
+        },
+    }
+
+    try:
+        # Validate database connectivity by executing a raw query
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+        health_status["services"]["database"] = "up"
+        return Response(health_status, status=status.HTTP_200_OK)
+    except Exception as e:
+        health_status["status"] = "unhealthy"
+        health_status["error"] = str(e)
+        return Response(
+            health_status, status=status.HTTP_503_SERVICE_UNAVAILABLE
+        )

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -239,4 +239,43 @@ def health_check(request):
         health_status["error"] = str(e)
         return Response(
             health_status, status=status.HTTP_503_SERVICE_UNAVAILABLE
-        )
+        )
+
+
+@api_view(["DELETE"])
+@permission_classes([IsAuthenticated])
+def delete_account(request):
+    """Permanently delete the authenticated user's account and all associated data.
+
+    Requires password verification and confirmation text.
+    """
+    password = request.data.get("password")
+    confirm_text = request.data.get("confirm_text")
+
+    if not password:
+        return Response(
+            {"error": "Password is required to confirm account deletion."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if confirm_text != "DELETE":
+        return Response(
+            {"error": "Please type 'DELETE' exactly to confirm your intent."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    user = request.user
+    if not user.check_password(password):
+        return Response(
+            {"error": "Incorrect password. Account deletion aborted."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # Permanently delete the user (triggers CASCADE on ResumeAnalysis)
+    user.delete()
+
+    return Response(
+        {"detail": "Your account and all associated data have been permanently deleted."},
+        status=status.HTTP_200_OK,
+    )
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { useAnalysisHistory, type AnalysisEntry } from "./hooks/useAnalysisHisto
 import { HistorySidebar } from "./HistorySidebar";
 import { useAuth } from "./hooks/useAuth";
 import { AuthModal } from "./AuthModal";
+import { AccountSettingsModal } from "./components/AccountSettingsModal";
 import { Footer } from "./Footer";
 import AnalysisSkeleton from "./components/AnalysisSkeleton/AnalysisSkeleton";
 import { InfoTooltip } from "./components/InfoTooltip";
@@ -276,6 +277,7 @@ function App() {
 
   const { user, signup, login, logout } = useAuth();
   const [showAuthModal, setShowAuthModal] = useState(false);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
 
   const { entries, unreadCount, lastViewedTimestamp, markAllAsViewed, addEntry, deleteEntry, clearHistory, setEntries } = useAnalysisHistory();
 
@@ -751,6 +753,7 @@ function App() {
         onLogin={() => setShowAuthModal(true)}
         onLogout={handleLogout}
         onHistoryClick={() => setHistoryOpen(true)}
+        onSettingsClick={() => setShowSettingsModal(true)}
       />
       <Routes>
         <Route path="/" element={
@@ -760,6 +763,14 @@ function App() {
                 onSignup={signup}
                 onLogin={login}
                 onClose={() => setShowAuthModal(false)}
+              />
+            )}
+
+            {showSettingsModal && (
+              <AccountSettingsModal
+                user={user}
+                onClose={() => setShowSettingsModal(false)}
+                onDeleteSuccess={handleLogout}
               />
             )}
 

--- a/frontend/src/components/AccountSettingsModal.tsx
+++ b/frontend/src/components/AccountSettingsModal.tsx
@@ -1,0 +1,266 @@
+import React, { useState } from "react";
+import { X, Trash2, Loader2, ShieldAlert } from "lucide-react";
+import type { AuthUser } from "../hooks/useAuth";
+import axios from "axios";
+
+interface AccountSettingsModalProps {
+  user: AuthUser | null;
+  onClose: () => void;
+  onDeleteSuccess: () => void;
+}
+
+export const AccountSettingsModal: React.FC<AccountSettingsModalProps> = ({
+  user,
+  onClose,
+  onDeleteSuccess,
+}) => {
+  const [password, setPassword] = useState("");
+  const [confirmText, setConfirmText] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [showDeleteZone, setShowDeleteZone] = useState(false);
+
+  const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://127.0.0.1:8000";
+
+  const handleDelete = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+
+    if (confirmText !== "DELETE") {
+      setError("Please type DELETE exactly to confirm.");
+      return;
+    }
+
+    setError("");
+    setLoading(true);
+
+    try {
+      await axios.delete(`${backendUrl}/api/auth/delete-account/`, {
+        headers: { Authorization: `Bearer ${user.token}` },
+        data: { password, confirm_text: confirmText },
+      });
+      onDeleteSuccess();
+      onClose();
+    } catch (err: any) {
+      const msg =
+        err.response?.data?.error ||
+        err.response?.data?.detail ||
+        "Failed to delete account";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-overlay" onClick={onClose}>
+      <div
+        className="auth-modal"
+        style={{ maxWidth: "420px", width: "100%" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: "20px",
+          }}
+        >
+          <h3 style={{ margin: 0, display: "flex", alignItems: "center", gap: "8px" }}>
+            ⚙️ Account Settings
+          </h3>
+          <button
+            onClick={onClose}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              color: "inherit",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div style={{ marginBottom: "24px" }}>
+          <p style={{ margin: "0 0 8px", fontSize: "0.95rem" }}>
+            Logged in as: <strong>{user?.username}</strong>
+          </p>
+          <p style={{ margin: 0, fontSize: "0.85rem", opacity: 0.7 }}>
+            Manage your account preferences and data deletion below.
+          </p>
+        </div>
+
+        <hr
+          style={{
+            border: "0",
+            borderTop: "1px solid rgba(255,255,255,0.1)",
+            marginBottom: "20px",
+          }}
+        />
+
+        {!showDeleteZone ? (
+          <div>
+            <h4
+              style={{
+                color: "var(--color-danger)",
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                fontSize: "1rem",
+                margin: "0 0 12px",
+              }}
+            >
+              <Trash2 size={16} /> Danger Zone
+            </h4>
+            <p style={{ fontSize: "0.85rem", margin: "0 0 16px", opacity: 0.8 }}>
+              Permanently delete your account and all associated data, including your
+              resume upload history and ATS scores. This action is irreversible.
+            </p>
+            <button
+              onClick={() => setShowDeleteZone(true)}
+              className="app-btn"
+              style={{
+                width: "100%",
+                backgroundColor: "rgba(239, 68, 68, 0.1)",
+                border: "1px solid var(--color-danger)",
+                color: "var(--color-danger)",
+                padding: "10px 14px",
+                borderRadius: "8px",
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              Delete Account & Data
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleDelete}>
+            <div
+              style={{
+                backgroundColor: "rgba(239, 68, 68, 0.08)",
+                border: "1px solid rgba(239, 68, 68, 0.2)",
+                borderRadius: "8px",
+                padding: "12px 14px",
+                marginBottom: "18px",
+                display: "flex",
+                gap: "10px",
+              }}
+            >
+              <ShieldAlert
+                size={20}
+                style={{ color: "var(--color-danger)", flexShrink: 0, marginTop: "2px" }}
+              />
+              <div>
+                <strong style={{ color: "var(--color-danger)", fontSize: "0.9rem" }}>
+                  Confirm Irreversible Deletion
+                </strong>
+                <p style={{ margin: "4px 0 0", fontSize: "0.8rem", opacity: 0.9 }}>
+                  All stored resume analyses and scores will be permanently deleted from the
+                  database.
+                </p>
+              </div>
+            </div>
+
+            <div style={{ marginBottom: "14px" }}>
+              <label
+                style={{
+                  display: "block",
+                  fontSize: "0.85rem",
+                  fontWeight: 500,
+                  marginBottom: "6px",
+                }}
+              >
+                Type{" "}
+                <code
+                  style={{
+                    color: "var(--color-danger)",
+                    background: "rgba(0,0,0,0.1)",
+                    padding: "2px 4px",
+                    borderRadius: "4px",
+                  }}
+                >
+                  DELETE
+                </code>{" "}
+                to confirm:
+              </label>
+              <input
+                className="auth-input"
+                type="text"
+                placeholder="DELETE"
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+
+            <div style={{ marginBottom: "16px" }}>
+              <label
+                style={{
+                  display: "block",
+                  fontSize: "0.85rem",
+                  fontWeight: 500,
+                  marginBottom: "6px",
+                }}
+              >
+                Confirm with your password:
+              </label>
+              <input
+                className="auth-input"
+                type="password"
+                placeholder="Enter password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+
+            {error && (
+              <p className="auth-error" style={{ marginBottom: "14px" }}>
+                {error}
+              </p>
+            )}
+
+            <div style={{ display: "flex", gap: "10px" }}>
+              <button
+                type="button"
+                className="app-btn app-btn--secondary"
+                style={{ flex: 1, padding: "10px 14px", borderRadius: "8px" }}
+                onClick={() => {
+                  setShowDeleteZone(false);
+                  setError("");
+                  setPassword("");
+                  setConfirmText("");
+                }}
+                disabled={loading}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="app-btn"
+                style={{
+                  flex: 1,
+                  backgroundColor: "var(--color-danger)",
+                  color: "#fff",
+                  border: "none",
+                  padding: "10px 14px",
+                  borderRadius: "8px",
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+                disabled={loading}
+              >
+                {loading ? <Loader2 size={16} className="spin" /> : "Confirm Delete"}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ interface NavbarProps {
   onLogin: () => void
   onLogout: () => void
   onHistoryClick: () => void
+  onSettingsClick: () => void
 }
 
 export const Navbar: React.FC<NavbarProps> = ({
@@ -17,6 +18,7 @@ export const Navbar: React.FC<NavbarProps> = ({
   onLogin,
   onLogout,
   onHistoryClick,
+  onSettingsClick,
 }) => {
   const [mobileOpen, setMobileOpen] = useState(false)
 
@@ -92,6 +94,16 @@ export const Navbar: React.FC<NavbarProps> = ({
           {user ? (
             <div className="navbar-user">
               <span className="auth-username">👤 {user.username}</span>
+              <button
+                className="auth-bar-btn"
+                onClick={() => {
+                  onSettingsClick()
+                  setMobileOpen(false)
+                }}
+                title="Account Settings"
+              >
+                ⚙️ Settings
+              </button>
               <button
                 className="auth-bar-btn"
                 onClick={() => {


### PR DESCRIPTION
### Description
Addresses #322 by enabling users to permanently delete their accounts and all associated data (resume upload history, scores) from the database via an interactive "Account Settings" modal.

### Changes
- **Backend (Django)**:
  - Created a protected DELETE endpoint at `/api/auth/delete-account/` verifying the user's password and confirmation input (`DELETE`).
  - Calls `user.delete()` which triggers a database cascade deletion of all user's `ResumeAnalysis` entries.
  - Added unit tests in `backend/analyzer/tests.py` verifying deletion success, cascade constraints, and unauthorized blocks.
- **Frontend (React)**:
  - Implemented the `AccountSettingsModal` settings panel with a dedicated Danger Zone and password/DELETE confirmation fields.
  - Added a "⚙️ Settings" button to the Navbar for authenticated users.
