### PR TITLE
feat: add password reset flow for usernames with console link generation

### DIFF
--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from .views import PasswordResetRequestView, PasswordResetConfirmView
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
@@ -29,4 +30,6 @@ urlpatterns = [
     path("compare/", compare_versions_view),
     path("suggestion-feedback/", suggestion_feedback),
     path("shared/<uuid:share_id>/", get_shared_result),
+    path('password-reset/', PasswordResetRequestView.as_view(), name='password_reset_request'),
+    path('password-reset-confirm/', PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
 ]

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -14,6 +14,12 @@ from rest_framework.decorators import (
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.encoding import force_bytes, force_str
+from django.core.mail import send_mail
 from rest_framework.throttling import SimpleRateThrottle
 
 from .comparison import compare_versions
@@ -217,3 +223,56 @@ def get_shared_result(request, share_id):
     analysis = get_object_or_404(ResumeAnalysis, share_id=share_id)
     serializer = ResumeAnalysisSerializer(analysis)
     return Response(serializer.data)
+
+User = get_user_model()
+
+class PasswordResetRequestView(APIView):
+    permission_classes = [AllowAny]
+    
+    def post(self, request):
+        username = request.data.get('username')
+        
+        user = User.objects.filter(username=username).first()
+        if user:
+            uid = urlsafe_base64_encode(force_bytes(user.pk))
+            token = default_token_generator.make_token(user)
+            
+            frontend_url = "http://localhost:5173" 
+            reset_link = f"{frontend_url}/reset-password/{uid}/{token}/"
+            
+            print("\n" + "="*50)
+            print(f"PASSWORD RESET LINK FOR USERNAME: {user.username}")
+            print(reset_link)
+            print("="*50 + "\n")
+            
+        return Response(
+            {"message": "If an account exists, a reset link has been generated in the console."}, 
+            status=status.HTTP_200_OK
+        )
+
+class PasswordResetConfirmView(APIView):
+    permission_classes = [AllowAny]
+    
+    def post(self, request):
+        uidb64 = request.data.get('uid')
+        token = request.data.get('token')
+        new_password = request.data.get('new_password')
+
+        try:
+            uid = force_str(urlsafe_base64_decode(uidb64))
+            user = User.objects.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            user = None
+
+        if user is not None and default_token_generator.check_token(user, token):
+            user.set_password(new_password)
+            user.save()
+            return Response(
+                {"message": "Password has been reset successfully."}, 
+                status=status.HTTP_200_OK
+            )
+        else:
+            return Response(
+                {"error": "Invalid or expired token."}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -98,7 +98,8 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+PASSWORD_RESET_TIMEOUT = 3600
 LANGUAGE_CODE = 'en-us'
 
 TIME_ZONE = 'UTC'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import AnalysisSkeleton from './components/AnalysisSkeleton/AnalysisSkeleton'
 import { InfoTooltip } from './components/InfoTooltip'
 import { SkillWordCloud } from './components/SkillWordCloud'
 import { TrackMatrix } from './components/TrackMatrix'
+import { ResetPasswordConfirmPage } from './components/ResetPasswordConfirmPage'
 import type { TrackComparisons } from './components/TrackMatrix'
 import {
   FileText,
@@ -855,6 +856,7 @@ function App() {
       />
       <Routes>
         <Route path="/shared/:shareId" element={<SharedResultView />} />
+        <Route path="/reset-password/:uid/:token" element={<ResetPasswordConfirmPage />} />
         <Route
           path="/"
           element={

--- a/frontend/src/AuthModal.tsx
+++ b/frontend/src/AuthModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Lock, FileSignature, Loader2 } from 'lucide-react'
+import axios from 'axios'
 
 interface AuthModalProps {
   onSignup: (username: string, password: string) => Promise<void>
@@ -8,7 +9,7 @@ interface AuthModalProps {
 }
 
 export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose }) => {
-  const [mode, setMode] = useState<'login' | 'signup'>('login')
+  const [mode, setMode] = useState<'login' | 'signup' | 'forgot_password'>('login');
   const [rememberMe, setRememberMe] = useState(true)
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -20,9 +21,16 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
     setError('')
     setLoading(true)
     try {
-      if (mode === 'signup') await onSignup(username, password)
-      else await onLogin(username, password, rememberMe)
-      onClose()
+      if (mode === 'signup') {
+        await onSignup(username, password)
+        onClose()
+      } else if (mode === 'login') {
+        await onLogin(username, password, rememberMe)
+        onClose()
+      } else if (mode === 'forgot_password') {
+        await axios.post('http://localhost:8000/api/password-reset/', { username: username })
+        onClose()
+      }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Authentication failed'
       setError(msg)
@@ -46,22 +54,37 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
           )}
         </h3>
         <form onSubmit={submit}>
-          <input
-            className="auth-input"
-            placeholder="Username"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            required
-            autoFocus
-          />
-          <input
-            className="auth-input"
-            type="password"
-            placeholder="Password (min 6 chars)"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
+          {mode === 'forgot_password' && (
+            <input
+              className="auth-input"
+              type="text"
+              placeholder="Enter your username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              autoFocus
+            />
+          )}
+          {mode !== 'forgot_password' && (
+            <>
+              <input
+                className="auth-input"
+                placeholder="Username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+                autoFocus
+              />
+              <input
+                className="auth-input"
+                type="password"
+                placeholder="Password (min 6 chars)"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </>
+          )}
           {mode === 'signup' &&
             password &&
             (() => {
@@ -126,13 +149,20 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
               />
               <label htmlFor="rememberMe" style={{ fontSize: '0.9rem', color: '#666' }}>Remember me</label>
             </div>
-          )}
+            )}
+            <div style={{ textAlign: 'right', marginBottom: '16px' }}>
+              <button type="button" onClick={() => { setMode('forgot_password'); setError(''); }} style={{ fontSize: '0.9rem', color: '#3b82f6', background: 'none', border: 'none', cursor: 'pointer' }}>
+                Forgot password?
+              </button>
+            </div>
           {error && <p className="auth-error">{error}</p>}
           <button className="auth-submit-btn" type="submit" disabled={loading}>
             {loading ? (
               <>
                 <Loader2 size={15} className="spin" /> Please wait...
               </>
+            ) : mode === 'forgot_password' ? (
+              'Send Reset Link'
             ) : mode === 'login' ? (
               'Login'
             ) : (

--- a/frontend/src/components/ResetPasswordConfirmPage.tsx
+++ b/frontend/src/components/ResetPasswordConfirmPage.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import { Lock, Loader2, CheckCircle } from 'lucide-react'
+
+export const ResetPasswordConfirmPage: React.FC = () => {
+ 
+  const { uid, token } = useParams<{ uid: string; token: string }>()
+  const navigate = useNavigate()
+
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  
+  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setSuccess('')
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match')
+      return
+    }
+
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters long')
+      return
+    }
+
+    setLoading(true)
+    try {
+      await axios.post(`${backendUrl}/api/password-reset-confirm/`, {
+        uid,
+        token,
+        new_password: password,
+      })
+      
+      setSuccess('Password reset successful! Redirecting...')
+      
+      setTimeout(() => {
+        navigate('/')
+      }, 3000)
+      
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        setError(err.response?.data?.error || 'Invalid or expired reset token.')
+      } else {
+        setError('An unexpected error occurred. Please try again.')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="auth-overlay" style={{ position: 'fixed', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div className="auth-modal" style={{ cursor: 'default' }}>
+        <h3>
+          <Lock size={16} /> Set New Password
+        </h3>
+        
+        {success ? (
+          <div style={{ textAlign: 'center', padding: '20px 0' }}>
+            <CheckCircle color="#4ade80" size={48} style={{ margin: '0 auto 16px' }} />
+            <p style={{ color: '#4ade80', fontSize: '1.1rem', fontWeight: 500 }}>{success}</p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <input
+              className="auth-input"
+              type="password"
+              placeholder="New Password (min 6 chars)"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoFocus
+            />
+            
+            <input
+              className="auth-input"
+              type="password"
+              placeholder="Confirm New Password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+            />
+            
+            {error && <p className="auth-error">{error}</p>}
+            
+            <button className="auth-submit-btn" type="submit" disabled={loading}>
+              {loading ? (
+                <>
+                  <Loader2 size={15} className="spin" />
+                </>
+              ) : (
+                'Save New Password'
+              )}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 📝 Description

This PR introduces the password reset flow for the application. It adds a "Forgot password?" link to the authentication modal, a backend request endpoint that looks up users by their username and generates a secure reset token, and a console-printing mechanism for local testing and validation.

Note: Since current user registration handles authentication via usernames rather than email addresses, this initial implementation is limited to username lookups. Once email integration is officially added to the core user model in a future update, this can be seamlessly transitioned to email-based verification for enhanced production security.

## 🔗 Related Issue

Closes #141 

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [X] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

<!-- Describe the steps you took to verify your change. -->
- [X] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [X] Backend tests pass (`python manage.py test analyzer`)
- [X] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)

https://github.com/user-attachments/assets/06d303e0-1213-4ac8-8d8f-f3aac684840b

<img width="617" height="138" alt="Screenshot 2026-07-24 063124" src="https://github.com/user-attachments/assets/5e425a94-2d69-4161-992f-d459082294e6" />

https://github.com/user-attachments/assets/a49f6ac6-d22c-46bd-801e-cdb945521b7e


## 📋 Checklist

- [X] My code follows the project's style and conventions
- [X] I have linked the related issue above
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
