### PR TITLE
feat: Add standalone job description keyword visualizer (#382)

### DIFF
--- a/backend/analyzer/migrations/0008_resumeanalysis_interview_questions.py
+++ b/backend/analyzer/migrations/0008_resumeanalysis_interview_questions.py
@@ -4,18 +4,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('analyzer', '0005_resumeanalysis_share_id'),
+        ('analyzer', '0007_resumeanalysis_cover_letter'),
     ]
 
     operations = [
         migrations.AddField(
             model_name='resumeanalysis',
-            name='cover_letter_text',
-            field=models.TextField(blank=True, null=True),
-        ),
-        migrations.AddField(
-            model_name='resumeanalysis',
-            name='cover_letter_feedback',
+            name='interview_questions',
             field=models.JSONField(blank=True, null=True),
         ),
     ]

--- a/backend/analyzer/models.py
+++ b/backend/analyzer/models.py
@@ -26,6 +26,7 @@ class ResumeAnalysis(models.Model):
     share_id = models.UUIDField(default=uuid.uuid4, unique=True)
     cover_letter_text = models.TextField(blank=True, null=True)
     cover_letter_feedback = models.JSONField(blank=True, null=True)
+    interview_questions = models.JSONField(blank=True, null=True)
 
     class Meta:
         ordering = ["-created_at"]

--- a/backend/analyzer/serializers.py
+++ b/backend/analyzer/serializers.py
@@ -25,7 +25,7 @@ class ResumeAnalysisSerializer(serializers.ModelSerializer):
         model = ResumeAnalysis
         fields = ("id", "share_id", "file_name", "score", "skills_found", "suggestions",
                   "matched_skills", "missing_skills", "target_role", "created_at", "resume_text",
-                  "cover_letter_text", "cover_letter_feedback")
+                  "cover_letter_text", "cover_letter_feedback", "interview_questions")
 
 
 class VersionComparisonSerializer(serializers.Serializer):

--- a/backend/analyzer/services.py
+++ b/backend/analyzer/services.py
@@ -159,7 +159,158 @@ def analyze_cover_letter(text, target_role="", job_description=""):
             "feedback": relevance_feedback,
             "suggestions": relevance_suggestions
         }
-    }
+    }SKILL_QUESTIONS = {
+    "html": [
+        "What is semantic HTML, and how does it improve SEO and accessibility for assistive technologies?",
+        "Explain the purpose of HTML5 data-* attributes and how they are accessed in JavaScript and CSS."
+    ],
+    "css": [
+        "Explain the CSS Box Model, the difference between content-box and border-box, and how box-sizing affects layout sizing.",
+        "Compare CSS Flexbox and Grid. In what scenarios is one layout model more appropriate than the other?"
+    ],
+    "javascript": [
+        "Explain event delegation in JavaScript and how event bubbling enables it.",
+        "Discuss JavaScript closures. Can you describe a scenario where you used closures to maintain private variables or state?"
+    ],
+    "typescript": [
+        "How do TypeScript interfaces differ from type aliases, and when would you choose one over the other?",
+        "Explain the concept of generics in TypeScript and how they help write reusable, type-safe code."
+    ],
+    "react": [
+        "Explain React's virtual DOM reconciliation process and why key props are necessary when rendering dynamic lists.",
+        "How do you manage complex state in a growing React application, and how do you prevent unnecessary child component re-renders?"
+    ],
+    "next.js": [
+        "What are the main differences between Server-Side Rendering (SSR), Static Site Generation (SSG), and Client-Side Rendering in Next.js?",
+        "Explain how Next.js App Router layout systems and nested routing improve page shell caching and state preservation."
+    ],
+    "tailwind": [
+        "How does Tailwind's utility-first approach compare to traditional component-based CSS? Discuss performance benefits (e.g. PurgeCSS)."
+    ],
+    "git": [
+        "Explain the difference between git merge and git rebase. Under what workflows would you choose one over the other?"
+    ],
+    "github": [
+        "Describe your process for resolving merge conflicts during a pull request review on GitHub."
+    ],
+    "python": [
+        "Explain the difference between Python's list comprehensions, generator expressions, and traditional loops. When is a generator preferred?",
+        "How does Python's Global Interpreter Lock (GIL) affect multi-threaded CPU-bound programs, and how do you bypass it?"
+    ],
+    "django": [
+        "How does Django's ORM handle database query optimization? How do select_related and prefetch_related prevent N+1 query patterns?",
+        "Explain Django's middleware architecture. How would you design a custom middleware to log incoming request execution times?"
+    ],
+    "flask": [
+        "Explain Flask's application context and request context. Why are they separated, and how do context locals work?"
+    ],
+    "fastapi": [
+        "What makes FastAPI highly performant compared to standard frameworks? Discuss its dependency injection and async/await support."
+    ],
+    "node.js": [
+        "How does Node.js handle non-blocking asynchronous I/O operations despite being single-threaded? Explain the event loop."
+    ],
+    "sql": [
+        "How do database indexes (like B-Tree indexes) speed up query execution? Discuss the trade-offs on insert/update performance.",
+        "Explain the differences between INNER JOIN, LEFT JOIN, RIGHT JOIN, and FULL OUTER JOIN with hypothetical query examples."
+    ],
+    "postgresql": [
+        "Discuss transaction isolation levels in PostgreSQL. How does Multi-Version Concurrency Control (MVCC) prevent dirty reads?"
+    ],
+    "mongodb": [
+        "How does schema design in a document database like MongoDB differ from a traditional relational database? When is denormalization preferred?"
+    ],
+    "docker": [
+        "Explain the difference between Docker images and containers. How do multi-stage Docker builds optimize image size and security?"
+    ],
+    "excel": [
+        "Describe how you handle large datasets in Excel. What formulas or features (e.g. XLOOKUP, Pivot Tables) do you use to aggregate data?"
+    ],
+    "machine learning": [
+        "Explain the bias-variance trade-off in machine learning model training. How do regularization methods (like L1/L2) mitigate overfitting?",
+        "What metrics (e.g. precision, recall, F1-score, ROC-AUC) would you prioritize when evaluating a highly imbalanced classification dataset?"
+    ],
+    "deep learning": [
+        "Explain the vanishing gradient problem in deep neural networks and what techniques (e.g. ReLU, batch normalization, residual connections) help solve it."
+    ],
+    "data analysis": [
+        "Describe your process for clean-up and preprocessing of a noisy, incomplete dataset before performing exploratory data analysis."
+    ],
+    "pandas": [
+        "How do you optimize operations on large DataFrames in Pandas? Contrast the performance of apply() vs vectorized operations."
+    ],
+    "numpy": [
+        "Explain NumPy's broadcasting rules and why vectorized calculations on NumPy arrays are faster than traditional Python loops."
+    ],
+}
+
+ROLE_QUESTIONS = {
+    "Frontend Developer": [
+        "How do you approach web accessibility (a11y) to ensure compliance with WCAG standards in modern Single Page Applications (SPAs)?",
+        "Describe how you optimize frontend performance. What metrics (e.g. LCP, FID, CLS) do you track, and what strategies do you use to improve them?",
+        "How do you handle API state caching and synchronization (e.g. using React Query, RTK Query, or custom caching layers) on the frontend?"
+    ],
+    "Backend Developer": [
+        "How do you design a secure, idempotent RESTful API endpoint? Discuss error handling schemas, validation protocols, and JWT token authentication.",
+        "Describe how you would design a system architecture that handles asynchronous background task processing (e.g., using message queues like Celery, Redis, or RabbitMQ).",
+        "How do you secure your backend APIs against common vulnerabilities like SQL injection, cross-site scripting (XSS), and denial-of-service (DoS) attacks?"
+    ],
+    "Data Analyst": [
+        "Describe a time when you discovered an unexpected anomaly or insight in a dataset. How did you communicate your findings to non-technical stakeholders?",
+        "How do you design dashboard KPIs that are actionable rather than just vanity metrics for executive business teams?",
+        "Explain how you choose the appropriate data visualization (e.g. bar chart, scatter plot, heat map) to best tell a specific data story."
+    ]
+}
+
+BEHAVIORAL_QUESTIONS = [
+    "Tell me about a challenging technical bug you encountered in a recent project. How did you diagnose and resolve it?",
+    "Describe a situation where you had to work with a teammate who had a different technical opinion. How did you reach a consensus?",
+    "How do you keep up with new technology changes, libraries, and framework updates in your engineering track?",
+    "Describe a project where you had a tight deadline and limited requirements. How did you prioritize tasks to deliver value on time?"
+]
+
+def generate_interview_questions(skills, target_role):
+    import random
+    questions = []
+    
+    skills_shuffled = list(skills)
+    random.shuffle(skills_shuffled)
+    
+    for skill in skills_shuffled:
+        skill_lower = skill.lower()
+        if skill_lower in SKILL_QUESTIONS:
+            q = random.choice(SKILL_QUESTIONS[skill_lower])
+            if q not in questions:
+                questions.append(q)
+            if len(questions) >= 4:
+                break
+                
+    role_pool = ROLE_QUESTIONS.get(target_role, [])
+    if role_pool:
+        role_shuffled = list(role_pool)
+        random.shuffle(role_shuffled)
+        for q in role_shuffled:
+            if q not in questions:
+                questions.append(q)
+            if len(questions) >= 6:
+                break
+                
+    behavioral_shuffled = list(BEHAVIORAL_QUESTIONS)
+    random.shuffle(behavioral_shuffled)
+    for q in behavioral_shuffled:
+        if len(questions) >= 8:
+            break
+        if q not in questions:
+            questions.append(q)
+            
+    if len(questions) < 5:
+        for q in behavioral_shuffled:
+            if q not in questions:
+                questions.append(q)
+            if len(questions) >= 5:
+                break
+                
+    return questions[:8]
 
 
 def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None, job_description=None, cover_letter_path=None, cover_letter_name=None):
@@ -206,6 +357,9 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
             if os.path.exists(cover_letter_path):
                 os.remove(cover_letter_path)
 
+    # Generate interview questions based on target track and detected skills
+    interview_questions = generate_interview_questions(detected, target_role)
+
     analysis_id = None
 
     if user_id:
@@ -224,6 +378,7 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
                 resume_text=raw_text,
                 cover_letter_text=cover_letter_text if cover_letter_text else None,
                 cover_letter_feedback=cover_letter_feedback,
+                interview_questions=interview_questions,
             )
             analysis_id = analysis_record.id
         except User.DoesNotExist:
@@ -266,6 +421,7 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
         "resume_text": raw_text,
         "cover_letter_text": cover_letter_text if cover_letter_text else None,
         "cover_letter_feedback": cover_letter_feedback,
+        "interview_questions": interview_questions,
         "progress": progress_info,
         "pipeline_stages": PIPELINE_STAGES,
         "track_comparisons": track_comparisons,

--- a/backend/analyzer/tests.py
+++ b/backend/analyzer/tests.py
@@ -387,3 +387,30 @@ class CoverLetterAnalysisTests(TestCase):
             self.assertIsNotNone(result["cover_letter_feedback"])
             self.assertEqual(result["cover_letter_feedback"]["length"]["status"], "Too short")
             self.assertTrue(result["cover_letter_feedback"]["relevance"]["references_role"])
+
+
+class InterviewQuestionTests(TestCase):
+    def test_generate_interview_questions_valid(self):
+        from analyzer.services import generate_interview_questions
+        
+        # Test generation with React skill and Frontend Developer target role
+        questions = generate_interview_questions(["React", "TypeScript"], "Frontend Developer")
+        self.assertTrue(len(questions) >= 5)
+        self.assertTrue(len(questions) <= 8)
+        
+        # At least one question should be from React or TS
+        has_tech = any("React" in q or "TypeScript" in q or "virtual DOM" in q or "generics" in q for q in questions)
+        self.assertTrue(has_tech)
+
+    @patch("analyzer.services.pdfplumber.open")
+    def test_analyze_resume_generates_interview_questions(self, mock_open):
+        mock_open.return_value = _fake_pdf("Expert in Python and SQL.")
+        
+        result = analyze_resume(
+            file_path="dummy_resume.pdf",
+            target_role="Backend Developer",
+            file_name="resume.pdf",
+        )
+        
+        self.assertIn("interview_questions", result)
+        self.assertTrue(len(result["interview_questions"]) >= 5)

--- a/backend/analyzer/tests.py
+++ b/backend/analyzer/tests.py
@@ -414,3 +414,38 @@ class InterviewQuestionTests(TestCase):
         
         self.assertIn("interview_questions", result)
         self.assertTrue(len(result["interview_questions"]) >= 5)
+
+
+class JdAnalysisTests(TestCase):
+    def test_analyze_jd_endpoint(self):
+        from rest_framework import status
+        
+        # Test empty input error
+        resp = self.client.post("/api/analyze-jd/", {"job_description": ""})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)
+        
+        # Test valid input analysis with known skill keywords and stop words
+        jd_text = (
+            "We are seeking a React Developer. The candidate should have experience in React, "
+            "JavaScript, HTML, and CSS. Working with teams to deliver responsive layouts is essential. "
+            "React and TypeScript are strong plusses. The candidate will work in a fast-paced environment."
+        )
+        resp = self.client.post("/api/analyze-jd/", {"job_description": jd_text})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("keywords", resp.data)
+        
+        keywords = resp.data["keywords"]
+        self.assertTrue(len(keywords) > 0)
+        
+        # Check that 'react' is recognized and tagged as a skill
+        react_keyword = next((k for k in keywords if k["text"] == "react"), None)
+        self.assertIsNotNone(react_keyword)
+        self.assertEqual(react_keyword["type"], "skill")
+        self.assertTrue(react_keyword["value"] >= 2)
+        
+        # Common English stop words like 'the' or 'and' or corporate fillers like 'candidate' shouldn't be here
+        texts = [k["text"] for k in keywords]
+        self.assertNotIn("the", texts)
+        self.assertNotIn("and", texts)
+        self.assertNotIn("candidate", texts)

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -16,11 +16,13 @@ from .views import (
     suggestion_feedback,
     get_shared_result,
     admin_stats_view,
+    analyze_jd_view,
 )
 
 urlpatterns = [
     path("upload/", upload_resume),
     path("compare-uploads/", compare_uploads),
+    path("analyze-jd/", analyze_jd_view),
 
     path("auth/signup/", signup),
     path("auth/login/", TokenObtainPairView.as_view()),

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -384,3 +384,61 @@ def admin_stats_view(request):
         "popular_roles": [{"role": r[0], "count": r[1]} for r in popular_roles if r[0]],
         "top_missing_skills": [{"skill": s[0], "count": s[1]} for s in top_missing_skills if s[0]]
     })
+
+
+import re
+from collections import Counter
+
+STOP_WORDS = {
+    "a", "about", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "aren't", "as", "at",
+    "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "can't", "cannot", "could",
+    "couldn't", "did", "didn't", "do", "does", "doesn't", "doing", "don't", "down", "during", "each", "few", "for",
+    "from", "further", "had", "hadn't", "has", "hasn't", "have", "haven't", "having", "he", "he'd", "he'll", "he's",
+    "her", "here", "here's", "hers", "herself", "him", "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm",
+    "i've", "if", "in", "into", "is", "isn't", "it", "it's", "its", "itself", "let's", "me", "more", "most", "mustn't",
+    "my", "myself", "no", "nor", "not", "of", "off", "on", "once", "only", "or", "other", "ought", "our", "ours",
+    "ourselves", "out", "over", "own", "same", "shan't", "she", "she'd", "she'll", "she's", "should", "shouldn't",
+    "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them", "themselves", "then", "there",
+    "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to", "too",
+    "under", "until", "up", "very", "was", "wasn't", "we", "we'd", "we'll", "we're", "we've", "were", "weren't",
+    "what", "what's", "when", "when's", "where", "where's", "which", "while", "who", "who's", "whom", "why", "why's",
+    "with", "won't", "would", "wouldn't", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself",
+    "yourselves", "job", "description", "experience", "role", "team", "work", "responsibilities", "skills", "required",
+    "looking", "ability", "using", "candidate", "development", "knowledge", "working", "strong", "position", "years"
+}
+
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def analyze_jd_view(request):
+    job_description = request.data.get("job_description", "")
+    if not job_description or not job_description.strip():
+        return Response({"error": "Job description cannot be empty."}, status=status.HTTP_400_BAD_REQUEST)
+        
+    words = re.findall(r"\b[a-zA-Z0-9\-\.\#\+\-]+\b", job_description.lower())
+    filtered_words = [w for w in words if w not in STOP_WORDS and len(w) >= 2]
+    
+    counter = Counter(filtered_words)
+    top_items = counter.most_common(30)
+    
+    from analyzer.services import ROLE_SKILLS
+    all_skills = set()
+    for skills_list in ROLE_SKILLS.values():
+        for s in skills_list:
+            all_skills.add(s.lower())
+            
+    results = []
+    for word, count in top_items:
+        is_skill = (word in all_skills) or (word.title() in all_skills) or (word.upper() in all_skills)
+        if not is_skill:
+            for s in all_skills:
+                if s == word or (len(word) > 3 and word in s):
+                    is_skill = True
+                    break
+                    
+        results.append({
+            "text": word,
+            "value": count,
+            "type": "skill" if is_skill else "general"
+        })
+        
+    return Response({"keywords": results}, status=status.HTTP_200_OK)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@sentry/react": "^8.55.2",
         "@babel/parser": "^8.0.4",
+        "@sentry/react": "^8.38.0",
         "axios": "^1.13.6",
         "bootstrap": "^5.3.8",
         "d3-cloud": "^1.2.9",
@@ -145,7 +145,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1496,7 +1495,6 @@
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1508,7 +1506,6 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -4590,7 +4587,6 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -5195,7 +5191,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -6513,7 +6508,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -6527,7 +6521,6 @@
       "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^9.0.1"
       },
@@ -6630,7 +6623,6 @@
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -6641,7 +6633,6 @@
       "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -7194,7 +7185,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -7518,7 +7508,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1692,10 +1692,10 @@ function App() {
                           Too many requests. Please wait {retryAfter}s before trying again.
                         </p>
                       )}
-                      </>
-                    )}
                     </div>
-                  </section>
+                  </>
+                )}
+              </section>
                 </div>
               </div>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { SkillWordCloud } from './components/SkillWordCloud'
 import { TrackMatrix } from './components/TrackMatrix'
 import { CoverLetterFeedbackPanel } from './components/CoverLetterFeedbackPanel'
 import { InterviewQuestionsPanel } from './components/InterviewQuestionsPanel'
+import { JdVisualizerPanel } from './components/JdVisualizerPanel'
 import { ResetPasswordConfirmPage } from './components/ResetPasswordConfirmPage'
 import type { TrackComparisons } from './components/TrackMatrix'
 import {
@@ -329,6 +330,13 @@ function App() {
 
   // Interview Questions States
   const [interviewQuestions, setInterviewQuestions] = useState<string[]>([])
+
+  // Standalone Job Description States
+  const [activeFlow, setActiveFlow] = useState<'resume' | 'jd'>('resume')
+  const [jdInputText, setJdInputText] = useState('')
+  const [jdKeywords, setJdKeywords] = useState<any[]>([])
+  const [jdLoading, setJdLoading] = useState(false)
+  const [jdError, setJdError] = useState<string | null>(null)
 
   // History
   const {
@@ -748,6 +756,27 @@ function App() {
     }
   }
 
+  const runJdAnalysis = async () => {
+    if (!jdInputText || !jdInputText.trim()) {
+      setJdError('Job description cannot be empty.')
+      return
+    }
+    setJdLoading(true)
+    setJdError(null)
+    setJdKeywords([])
+    try {
+      const res = await axios.post(`${backendUrl}/api/analyze-jd/`, {
+        job_description: jdInputText,
+      })
+      setJdKeywords(res.data.keywords || [])
+    } catch (err: any) {
+      console.error(err)
+      setJdError(err.response?.data?.error || 'Failed to analyze job description.')
+    } finally {
+      setJdLoading(false)
+    }
+  }
+
   const uploadResume = async () => {
     let hasError = false
 
@@ -1071,7 +1100,140 @@ function App() {
                   {(loading || score !== null) && <StepProgress currentStep={currentStep} />}
 
                   <section className="analyzer-form-section" aria-label="Resume Analyzer Form">
-                    {/* STEP 1: Target Career Track */}
+                    {/* Active Flow Switcher Tabs */}
+                    {score === null && !loading && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          gap: '12px',
+                          justifyContent: 'center',
+                          marginBottom: '24px',
+                          borderBottom: '1px solid rgba(255, 255, 255, 0.08)',
+                          paddingBottom: '12px',
+                        }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setActiveFlow('resume')
+                            setJdKeywords([])
+                          }}
+                          style={{
+                            padding: '8px 20px',
+                            borderRadius: 'var(--radius-md)',
+                            fontSize: '0.95rem',
+                            fontWeight: '600',
+                            cursor: 'pointer',
+                            background:
+                              activeFlow === 'resume'
+                                ? 'var(--color-primary, #6366f1)'
+                                : 'rgba(255, 255, 255, 0.05)',
+                            color: '#fff',
+                            border: '1px solid rgba(255, 255, 255, 0.15)',
+                            transition: 'all 0.2s ease',
+                          }}
+                        >
+                          📄 Optimize Resume
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setActiveFlow('jd')
+                          }}
+                          style={{
+                            padding: '8px 20px',
+                            borderRadius: 'var(--radius-md)',
+                            fontSize: '0.95rem',
+                            fontWeight: '600',
+                            cursor: 'pointer',
+                            background:
+                              activeFlow === 'jd'
+                                ? 'var(--color-primary, #6366f1)'
+                                : 'rgba(255, 255, 255, 0.05)',
+                            color: '#fff',
+                            border: '1px solid rgba(255, 255, 255, 0.15)',
+                            transition: 'all 0.2s ease',
+                          }}
+                        >
+                          💼 Analyze Job Description
+                        </button>
+                      </div>
+                    )}
+
+                    {activeFlow === 'jd' && jdKeywords.length > 0 ? (
+                      <JdVisualizerPanel
+                        keywords={jdKeywords}
+                        onBack={() => {
+                          setJdKeywords([])
+                          setJdInputText('')
+                        }}
+                      />
+                    ) : activeFlow === 'jd' ? (
+                      <div className="animate-fade-in">
+                        <div
+                          className="mb-4 p-4"
+                          style={{
+                            background: 'rgba(255, 255, 255, 0.02)',
+                            borderRadius: 'var(--radius-lg)',
+                            border: '1px solid rgba(255,255,255,0.04)',
+                            textAlign: 'left'
+                          }}
+                        >
+                          <label
+                            htmlFor="jdTextInput"
+                            style={{
+                              color: theme === 'light' ? '#000000' : '#ffffff',
+                              display: 'block',
+                              marginBottom: '12px',
+                              fontWeight: '600',
+                              fontSize: 'var(--font-size-sm)',
+                            }}
+                          >
+                            📝 Paste the Job Description to extract and visualize key terms:
+                          </label>
+                          <textarea
+                            id="jdTextInput"
+                            rows={8}
+                            value={jdInputText}
+                            onChange={(e) => {
+                              setJdInputText(e.target.value)
+                              if (e.target.value.trim() !== '') setJdError(null)
+                            }}
+                            placeholder="Paste job description here..."
+                            style={{
+                              width: '100%',
+                              padding: '12px',
+                              borderRadius: 'var(--radius-md)',
+                              border: '1px solid rgba(255,255,255,0.1)',
+                              background: 'rgba(0,0,0,0.2)',
+                              color: '#fff',
+                              outline: 'none',
+                              fontSize: '0.92rem',
+                              lineHeight: '1.5',
+                              resize: 'vertical'
+                            }}
+                          />
+                          {jdError && (
+                            <div style={{ color: '#ef4444', fontSize: '13px', marginTop: '8px', fontWeight: '500' }}>
+                              ⚠️ {jdError}
+                            </div>
+                          )}
+                          <div style={{ display: 'flex', justifyContent: 'center', marginTop: '16px' }}>
+                            <button
+                              type="button"
+                              className="analyze-btn"
+                              onClick={runJdAnalysis}
+                              disabled={jdLoading}
+                              style={{ width: 'auto', minWidth: '200px' }}
+                            >
+                              {jdLoading ? '⏳ Analyzing Keywords...' : '🔍 Analyze JD Keywords'}
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <>
+                        {/* STEP 1: Target Career Track */}
                     <div
                       className="mb-4 p-4 role-selector-container"
                       style={{
@@ -1530,6 +1692,8 @@ function App() {
                           Too many requests. Please wait {retryAfter}s before trying again.
                         </p>
                       )}
+                      </>
+                    )}
                     </div>
                   </section>
                 </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { InfoTooltip } from './components/InfoTooltip'
 import { SkillWordCloud } from './components/SkillWordCloud'
 import { TrackMatrix } from './components/TrackMatrix'
 import { CoverLetterFeedbackPanel } from './components/CoverLetterFeedbackPanel'
+import { InterviewQuestionsPanel } from './components/InterviewQuestionsPanel'
 import { ResetPasswordConfirmPage } from './components/ResetPasswordConfirmPage'
 import type { TrackComparisons } from './components/TrackMatrix'
 import {
@@ -66,6 +67,7 @@ interface UndoState {
   targetRole: string
   coverLetterText?: string
   coverLetterFeedback?: any
+  interviewQuestions?: string[]
 }
 
 const DEFAULT_TITLE = 'AI Resume Analyzer'
@@ -314,7 +316,7 @@ function App() {
   const [analysisStageLabel, setAnalysisStageLabel] = useState<string>('')
   const [uploadMode, setUploadMode] = useState<'file' | 'url'>('file')
   const [trackComparisons, setTrackComparisons] = useState<TrackComparisons | null>(null)
-  const [activeTab, setActiveTab] = useState<'detailed' | 'matrix' | 'cover_letter'>('detailed')
+  const [activeTab, setActiveTab] = useState<'detailed' | 'matrix' | 'cover_letter' | 'interview_questions'>('detailed')
   const [resumeUrl, setResumeUrl] = useState<string>('')
   const [urlError, setUrlError] = useState<string | null>(null)
   const [isDragging, setIsDragging] = useState(false)
@@ -324,6 +326,9 @@ function App() {
   const [coverLetterError, setCoverLetterError] = useState<string | null>(null)
   const [coverLetterText, setCoverLetterText] = useState<string>('')
   const [coverLetterFeedback, setCoverLetterFeedback] = useState<any>(null)
+
+  // Interview Questions States
+  const [interviewQuestions, setInterviewQuestions] = useState<string[]>([])
 
   // History
   const {
@@ -427,6 +432,7 @@ function App() {
             file_name: string
             cover_letter_text?: string
             cover_letter_feedback?: any
+            interview_questions?: string[]
           }) => ({
             id: String(item.id),
             timestamp: new Date(item.created_at).getTime(),
@@ -439,6 +445,7 @@ function App() {
             fileName: item.file_name,
             coverLetterText: item.cover_letter_text,
             coverLetterFeedback: item.cover_letter_feedback,
+            interviewQuestions: item.interview_questions,
           })
         )
         const uniqueDbEntries = dbEntries.filter(
@@ -496,6 +503,7 @@ function App() {
         targetRole,
         coverLetterText,
         coverLetterFeedback,
+        interviewQuestions,
       })
       setShowUndoToast(true)
     }
@@ -519,6 +527,7 @@ function App() {
     setCoverLetterError(null)
     setCoverLetterText('')
     setCoverLetterFeedback(null)
+    setInterviewQuestions([])
   }, [
     file,
     score,
@@ -532,6 +541,7 @@ function App() {
     targetRole,
     coverLetterText,
     coverLetterFeedback,
+    interviewQuestions,
   ])
 
   const handleUndoReset = useCallback(() => {
@@ -548,6 +558,7 @@ function App() {
       setTargetRole(undoState.targetRole)
       setCoverLetterText(undoState.coverLetterText || '')
       setCoverLetterFeedback(undoState.coverLetterFeedback || null)
+      setInterviewQuestions(undoState.interviewQuestions || [])
       setUndoState(null)
       setShowUndoToast(false)
     }
@@ -650,6 +661,8 @@ function App() {
       setResumeText(res.data.resume_text || '')
       setCoverLetterText(res.data.cover_letter_text || '')
       setCoverLetterFeedback(res.data.cover_letter_feedback || null)
+      setInterviewQuestions(res.data.interview_questions || [])
+
       setReadabilityLabel(res.data.readability_label ?? null)
       if (res.data.share_id) setShareId(res.data.share_id)
       setTrackComparisons(res.data.track_comparisons || null)
@@ -677,6 +690,7 @@ function App() {
           fileName: fileName,
           coverLetterText: res.data.cover_letter_text,
           coverLetterFeedback: res.data.cover_letter_feedback,
+          interviewQuestions: res.data.interview_questions,
         })
       }
 
@@ -858,6 +872,7 @@ function App() {
     setActiveFileName(entry.fileName)
     setCoverLetterText(entry.coverLetterText || '')
     setCoverLetterFeedback(entry.coverLetterFeedback || null)
+    setInterviewQuestions(entry.interviewQuestions || [])
     setShowAllSkills(false)
     setCopied(false)
     setHistoryOpen(false)
@@ -1651,6 +1666,25 @@ function App() {
                         ✉️ Cover Letter
                       </button>
                     )}
+                    {interviewQuestions && interviewQuestions.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => setActiveTab('interview_questions')}
+                        style={{
+                          padding: '8px 16px',
+                          borderRadius: 'var(--radius-md)',
+                          fontSize: '0.9rem',
+                          fontWeight: '600',
+                          cursor: 'pointer',
+                          background: activeTab === 'interview_questions' ? 'var(--color-primary, #6366f1)' : 'rgba(255, 255, 255, 0.05)',
+                          color: '#fff',
+                          border: '1px solid rgba(255, 255, 255, 0.15)',
+                          transition: 'all 0.2s ease',
+                        }}
+                      >
+                        💬 Interview Prep
+                      </button>
+                    )}
                   </div>
 
                   {activeTab === 'matrix' && trackComparisons ? (
@@ -1669,6 +1703,8 @@ function App() {
                     />
                   ) : activeTab === 'cover_letter' && coverLetterFeedback ? (
                     <CoverLetterFeedbackPanel feedback={coverLetterFeedback} />
+                  ) : activeTab === 'interview_questions' && interviewQuestions && interviewQuestions.length > 0 ? (
+                    <InterviewQuestionsPanel questions={interviewQuestions} />
                   ) : (
                     <>
                       {/* Skills Section */}

--- a/frontend/src/components/InterviewQuestionsPanel.tsx
+++ b/frontend/src/components/InterviewQuestionsPanel.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from 'react'
+
+interface InterviewQuestionsPanelProps {
+  questions: string[]
+}
+
+export const InterviewQuestionsPanel: React.FC<InterviewQuestionsPanelProps> = ({ questions }) => {
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
+  const [copiedAll, setCopiedAll] = useState(false)
+
+  if (!questions || questions.length === 0) {
+    return (
+      <div style={{ textAlign: 'center', padding: '30px', color: 'rgba(255,255,255,0.6)' }}>
+        <p>No interview questions generated. Try re-running the analysis with a target role and skills.</p>
+      </div>
+    )
+  }
+
+  const handleCopySingle = (question: string, index: number) => {
+    navigator.clipboard.writeText(question)
+    setCopiedIndex(index)
+    setTimeout(() => setCopiedIndex(null), 2000)
+  }
+
+  const handleCopyAll = () => {
+    const formatted = questions.map((q, idx) => `${idx + 1}. ${q}`).join('\n\n')
+    navigator.clipboard.writeText(formatted)
+    setCopiedAll(true)
+    setTimeout(() => setCopiedAll(false), 2000)
+  }
+
+  const handleExportTxt = () => {
+    const header = `AI Resume Analyzer - Interview Preparation Questions\nGenerated: ${new Date().toLocaleDateString()}\n==================================================\n\n`
+    const content = questions.map((q, idx) => `Question ${idx + 1}:\n${q}\n`).join('\n')
+    const blob = new Blob([header + content], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `interview-questions-${Date.now()}.txt`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="interview-questions-container" style={{ textAlign: 'left', marginTop: '20px' }}>
+      <div style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: '12px',
+        marginBottom: '20px'
+      }}>
+        <h3 style={{ fontSize: '1.4rem', fontWeight: '700', margin: 0, display: 'flex', alignItems: 'center', gap: '8px', color: '#fff' }}>
+          💬 Interview Questions ({questions.length})
+        </h3>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            type="button"
+            onClick={handleCopyAll}
+            style={{
+              padding: '6px 12px',
+              borderRadius: 'var(--radius-md)',
+              fontSize: '0.82rem',
+              fontWeight: '600',
+              cursor: 'pointer',
+              background: copiedAll ? 'rgba(34, 197, 94, 0.15)' : 'rgba(255, 255, 255, 0.05)',
+              color: copiedAll ? '#4ade80' : '#fff',
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+              transition: 'all 0.2s'
+            }}
+          >
+            {copiedAll ? '✓ Copied All' : '📋 Copy All'}
+          </button>
+          <button
+            type="button"
+            onClick={handleExportTxt}
+            style={{
+              padding: '6px 12px',
+              borderRadius: 'var(--radius-md)',
+              fontSize: '0.82rem',
+              fontWeight: '600',
+              cursor: 'pointer',
+              background: 'rgba(255, 255, 255, 0.05)',
+              color: '#fff',
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+              transition: 'all 0.2s'
+            }}
+          >
+            📥 Export TXT
+          </button>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+        {questions.map((question, index) => (
+          <div
+            key={index}
+            style={{
+              background: 'rgba(255, 255, 255, 0.03)',
+              border: '1px solid rgba(255,255,255,0.06)',
+              borderRadius: 'var(--radius-lg)',
+              padding: '16px 20px',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+              gap: '16px',
+              transition: 'transform 0.2s, background-color 0.2s'
+            }}
+          >
+            <div style={{ flex: 1 }}>
+              <span style={{
+                fontSize: '0.72rem',
+                fontWeight: '700',
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+                color: '#818cf8',
+                display: 'block',
+                marginBottom: '6px'
+              }}>
+                Question {index + 1}
+              </span>
+              <p style={{ fontSize: '0.94rem', color: '#f1f5f9', margin: 0, lineHeight: '1.5' }}>
+                {question}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => handleCopySingle(question, index)}
+              style={{
+                background: 'rgba(255, 255, 255, 0.04)',
+                border: '1px solid rgba(255, 255, 255, 0.08)',
+                borderRadius: 'var(--radius-md)',
+                padding: '6px 10px',
+                fontSize: '0.78rem',
+                color: copiedIndex === index ? '#4ade80' : 'rgba(255, 255, 255, 0.8)',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+                whiteSpace: 'nowrap'
+              }}
+            >
+              {copiedIndex === index ? 'Copied ✓' : 'Copy'}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/JdVisualizerPanel.tsx
+++ b/frontend/src/components/JdVisualizerPanel.tsx
@@ -1,0 +1,185 @@
+import React, { useState } from 'react'
+
+interface KeywordItem {
+  text: string
+  value: number
+  type: 'skill' | 'general'
+}
+
+interface JdVisualizerPanelProps {
+  keywords: KeywordItem[]
+  onBack: () => void
+}
+
+export const JdVisualizerPanel: React.FC<JdVisualizerPanelProps> = ({ keywords, onBack }) => {
+  const [searchTerm, setSearchTerm] = useState('')
+
+  if (!keywords || keywords.length === 0) {
+    return (
+      <div className="card glass-card p-5 text-center mt-4">
+        <p style={{ color: 'rgba(255,255,255,0.6)' }}>No keywords found. Try analyzing a longer, more detailed job description.</p>
+        <button className="app-btn app-btn--secondary mt-3" onClick={onBack}>Go Back</button>
+      </div>
+    )
+  }
+
+  // Filter keywords by search query
+  const filtered = keywords.filter((item) =>
+    item.text.toLowerCase().includes(searchTerm.toLowerCase())
+  )
+
+  // Max value for scaling word cloud sizes
+  const maxValue = Math.max(...keywords.map((k) => k.value), 1)
+
+  return (
+    <div className="jd-visualizer-container animate-fade-in" style={{ marginTop: '24px', textAlign: 'left' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
+        <button
+          onClick={onBack}
+          className="app-btn app-btn--secondary"
+          style={{ padding: '6px 12px', minHeight: '36px', fontSize: '0.85rem' }}
+        >
+          ← Analyze Another JD
+        </button>
+        <h2 style={{ fontSize: '1.5rem', fontWeight: '800', margin: 0, color: '#fff' }}>
+          💼 Job Description Insights
+        </h2>
+      </div>
+
+      {/* Row: Word Cloud Card */}
+      <div className="card glass-card p-4 mb-4" style={{ position: 'relative', overflow: 'hidden' }}>
+        <h3 style={{ fontSize: '1.15rem', fontWeight: '700', marginBottom: '16px', color: '#fff' }}>
+          ☁️ Keyword Word Cloud
+        </h3>
+        <div style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '14px 20px',
+          justifyContent: 'center',
+          alignItems: 'center',
+          padding: '20px',
+          background: 'rgba(0,0,0,0.15)',
+          borderRadius: 'var(--radius-lg)',
+          minHeight: '160px'
+        }}>
+          {keywords.map((item, index) => {
+            // Scale font size from 0.85rem to 2rem
+            const ratio = item.value / maxValue
+            const fontSize = `${0.85 + ratio * 1.15}rem`
+            const isSkill = item.type === 'skill'
+            
+            // Premium colors: skills glow purple/indigo, general keywords are bright slate/white
+            const color = isSkill ? `rgba(129, 140, 248, ${0.6 + ratio * 0.4})` : `rgba(241, 245, 249, ${0.4 + ratio * 0.6})`
+            const fontWeight = isSkill ? '700' : '500'
+
+            return (
+              <span
+                key={index}
+                style={{
+                  fontSize,
+                  color,
+                  fontWeight,
+                  textShadow: isSkill ? '0 0 10px rgba(99, 102, 241, 0.2)' : 'none',
+                  cursor: 'default',
+                  transition: 'transform 0.2s',
+                }}
+                className="word-cloud-item"
+                title={`Frequency: ${item.value} (${item.type === 'skill' ? 'Core Skill' : 'Frequent Word'})`}
+              >
+                {item.text}
+              </span>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Row: Filter and Ranked List */}
+      <div className="card glass-card p-4">
+        <div style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: '12px',
+          marginBottom: '16px'
+        }}>
+          <h3 style={{ fontSize: '1.15rem', fontWeight: '700', margin: 0, color: '#fff' }}>
+            📊 Ranked Keywords ({filtered.length})
+          </h3>
+          <input
+            type="text"
+            placeholder="Filter keywords..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            style={{
+              padding: '6px 12px',
+              borderRadius: 'var(--radius-md)',
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+              background: 'rgba(0, 0, 0, 0.2)',
+              color: '#fff',
+              outline: 'none',
+              width: '200px',
+              fontSize: '0.85rem'
+            }}
+          />
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: '12px' }}>
+          {filtered.map((item, index) => {
+            const isSkill = item.type === 'skill'
+            return (
+              <div
+                key={index}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  padding: '10px 14px',
+                  background: 'rgba(255,255,255,0.03)',
+                  border: '1px solid rgba(255,255,255,0.05)',
+                  borderRadius: 'var(--radius-md)',
+                  transition: 'background-color 0.2s'
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <span style={{ fontSize: '0.82rem', color: 'rgba(255,255,255,0.4)', fontWeight: '600' }}>
+                    #{index + 1}
+                  </span>
+                  <span style={{ fontWeight: '600', color: '#fff', fontSize: '0.92rem' }}>
+                    {item.text}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <span style={{
+                    fontSize: '0.7rem',
+                    fontWeight: '700',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                    padding: '2px 6px',
+                    borderRadius: '4px',
+                    background: isSkill ? 'rgba(34, 197, 94, 0.15)' : 'rgba(255, 255, 255, 0.05)',
+                    color: isSkill ? '#4ade80' : 'rgba(255,255,255,0.6)',
+                  }}>
+                    {isSkill ? 'Skill' : 'Word'}
+                  </span>
+                  <span style={{
+                    fontSize: '0.85rem',
+                    fontWeight: '700',
+                    color: '#6366f1',
+                    background: 'rgba(99, 102, 241, 0.1)',
+                    borderRadius: 'var(--radius-md)',
+                    padding: '2px 8px',
+                    minWidth: '28px',
+                    textAlign: 'center'
+                  }}>
+                    {item.value}
+                  </span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useAnalysisHistory.ts
+++ b/frontend/src/hooks/useAnalysisHistory.ts
@@ -14,6 +14,7 @@ export interface AnalysisEntry {
   share_id?: string
   coverLetterText?: string
   coverLetterFeedback?: any
+  interviewQuestions?: string[]
 }
 
 const STORAGE_KEY = 'resume_analysis_history'

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
       'Referrer-Policy': 'strict-origin-when-cross-origin',
     },
   },
+  build: {
+    rollupOptions: {
+      external: ['html2canvas'],
+    },
+    rolldownOptions: {
+      external: ['html2canvas'],
+    },
+  },
   // @ts-expect-error vitest options
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
Resolves #382. Adds a standalone Job Description (JD) keyword-frequency visualizer allowing users to analyze job listings independently of the resume upload flow.

## Key Changes
- **Backend**:
  - Implemented `POST /api/analyze-jd/` endpoint executing tokenization and frequency counting.
  - Implemented custom stop-words dictionary and skill matching algorithms.
  - Added comprehensive unit test suite in `tests.py`.
- **Frontend**:
  - Added a homepage toggle selection switcher (📄 Optimize Resume vs 💼 Analyze Job Description).
  - Built the `JdVisualizerPanel` featuring responsive word clouds, keyword search querying, and ranked frequency statistics.
