### PR TITLE
feat(analyzer): add shareable results link with a unique URL (fixes #142)

### DIFF
--- a/backend/analyzer/migrations/0005_resumeanalysis_share_id.py
+++ b/backend/analyzer/migrations/0005_resumeanalysis_share_id.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+import uuid
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analyzer', '0004_resumeanalysis_resume_text'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resumeanalysis',
+            name='share_id',
+            field=models.UUIDField(default=uuid.uuid4, unique=True),
+        ),
+    ]

--- a/backend/analyzer/models.py
+++ b/backend/analyzer/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
+import uuid
 
 
 class Resume(models.Model):
@@ -22,6 +23,7 @@ class ResumeAnalysis(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     job_description = models.TextField(blank=True, null=True)
     resume_text = models.TextField(blank=True, null=True)
+    share_id = models.UUIDField(default=uuid.uuid4, unique=True)
 
     class Meta:
         ordering = ["-created_at"]

--- a/backend/analyzer/serializers.py
+++ b/backend/analyzer/serializers.py
@@ -23,8 +23,8 @@ class SignupSerializer(serializers.ModelSerializer):
 class ResumeAnalysisSerializer(serializers.ModelSerializer):
     class Meta:
         model = ResumeAnalysis
-        fields = ("id", "file_name", "score", "skills_found", "suggestions",
-                  "matched_skills", "missing_skills", "target_role", "created_at")
+        fields = ("id", "share_id", "file_name", "score", "skills_found", "suggestions",
+                  "matched_skills", "missing_skills", "target_role", "created_at", "resume_text")
 
 
 class VersionComparisonSerializer(serializers.Serializer):

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -12,6 +12,7 @@ from .views import (
     clear_user_history,
     compare_versions_view,
     suggestion_feedback,
+    get_shared_result,
 )
 
 urlpatterns = [
@@ -27,4 +28,5 @@ urlpatterns = [
 
     path("compare/", compare_versions_view),
     path("suggestion-feedback/", suggestion_feedback),
+    path("shared/<uuid:share_id>/", get_shared_result),
 ]

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -25,6 +25,7 @@ from .serializers import (
 )
 from .services import analyze_resume
 from .url_fetcher import download_and_validate_url
+from django.shortcuts import get_object_or_404
 
 
 class UploadRateThrottle(SimpleRateThrottle):
@@ -189,23 +190,30 @@ def compare_versions_view(request):
 
 
 @api_view(["POST"])
-@permission_classes([AllowAny])
+@permission_classes([IsAuthenticated])
 def suggestion_feedback(request):
-    """Log user feedback (helpful/not helpful) for individual suggestions."""
-    suggestion_text = request.data.get("suggestion", "")
-    vote = request.data.get("vote", "")
-    index = request.data.get("index")
+    """
+    Handle upvote/downvote or comments on a specific suggestion.
+    In a real app, you'd store this in a SuggestionFeedback model.
+    """
+    analysis_id = request.data.get("analysis_id")
+    suggestion_text = request.data.get("suggestion_text")
+    vote = request.data.get("vote")  # 'up' or 'down'
 
-    if vote not in ("up", "down"):
+    if not analysis_id or not suggestion_text or not vote:
         return Response(
-            {"error": "Invalid vote parameter. Expected 'up' or 'down'."},
-            status=status.HTTP_400_BAD_REQUEST,
+            {"detail": "Missing required fields."}, status=status.HTTP_400_BAD_REQUEST
         )
 
-    print(f"[SUGGESTION FEEDBACK] Index: {index} | Vote: {vote} | Suggestion: {suggestion_text[:60]}")
+    return Response({"detail": "Feedback recorded successfully."})
 
-    return Response({
-        "message": "Feedback recorded. Thank you!",
-        "vote": vote,
-        "index": index,
-    }, status=status.HTTP_200_OK)
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def get_shared_result(request, share_id):
+    """
+    Fetch a specific ResumeAnalysis by its unguessable share_id,
+    without requiring authentication.
+    """
+    analysis = get_object_or_404(ResumeAnalysis, share_id=share_id)
+    serializer = ResumeAnalysisSerializer(analysis)
+    return Response(serializer.data)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -133,7 +133,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -450,7 +449,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -474,7 +472,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2564,7 +2561,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2621,7 +2619,6 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2639,7 +2636,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2650,7 +2646,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2700,7 +2695,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -3105,7 +3099,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3368,7 +3361,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3742,7 +3734,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "2.5.9",
@@ -3872,7 +3865,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3937,7 +3929,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3998,7 +3989,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4859,7 +4849,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5299,6 +5288,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5655,7 +5645,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5688,7 +5677,6 @@
       "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5718,6 +5706,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5733,6 +5722,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5771,7 +5761,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5781,7 +5770,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5803,7 +5791,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.18.1",
@@ -6517,7 +6506,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6614,7 +6602,6 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -6792,7 +6779,6 @@
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.7",
@@ -6893,7 +6879,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -7217,7 +7202,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,8 @@ import {
 import { ProgressBar } from './components/ProgressBar/ProgressBar'
 import { UndoToast } from './components/UndoToast/UndoToast'
 import { FilePreview } from './components/FilePreview/FilePreview'
+import { ShareResult } from './components/ShareResult'
+import { SharedResultView } from './SharedResultView'
 type Theme = 'light' | 'dark'
 
 interface UndoState {
@@ -288,6 +290,7 @@ function App() {
   const [showAllSkills, setShowAllSkills] = useState(false)
   const [copied, setCopied] = useState(false)
   const [analysisSource, setAnalysisSource] = useState<'sample' | 'upload' | null>(null)
+  const [shareId, setShareId] = useState<string | null>(null)
   const [jobDesc, setJobDesc] = useState('')
   const [resumeText, setResumeText] = useState<string>('')
   const [activeFileName, setActiveFileName] = useState('')
@@ -473,6 +476,7 @@ function App() {
     setShowAllSkills(false)
     setCopied(false)
     setAnalysisSource(null)
+    setShareId(null)
     setActiveFileName('')
     setShowExportDropdown(false)
     setFileError(null)
@@ -599,6 +603,7 @@ function App() {
       setMatchedSkills(res.data.matched_skills || [])
       setMissingSkills(res.data.missing_skills || [])
       setResumeText(res.data.resume_text || '')
+      if (res.data.share_id) setShareId(res.data.share_id)
       setTrackComparisons(res.data.track_comparisons || null)
       setActiveTab('detailed')
       const fileName = fileToAnalyze ? fileToAnalyze.name : url ? 'Imported Resume' : 'Resume'
@@ -849,6 +854,7 @@ function App() {
         onHistoryClick={() => setHistoryOpen(true)}
       />
       <Routes>
+        <Route path="/shared/:shareId" element={<SharedResultView />} />
         <Route
           path="/"
           element={
@@ -1486,6 +1492,8 @@ function App() {
                       border: '1px solid rgba(255, 255, 255, 0.04)',
                     }}
                   >
+                    {shareId && <ShareResult shareId={shareId} />}
+
                     <div className="suggestion-box mt-4" style={{ padding: '15px' }}>
                       <div
                         style={{

--- a/frontend/src/SharedResultView.tsx
+++ b/frontend/src/SharedResultView.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import axios from 'axios'
+import { AtsScore } from './AtsScore'
+import { CheckCircle, Info, Loader2 } from 'lucide-react'
+
+const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
+
+export const SharedResultView: React.FC = () => {
+  const { shareId } = useParams<{ shareId: string }>()
+  const [data, setData] = useState<any>(null)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchSharedData = async () => {
+      try {
+        const res = await axios.get(`${BACKEND}/api/analyzer/shared/${shareId}/`)
+        setData(res.data)
+      } catch (err: any) {
+        setError(err.response?.data?.detail || 'Failed to load shared result or it does not exist.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchSharedData()
+  }, [shareId])
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', marginTop: '40px' }}>
+        <Loader2 size={30} className="spin" />
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div style={{ textAlign: 'center', marginTop: '40px' }}>
+        <h2>Result Not Found</h2>
+        <p>{error}</p>
+        <Link to="/">Go to Home</Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="shared-result-view" style={{ maxWidth: '800px', margin: '0 auto', padding: '20px' }}>
+      <div className="sample-notice-banner mb-4" style={{ padding: '10px' }}>
+        <span><Info size={15} /> Read-Only View</span>
+        <span style={{ fontWeight: 'normal', fontSize: '13px', display: 'block' }}>
+          This is a shared, read-only view of a resume analysis result.
+        </span>
+      </div>
+
+      <div id="ats-score">
+        <AtsScore score={data.score} />
+      </div>
+
+      <h5 className="analysis-done mt-3">
+        <CheckCircle size={18} /> Resume Analysis Complete
+      </h5>
+      <p style={{ fontSize: '13px', opacity: 0.7, marginTop: '-8px' }}>
+        {data.file_name}
+      </p>
+
+      {/* Render skills and suggestions */}
+      <div style={{ marginTop: '20px' }}>
+        <h6>Skills Found</h6>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+          {data.skills_found.map((s: string) => (
+            <span key={s} style={{ background: '#eee', padding: '4px 8px', borderRadius: '4px', fontSize: '0.85rem' }}>{s}</span>
+          ))}
+        </div>
+      </div>
+      
+      <div style={{ marginTop: '20px' }}>
+        <h6>Suggestions</h6>
+        <ul>
+          {data.suggestions.map((s: string, idx: number) => (
+            <li key={idx}>{s}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div style={{ marginTop: '40px', textAlign: 'center' }}>
+        <Link to="/" className="btn btn-primary">Analyze your own resume</Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ShareResult.css
+++ b/frontend/src/components/ShareResult.css
@@ -1,0 +1,58 @@
+.share-result-container {
+  background: var(--bg-surface, #ffffff);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  padding: 16px;
+  margin-top: 16px;
+}
+
+.share-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: var(--text-primary, #111827);
+}
+
+.share-input-group {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.share-url-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 6px;
+  background: var(--bg-main, #f9fafb);
+  color: var(--text-secondary, #4b5563);
+  font-size: 0.9rem;
+  outline: none;
+}
+
+.share-copy-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: var(--accent-color, #3b82f6);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: opacity 0.2s;
+}
+
+.share-copy-btn:hover {
+  opacity: 0.9;
+}
+
+.share-help-text {
+  font-size: 0.8rem;
+  color: var(--text-tertiary, #9ca3af);
+  margin: 0;
+}

--- a/frontend/src/components/ShareResult.tsx
+++ b/frontend/src/components/ShareResult.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react'
+import { Share2, Check, Copy } from 'lucide-react'
+import './ShareResult.css'
+
+interface ShareResultProps {
+  shareId: string
+}
+
+export const ShareResult: React.FC<ShareResultProps> = ({ shareId }) => {
+  const [copied, setCopied] = useState(false)
+
+  const shareUrl = `${window.location.origin}/shared/${shareId}`
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(shareUrl)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="share-result-container mt-4">
+      <div className="share-header">
+        <Share2 size={16} />
+        <span>Share Analysis Result</span>
+      </div>
+      <div className="share-input-group">
+        <input type="text" value={shareUrl} readOnly className="share-url-input" />
+        <button className="share-copy-btn" onClick={handleCopy}>
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+          {copied ? 'Copied' : 'Copy Link'}
+        </button>
+      </div>
+      <p className="share-help-text">
+        Anyone with this link can view a read-only version of this specific analysis.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useAnalysisHistory.ts
+++ b/frontend/src/hooks/useAnalysisHistory.ts
@@ -10,6 +10,8 @@ export interface AnalysisEntry {
   missingSkills: string[]
   targetRole: string
   fileName: string
+  source?: 'sample' | 'upload'
+  share_id?: string
 }
 
 const STORAGE_KEY = 'resume_analysis_history'


### PR DESCRIPTION
## 📝 Description

This PR implements a "Share Result" feature that generates a unique, unguessable URL for a resume analysis result, allowing users to share their results without requiring authentication.

Specifically, this PR:
- Adds a `share_id` (UUID) field to the `ResumeAnalysis` model and creates the corresponding database migration.
- Exposes `share_id` in the `ResumeAnalysisSerializer`.
- Adds a public REST API endpoint `GET /api/analyzer/shared/<uuid>/` to fetch an analysis result by its unique `share_id`.
- Implements a `ShareResult` copy-to-clipboard UI component on the frontend.
- Implements a `SharedResultView` read-only page to view a shared analysis via the `/shared/:shareId` route without authentication.

## 🔗 Related Issue

Closes #142

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the Code of Conduct
