### PR TITLE
Feature/admin dashboard #217

### DIFF
--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -14,6 +14,7 @@ from .views import (
     compare_versions_view,
     suggestion_feedback,
     get_shared_result,
+    admin_stats_view,
 )
 
 urlpatterns = [
@@ -32,4 +33,5 @@ urlpatterns = [
     path("shared/<uuid:share_id>/", get_shared_result),
     path('password-reset/', PasswordResetRequestView.as_view(), name='password_reset_request'),
     path('password-reset-confirm/', PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
+    path("admin/stats/", admin_stats_view, name="admin_stats"),
 ]

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -276,3 +276,32 @@ class PasswordResetConfirmView(APIView):
                 {"error": "Invalid or expired token."}, 
                 status=status.HTTP_400_BAD_REQUEST
             )
+
+from collections import Counter
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def admin_stats_view(request):
+    if not request.user.is_staff and not request.user.is_superuser:
+        return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        
+    total_analyses = ResumeAnalysis.objects.count()
+    
+    # Most popular career tracks
+    roles = ResumeAnalysis.objects.values_list('target_role', flat=True)
+    popular_roles = Counter(roles).most_common(5)
+    
+    # Most commonly missing skills
+    all_missing_skills = ResumeAnalysis.objects.values_list('missing_skills', flat=True)
+    missing_skills_counter = Counter()
+    for skills_list in all_missing_skills:
+        if isinstance(skills_list, list):
+            missing_skills_counter.update(skills_list)
+            
+    top_missing_skills = missing_skills_counter.most_common(10)
+    
+    return Response({
+        "total_analyses": total_analyses,
+        "popular_roles": [{"role": r[0], "count": r[1]} for r in popular_roles if r[0]],
+        "top_missing_skills": [{"skill": s[0], "count": s[1]} for s in top_missing_skills if s[0]]
+    })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,8 @@ import { FilePreview } from './components/FilePreview/FilePreview'
 import { ShareResult } from './components/ShareResult'
 import { SharedResultView } from './SharedResultView'
 import CookieConsentBanner from './components/CookieConsentBanner'
+import AdminDashboard from './components/AdminDashboard'
+
 type Theme = 'light' | 'dark'
 
 interface UndoState {
@@ -863,6 +865,7 @@ function App() {
         onHistoryClick={() => setHistoryOpen(true)}
       />
       <Routes>
+        <Route path="/admin" element={<AdminDashboard user={user} />} />
         <Route path="/shared/:shareId" element={<SharedResultView />} />
         <Route path="/reset-password/:uid/:token" element={<ResetPasswordConfirmPage />} />
         <Route

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import type { AuthUser } from '../hooks/useAuth';
+
+interface AdminDashboardProps {
+  user: AuthUser | null;
+}
+
+interface StatItem {
+  role?: string;
+  skill?: string;
+  count: number;
+}
+
+interface AdminStats {
+  total_analyses: number;
+  popular_roles: StatItem[];
+  top_missing_skills: StatItem[];
+}
+
+const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000';
+
+const AdminDashboard: React.FC<AdminDashboardProps> = ({ user }) => {
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) {
+      setError('You must be logged in as an admin to view this page.');
+      setLoading(false);
+      return;
+    }
+
+    const fetchStats = async () => {
+      try {
+        const res = await axios.get(`${BACKEND}/api/admin/stats/`, {
+          headers: { Authorization: `Bearer ${user.token}` },
+        });
+        setStats(res.data);
+      } catch (err: any) {
+        if (err.response?.status === 403) {
+          setError('Access Denied: You do not have permission to view this page.');
+        } else {
+          setError('An error occurred while fetching admin stats.');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, [user]);
+
+  if (loading) {
+    return <div style={{ padding: '2rem', textAlign: 'center' }}>Loading dashboard...</div>;
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--color-danger)' }}>
+        <h2>{error}</h2>
+      </div>
+    );
+  }
+
+  if (!stats) return null;
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: '800px', margin: '0 auto', color: 'var(--color-text)' }}>
+      <h1 style={{ marginBottom: '1.5rem', textAlign: 'center' }}>Admin Dashboard</h1>
+      
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+        gap: '1.5rem',
+        marginBottom: '2rem'
+      }}>
+        <div style={{
+          padding: '1.5rem',
+          borderRadius: '8px',
+          backgroundColor: 'var(--color-bg-card)',
+          boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
+          textAlign: 'center'
+        }}>
+          <h3>Total Analyses Run</h3>
+          <p style={{ fontSize: '2.5rem', fontWeight: 'bold', margin: '0.5rem 0' }}>
+            {stats.total_analyses}
+          </p>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '2rem' }}>
+        <div style={{
+          padding: '1.5rem',
+          borderRadius: '8px',
+          backgroundColor: 'var(--color-bg-card)',
+          boxShadow: '0 4px 6px rgba(0,0,0,0.1)'
+        }}>
+          <h3>Most Popular Career Tracks</h3>
+          <ul style={{ paddingLeft: '1.5rem', marginTop: '1rem' }}>
+            {stats.popular_roles.map((item, i) => (
+              <li key={i} style={{ marginBottom: '0.5rem' }}>
+                <strong>{item.role}</strong>: {item.count} analyses
+              </li>
+            ))}
+            {stats.popular_roles.length === 0 && <li>No data available</li>}
+          </ul>
+        </div>
+
+        <div style={{
+          padding: '1.5rem',
+          borderRadius: '8px',
+          backgroundColor: 'var(--color-bg-card)',
+          boxShadow: '0 4px 6px rgba(0,0,0,0.1)'
+        }}>
+          <h3>Most Commonly Missing Skills</h3>
+          <ul style={{ paddingLeft: '1.5rem', marginTop: '1rem' }}>
+            {stats.top_missing_skills.map((item, i) => (
+              <li key={i} style={{ marginBottom: '0.5rem' }}>
+                <strong>{item.skill}</strong>: missing in {item.count} analyses
+              </li>
+            ))}
+            {stats.top_missing_skills.length === 0 && <li>No data available</li>}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/frontend/src/components/HowItWorks.tsx
+++ b/frontend/src/components/HowItWorks.tsx
@@ -4,7 +4,7 @@ import { UploadCloud, Cpu, CheckCircle } from 'lucide-react'
 const steps = [
   
   {
-    icon: <FiUploadCloud size={36} />,
+    icon: <UploadCloud size={36} />,
     color: '#eeeff5',
     title: '1. Upload',
     description: 'Upload your resume in PDF format.',

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -77,7 +77,7 @@ export const Navbar: React.FC<NavbarProps> = ({
             }}
           >
             Home
-          </Link>
+          </a>
           <Link to="/analyze" onClick={() => setMobileOpen(false)}>
             Analyze Resume
           </Link>


### PR DESCRIPTION
 ──────
  ## 📝 Description

  This PR introduces an internal Admin Dashboard for maintainers to view
  anonymized, aggregate statistics across the platform, helping
  prioritize future work and analyze usage.

  Specifically, this PR:

  1. Backend API (/api/admin/stats/): Adds a new endpoint restricted to
  users with is_staff or is_superuser privileges. It queries and computes
  three core aggregate metrics:
      • Total analyses run
      • Most popular career tracks (Top 5)
      • Most commonly missing skills (Top 10)
      (Note: No individual user's raw resume text is returned or exposed,
      preserving privacy).
  2. Frontend View (/admin): Adds the AdminDashboard component and routes
  it to /admin. It requests the stats using the user's auth token. Non-
  admin users attempting to view the page will be presented with an
  "Access Denied" error message.

  ## 🔗 Related Issue

  Closes #217

  ## ✅ Type of Change

  [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
  [✓] ✨ New feature (non-breaking change that adds functionality)
  [ ] 📚 Documentation update
  [ ] 💅 UI/UX improvement
  [ ] ♻️ Refactor (no functional change)
  [ ] ⚡ Performance improvement

  ## 🧪 How Has This Been Tested?

  [✓] Frontend builds (npm run build) and lints (npm run lint) clean
  [ ] Backend tests pass (python manage.py test analyzer)
  [✓] Manually tested in the browser / API client

  ## 📸 Screenshots (if applicable)

  (You can drag & drop screenshots of the new Admin Dashboard UI here
  before submitting)

  ## 📋 Checklist

  [✓] My code follows the project's style and conventions
  [✓] I have linked the related issue above
  [✓] I have read the Code of Conduct /CODE_OF_CONDUCT.md***
