### PR TITLE
feat: add readability score indicator alongside ATS score

### DIFF
--- a/backend/analyzer/services.py
+++ b/backend/analyzer/services.py
@@ -1,5 +1,6 @@
 import os
 import pdfplumber
+import textstat
 from django.contrib.auth import get_user_model
 from .models import ResumeAnalysis
 from .skill_matcher import extract_skills
@@ -31,6 +32,15 @@ PIPELINE_STAGES = [
     {"stage": "done", "label": "Analysis complete", "percent": 100},
 ]
 
+def calculate_readability(text):
+    score = textstat.flesch_reading_ease(text)
+    if score >= 60:
+        label = "easy"
+    elif score >= 30:
+        label = "moderate"
+    else:
+        label = "dense"
+    return round(score , 1), label
 
 def analyze_resume(file_path, target_role, file_name="resume.pdf",user_id=None,job_description=None):
 
@@ -48,6 +58,7 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf",user_id=None,j
             os.remove(file_path)
 
     raw_text = text
+    readability_score, readability_label = calculate_readability(raw_text)
     detected = extract_skills(text)
 
     matched = []
@@ -127,6 +138,8 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf",user_id=None,j
     return {
         "id": analysis_id,
         "score": score,
+        "readability_score": readability_score,
+        "readability_label": readability_label,
         "skills_found": detected,
         "suggestions": suggestions,
         "matched_skills": matched,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,7 +51,7 @@ interface UndoState {
   score: number | null
   skills: string[]
   suggestions: string[]
-  matchedSkills: string[]   
+  matchedSkills: string[]
   missingSkills: string[]
   resumeText: string
   analysisSource: 'sample' | 'upload' | null
@@ -274,6 +274,8 @@ function App() {
   const [score, setScore] = useState<number | null>(null)
   const [skills, setSkills] = useState<string[]>([])
   const [suggestions, setSuggestions] = useState<string[]>([])
+  const [readabilityScore, setReadabilityScore] = useState<number | null>(null)
+  const [readabilityLabel, setReadabilityLabel] = useState<string | null>(null)
   const [undoState, setUndoState] = useState<UndoState | null>(null)
   const [showUndoToast, setShowUndoToast] = useState(false)
 
@@ -604,6 +606,8 @@ function App() {
       setMatchedSkills(res.data.matched_skills || [])
       setMissingSkills(res.data.missing_skills || [])
       setResumeText(res.data.resume_text || '')
+      setReadabilityScore(res.data.readability_score ?? null)
+      setReadabilityLabel(res.data.readability_label ?? null)
       if (res.data.share_id) setShareId(res.data.share_id)
       setTrackComparisons(res.data.track_comparisons || null)
       setActiveTab('detailed')
@@ -1016,7 +1020,7 @@ function App() {
                             setFileError(null)
                           }}
                           style={{
-                             padding: '8px 16px',
+                            padding: '8px 16px',
                             borderRadius: 'var(--radius-md)',
                             fontSize: '0.85rem',
                             fontWeight: '600',
@@ -1192,7 +1196,7 @@ function App() {
                             fontWeight: '600',
                             display: 'block',
                             marginBottom: '8px',
-                            
+
                           }}
                         >
                           Job Description (Optional)
@@ -1318,7 +1322,11 @@ function App() {
                   )}
 
                   <div id="ats-score">
-                    <AtsScore score={score} />
+                    <AtsScore
+                      score={score}
+                      readabilityScore={readabilityScore}
+                      readabilityLabel={readabilityLabel}
+                    />
                   </div>
 
                   <ResumePreview text={resumeText} skills={skills} />
@@ -1379,7 +1387,7 @@ function App() {
                   </div>
 
                   {activeTab === 'matrix' && trackComparisons ? (
-                    <TrackMatrix 
+                    <TrackMatrix
                       trackComparisons={trackComparisons}
                       activeRole={targetRole}
                       onRowClick={(role) => {
@@ -1395,237 +1403,237 @@ function App() {
                   ) : (
                     <>
                       {/* Skills Section */}
-                  <section className="mt-4" aria-labelledby="skills-found-heading">
-                    <h4 id="skills-found-heading">Skills Found ({skills.length})</h4>
-                    {skills.length === 0 && <p>No skills detected</p>}
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexWrap: 'wrap',
-                        gap: '8px',
-                        justifyContent: 'center',
-                      }}
-                    >
-                      {(showAllSkills ? skills : skills.slice(0, 15)).map(
-                        (skill: string, i: number) => (
-                          <SkillChip key={i} skill={skill} type="detected" />
-                        )
-                      )}
-                    </div>
-                    {skills.length > 15 && (
-                      <button
-                        type="button"
-                        className="app-btn app-btn--secondary"
-                        style={{ marginTop: '16px', minHeight: '44px' }}
-                        onClick={() => setShowAllSkills(!showAllSkills)}
-                      >
-                        {showAllSkills ? (
-                          <>
-                            <ChevronUp size={15} /> Show Less
-                          </>
-                        ) : (
-                          <>
-                            <ChevronDown size={15} /> Show More ({skills.length - 15} more)
-                          </>
-                        )}
-                      </button>
-                    )}
-                  </section>
-
-                  {/* Word Cloud */}
-                  <SkillWordCloud skills={skills} />
-
-                  {/* Skill Gap Matrix */}
-                  <section
-                    className="mt-4 p-3"
-                    style={{ background: 'rgba(255,255,255,0.05)', borderRadius: '8px' }}
-                    aria-labelledby="skill-gap-heading"
-                  >
-                    <h4
-                      id="skill-gap-heading"
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        flexWrap: 'wrap',
-                        textAlign: 'center',
-                        gap: '6px',
-                      }}
-                    >
-                      <Target size={18} /> Skill Gap Matrix ({targetRole})
-                      <InfoTooltip content="Shows which required skills are already in your resume and which important skills are missing." />
-                    </h4>
-                    <div
-                      className="skill-gap-layout"
-                      style={{
-                        display: 'flex',
-                        flexWrap: 'wrap',
-                        gap: '20px',
-                        justifyContent: 'space-around',
-                        marginTop: '12px',
-                      }}
-                    >
-                      <div style={{ flex: '1 1 140px', minWidth: '140px' }}>
-                        <h6 style={{ color: '#22c55e' }}>Matched Skills</h6>
-                        {matchedSkills.length === 0 ? (
-                          <p style={{ fontSize: '12px' }}>None</p>
-                        ) : (
-                          <div
-                            style={{
-                              display: 'flex',
-                              flexWrap: 'wrap',
-                              gap: '4px',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            {matchedSkills.map((s, i) => (
-                              <SkillChip key={i} skill={s} type="matched" targetRole={targetRole} />
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </section>
-
-                  {/* Upgraded Suggestions Section */}
-                  <section
-                    className="mt-5 p-4"
-                    style={{
-                      background: 'rgba(30, 30, 47, 0.4)',
-                      borderRadius: 'var(--radius-lg)',
-                      border: '1px solid rgba(255, 255, 255, 0.04)',
-                    }}
-                  >
-                    {shareId && <ShareResult shareId={shareId} />}
-
-                    <div className="suggestion-box mt-4" style={{ padding: '15px' }}>
-                      <div
-                        style={{
-                          display: 'flex',
-                          flexWrap: 'wrap',
-                          gap: '10px',
-                          justifyContent: 'space-between',
-                          alignItems: 'center',
-                          marginBottom: '12px',
-                        }}
-                      >
-                        <h4 id="suggestions-heading" style={{ margin: 0 }}>
-                          💡 Suggestions
-                        </h4>
-                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
-                          {suggestions.length > 0 && (
-                            <button
-                              type="button"
-                              className={`app-btn app-btn--accent${copied ? ' is-success' : ''}`}
-                              onClick={copySuggestionsToClipboard}
-                              style={{ minHeight: '44px', padding: '8px 16px', fontSize: '13px' }}
-                            >
-                              {copied ? '✅ Copied!' : '📋 Copy All'}
-                            </button>
+                      <section className="mt-4" aria-labelledby="skills-found-heading">
+                        <h4 id="skills-found-heading">Skills Found ({skills.length})</h4>
+                        {skills.length === 0 && <p>No skills detected</p>}
+                        <div
+                          style={{
+                            display: 'flex',
+                            flexWrap: 'wrap',
+                            gap: '8px',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          {(showAllSkills ? skills : skills.slice(0, 15)).map(
+                            (skill: string, i: number) => (
+                              <SkillChip key={i} skill={skill} type="detected" />
+                            )
                           )}
+                        </div>
+                        {skills.length > 15 && (
+                          <button
+                            type="button"
+                            className="app-btn app-btn--secondary"
+                            style={{ marginTop: '16px', minHeight: '44px' }}
+                            onClick={() => setShowAllSkills(!showAllSkills)}
+                          >
+                            {showAllSkills ? (
+                              <>
+                                <ChevronUp size={15} /> Show Less
+                              </>
+                            ) : (
+                              <>
+                                <ChevronDown size={15} /> Show More ({skills.length - 15} more)
+                              </>
+                            )}
+                          </button>
+                        )}
+                      </section>
 
-                          <div style={{ position: 'relative', display: 'inline-block' }}>
-                            <button
-                              type="button"
-                              className="app-btn app-btn--secondary"
-                              onClick={() => setShowExportDropdown(!showExportDropdown)}
-                              style={{ minHeight: '44px' }}
-                            >
-                              Export ▼
-                            </button>
-                            {showExportDropdown && (
+                      {/* Word Cloud */}
+                      <SkillWordCloud skills={skills} />
+
+                      {/* Skill Gap Matrix */}
+                      <section
+                        className="mt-4 p-3"
+                        style={{ background: 'rgba(255,255,255,0.05)', borderRadius: '8px' }}
+                        aria-labelledby="skill-gap-heading"
+                      >
+                        <h4
+                          id="skill-gap-heading"
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            flexWrap: 'wrap',
+                            textAlign: 'center',
+                            gap: '6px',
+                          }}
+                        >
+                          <Target size={18} /> Skill Gap Matrix ({targetRole})
+                          <InfoTooltip content="Shows which required skills are already in your resume and which important skills are missing." />
+                        </h4>
+                        <div
+                          className="skill-gap-layout"
+                          style={{
+                            display: 'flex',
+                            flexWrap: 'wrap',
+                            gap: '20px',
+                            justifyContent: 'space-around',
+                            marginTop: '12px',
+                          }}
+                        >
+                          <div style={{ flex: '1 1 140px', minWidth: '140px' }}>
+                            <h6 style={{ color: '#22c55e' }}>Matched Skills</h6>
+                            {matchedSkills.length === 0 ? (
+                              <p style={{ fontSize: '12px' }}>None</p>
+                            ) : (
                               <div
                                 style={{
-                                  position: 'absolute',
-                                  top: '100%',
-                                  right: 0,
-                                  marginTop: '4px',
-                                  backgroundColor: 'var(--card-bg)',
-                                  border: '1px solid var(--surface-border)',
-                                  borderRadius: '6px',
-                                  boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
-                                  zIndex: 10,
                                   display: 'flex',
-                                  flexDirection: 'column',
-                                  minWidth: '120px',
-                                  overflow: 'hidden',
+                                  flexWrap: 'wrap',
+                                  gap: '4px',
+                                  justifyContent: 'center',
                                 }}
                               >
-                                <button
-                                  type="button"
-                                  onClick={exportJSON}
-                                  style={{
-                                    padding: '8px 12px',
-                                    background: 'transparent',
-                                    border: 'none',
-                                    color: 'var(--body-text)',
-                                    textAlign: 'left',
-                                    cursor: 'pointer',
-                                    borderBottom: '1px solid var(--surface-border)',
-                                  }}
-                                >
-                                  Export JSON
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={exportCSV}
-                                  style={{
-                                    padding: '8px 12px',
-                                    background: 'transparent',
-                                    border: 'none',
-                                    color: 'var(--body-text)',
-                                    textAlign: 'left',
-                                    cursor: 'pointer',
-                                  }}
-                                >
-                                  Export CSV
-                                </button>
+                                {matchedSkills.map((s, i) => (
+                                  <SkillChip key={i} skill={s} type="matched" targetRole={targetRole} />
+                                ))}
                               </div>
                             )}
                           </div>
                         </div>
-                      </div>
+                      </section>
 
-                      {suggestions.length === 0 ? (
-                        <p
-                          style={{
-                            color: '#64748b',
-                            fontStyle: 'italic',
-                            fontSize: 'var(--font-size-sm)',
-                            textAlign: 'left',
-                            margin: '16px 0 0 0',
-                          }}
-                        >
-                          No actionable layout suggestions generated for the current profile
-                          structure matrix.
-                        </p>
-                      ) : (
-                        <div className="suggestions-grid">
-                          {suggestions.map((suggestion, index) => (
-                            <SuggestionCard
-                              key={index}
-                              text={suggestion}
-                              index={index}
-                              backendUrl={backendUrl}
-                            />
-                          ))}
+                      {/* Upgraded Suggestions Section */}
+                      <section
+                        className="mt-5 p-4"
+                        style={{
+                          background: 'rgba(30, 30, 47, 0.4)',
+                          borderRadius: 'var(--radius-lg)',
+                          border: '1px solid rgba(255, 255, 255, 0.04)',
+                        }}
+                      >
+                        {shareId && <ShareResult shareId={shareId} />}
+
+                        <div className="suggestion-box mt-4" style={{ padding: '15px' }}>
+                          <div
+                            style={{
+                              display: 'flex',
+                              flexWrap: 'wrap',
+                              gap: '10px',
+                              justifyContent: 'space-between',
+                              alignItems: 'center',
+                              marginBottom: '12px',
+                            }}
+                          >
+                            <h4 id="suggestions-heading" style={{ margin: 0 }}>
+                              💡 Suggestions
+                            </h4>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+                              {suggestions.length > 0 && (
+                                <button
+                                  type="button"
+                                  className={`app-btn app-btn--accent${copied ? ' is-success' : ''}`}
+                                  onClick={copySuggestionsToClipboard}
+                                  style={{ minHeight: '44px', padding: '8px 16px', fontSize: '13px' }}
+                                >
+                                  {copied ? '✅ Copied!' : '📋 Copy All'}
+                                </button>
+                              )}
+
+                              <div style={{ position: 'relative', display: 'inline-block' }}>
+                                <button
+                                  type="button"
+                                  className="app-btn app-btn--secondary"
+                                  onClick={() => setShowExportDropdown(!showExportDropdown)}
+                                  style={{ minHeight: '44px' }}
+                                >
+                                  Export ▼
+                                </button>
+                                {showExportDropdown && (
+                                  <div
+                                    style={{
+                                      position: 'absolute',
+                                      top: '100%',
+                                      right: 0,
+                                      marginTop: '4px',
+                                      backgroundColor: 'var(--card-bg)',
+                                      border: '1px solid var(--surface-border)',
+                                      borderRadius: '6px',
+                                      boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+                                      zIndex: 10,
+                                      display: 'flex',
+                                      flexDirection: 'column',
+                                      minWidth: '120px',
+                                      overflow: 'hidden',
+                                    }}
+                                  >
+                                    <button
+                                      type="button"
+                                      onClick={exportJSON}
+                                      style={{
+                                        padding: '8px 12px',
+                                        background: 'transparent',
+                                        border: 'none',
+                                        color: 'var(--body-text)',
+                                        textAlign: 'left',
+                                        cursor: 'pointer',
+                                        borderBottom: '1px solid var(--surface-border)',
+                                      }}
+                                    >
+                                      Export JSON
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={exportCSV}
+                                      style={{
+                                        padding: '8px 12px',
+                                        background: 'transparent',
+                                        border: 'none',
+                                        color: 'var(--body-text)',
+                                        textAlign: 'left',
+                                        cursor: 'pointer',
+                                      }}
+                                    >
+                                      Export CSV
+                                    </button>
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+
+                          {suggestions.length === 0 ? (
+                            <p
+                              style={{
+                                color: '#64748b',
+                                fontStyle: 'italic',
+                                fontSize: 'var(--font-size-sm)',
+                                textAlign: 'left',
+                                margin: '16px 0 0 0',
+                              }}
+                            >
+                              No actionable layout suggestions generated for the current profile
+                              structure matrix.
+                            </p>
+                          ) : (
+                            <div className="suggestions-grid">
+                              {suggestions.map((suggestion, index) => (
+                                <SuggestionCard
+                                  key={index}
+                                  text={suggestion}
+                                  index={index}
+                                  backendUrl={backendUrl}
+                                />
+                              ))}
+                            </div>
+                          )}
+
+                          <CuratedTips targetRole={targetRole} />
+
+                          <div style={{ marginTop: '24px', textAlign: 'center' }}>
+                            <button
+                              type="button"
+                              className="app-btn app-btn--secondary"
+                              onClick={resetAnalysis}
+                              style={{ minHeight: '44px', width: '100%', maxWidth: '250px' }}
+                            >
+                              <RefreshCw size={15} /> Start New Analysis
+                            </button>
+                          </div>
                         </div>
-                      )}
-
-                      <CuratedTips targetRole={targetRole} />
-
-                      <div style={{ marginTop: '24px', textAlign: 'center' }}>
-                        <button
-                          type="button"
-                          className="app-btn app-btn--secondary"
-                          onClick={resetAnalysis}
-                          style={{ minHeight: '44px', width: '100%', maxWidth: '250px' }}
-                        >
-                          <RefreshCw size={15} /> Start New Analysis
-                        </button>
-                      </div>
-                    </div>
-                  </section>
+                      </section>
                     </>
                   )}
                 </section>

--- a/frontend/src/AtsScore.tsx
+++ b/frontend/src/AtsScore.tsx
@@ -3,9 +3,12 @@ import { InfoTooltip } from './components/InfoTooltip'
 
 interface AtsScoreProps {
   score: number
+  readabilityScore? : number | null
+  readabilityLabel? : string | null
 }
 
-export const AtsScore: React.FC<AtsScoreProps> = ({ score }) => {
+export const AtsScore: React.FC<AtsScoreProps> = ({ score ,readabilityScore,
+  readabilityLabel}) => {
   return (
     <div className="score-section mt-4">
       <div
@@ -25,6 +28,24 @@ export const AtsScore: React.FC<AtsScoreProps> = ({ score }) => {
         ATS Resume Score
         <InfoTooltip content="Shows how well your resume matches the job description and how likely it is to pass an Applicant Tracking System." />
       </h3>
+      {readabilityLabel && (
+        <div
+          className="readability-indicator mt-2"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '6px',
+            fontSize: '0.9rem',
+          }}
+        >
+          <span>
+            Readability:{' '}
+            <strong style={{ textTransform: 'capitalize' }}>{readabilityLabel}</strong>
+          </span>
+          <InfoTooltip content="Based on sentence length and word complexity (Flesch-Kincaid formula) — easier text is quicker for recruiters to scan." />
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 📝 Description

Adds a readability score alongside the existing ATS score, so users get a quick sense of how easy their resume is to scan. The score is calculated server-side using the Flesch-Kincaid formula and shown as a simple label (easy/moderate/dense) next to the ATS score, with a hover/tap tooltip explaining what it means.

- `services.py`: added `calculate_readability()` using `textstat.flesch_reading_ease()`, mapped to a label (easy/moderate/dense)
- `App.tsx`: added state for `readabilityScore`/`readabilityLabel`, captured from the `/api/upload/` response
- `AtsScore.tsx`: displays the readability label next to the ATS score with a tooltip explaining the metric (reuses existing `InfoTooltip` component)
- Manually verified via sample resume upload — label renders correctly and tooltip appears on hover


## 🔗 Related Issue

<!-- Replace XX with the issue number, e.g. Closes #12 or Fixes #34 -->
Closes #377 

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

<!-- Describe the steps you took to verify your change. -->
- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)

<!-- Drag & drop screenshots or a GIF here. -->

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
