### PR TITLE
Feat: Add support for DOCX resume uploads

### DIFF
--- a/backend/analyzer/services.py
+++ b/backend/analyzer/services.py
@@ -1,5 +1,6 @@
 import os
 import pdfplumber
+import docx
 import textstat
 from django.contrib.auth import get_user_model
 from .models import ResumeAnalysis
@@ -47,11 +48,16 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf",user_id=None,j
     text = ""
 
     try:
-        with pdfplumber.open(file_path) as pdf:
-            for page in pdf.pages:
-                extracted = page.extract_text()
-                if extracted:
-                    text += extracted
+        if file_name.lower().endswith('.docx'):
+            doc = docx.Document(file_path)
+            for paragraph in doc.paragraphs:
+                text += paragraph.text + "\n"
+        else:
+            with pdfplumber.open(file_path) as pdf:
+                for page in pdf.pages:
+                    extracted = page.extract_text()
+                    if extracted:
+                        text += extracted
 
     finally:
         if os.path.exists(file_path):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ pdfplumber>=0.11.10
 gunicorn>=26.0.0
 whitenoise>=6.8.0
 coverage>=7.0.0
+python-docx>=1.0.0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -329,8 +329,16 @@ function App() {
     e.stopPropagation()
     setIsDragging(false)
     if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-      setFile(e.dataTransfer.files[0])
-      setFileError(null)
+      const droppedFile = e.dataTransfer.files[0]
+      const validTypes = ['.pdf', '.docx']
+      const isValid = validTypes.some(ext => droppedFile.name.toLowerCase().endsWith(ext))
+      
+      if (isValid) {
+        setFile(droppedFile)
+        setFileError(null)
+      } else {
+        setFileError('Only PDF and DOCX files are supported.')
+      }
     }
   }
 
@@ -1083,10 +1091,19 @@ function App() {
                             type="file"
                             id="fileUpload"
                             hidden
+                            accept=".pdf,.docx"
                             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                               if (e.target.files && e.target.files[0]) {
-                                setFile(e.target.files[0])
-                                setFileError(null)
+                                const selectedFile = e.target.files[0]
+                                const validTypes = ['.pdf', '.docx']
+                                const isValid = validTypes.some(ext => selectedFile.name.toLowerCase().endsWith(ext))
+                                
+                                if (isValid) {
+                                  setFile(selectedFile)
+                                  setFileError(null)
+                                } else {
+                                  setFileError('Only PDF and DOCX files are supported.')
+                                }
                               }
                             }}
                           />


### PR DESCRIPTION
Closes #29 

    ## 📝 Description

    This PR introduces support for `.docx` resume file uploads to complement the
  existing PDF support. It adds the `python-docx` library to the backend to
  correctly extract text from uploaded Word documents, feeding it into the exact
  same analysis pipeline used for PDFs. On the frontend side, it updates file
  validation logic to smoothly accept both `.pdf` and `.docx` extensions via
  drag-and-drop and the file selection dialog.

    ## 🔗 Related Issue

    Closes #29

    ## ✅ Type of Change

    - [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
    - [x] ✨ New feature (non-breaking change that adds functionality)
    - [ ] 📚 Documentation update
    - [ ] 💅 UI/UX improvement
    - [ ] ♻️ Refactor (no functional change)
    - [ ] ⚡ Performance improvement

    ## 🧪 How Has This Been Tested?

    - [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
    - [ ] Backend tests pass (`python manage.py test analyzer`)
    - [x] Manually tested in the browser / API client

    ## 📋 Checklist

    - [x] My code follows the project's style and conventions
    - [x] I have linked the related issue above
    - [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
