### PR TITLE
feat: add career track filter to template gallery

### DIFF
--- a/frontend/src/components/TemplateCard.tsx
+++ b/frontend/src/components/TemplateCard.tsx
@@ -6,6 +6,8 @@ interface TemplateCardProps {
   atsNote: string
   fileName: string // e.g., "modern.docx"
   imageSrc: string // public path to preview image
+  careerTrack?: string
+  designStyle?: string
 }
 
 export const TemplateCard: React.FC<TemplateCardProps> = ({

--- a/frontend/src/components/TemplateGallery.tsx
+++ b/frontend/src/components/TemplateGallery.tsx
@@ -1,14 +1,26 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { TemplateCard } from './TemplateCard'
 import '../components/AnalysisSkeleton/AnalysisSkeleton.css'
 
-const TEMPLATES = [
+interface Template {
+  name: string
+  description: string
+  atsNote: string
+  fileName: string
+  imageSrc: string
+  careerTrack: string
+  designStyle: string
+}
+
+const TEMPLATES: Template[] = [
   {
     name: 'Modern',
     description: 'A clean, modern layout with clear sections and plenty of white space.',
     atsNote: 'Optimized for ATS parsing – simple formatting, no tables.',
     fileName: 'modern.docx',
     imageSrc: '/templates/modern.png',
+    careerTrack: 'general',
+    designStyle: 'modern',
   },
   {
     name: 'Clean',
@@ -16,6 +28,8 @@ const TEMPLATES = [
     atsNote: 'Uses standard headings and bullet points – ATS friendly.',
     fileName: 'clean.docx',
     imageSrc: '/templates/clean.png',
+    careerTrack: 'general',
+    designStyle: 'minimal',
   },
   {
     name: 'Creative',
@@ -23,8 +37,18 @@ const TEMPLATES = [
     atsNote: 'No complex tables or graphics – plain text formatting.',
     fileName: 'creative.docx',
     imageSrc: '/templates/creative.png',
+    careerTrack: 'design',
+    designStyle: 'creative',
   },
+  // Add more templates here as needed — just set careerTrack/designStyle accordingly
 ]
+
+const CAREER_TRACKS = [
+  { value: 'all', label: 'All Tracks' },
+  { value: 'general', label: 'General / Corporate' },
+  { value: 'design', label: 'Design / Creative' },
+  { value: 'tech', label: 'Tech / Engineering' },
+] as const
 
 function TemplateCardSkeleton() {
   return (
@@ -67,6 +91,7 @@ function TemplateCardSkeleton() {
 
 export const TemplateGallery: React.FC = () => {
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading')
+  const [activeTrack, setActiveTrack] = useState<string>('all')
 
   useEffect(() => {
     let cancelled = false
@@ -79,6 +104,13 @@ export const TemplateGallery: React.FC = () => {
       clearTimeout(timer)
     }
   }, [])
+
+  const filteredTemplates = useMemo(() => {
+    if (activeTrack === 'all') return TEMPLATES
+    return TEMPLATES.filter((t) => t.careerTrack === activeTrack)
+  }, [activeTrack])
+
+  const handleReset = () => setActiveTrack('all')
 
   if (status === 'loading') {
     return (
@@ -122,23 +154,104 @@ export const TemplateGallery: React.FC = () => {
   }
 
   return (
-    <div
-      style={{
-        display: 'grid',
-        gap: '24px',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
-      }}
-    >
-      {TEMPLATES.map((t) => (
-        <TemplateCard
-          key={t.name}
-          name={t.name}
-          description={t.description}
-          atsNote={t.atsNote}
-          fileName={t.fileName}
-          imageSrc={t.imageSrc}
-        />
-      ))}
-    </div>
+    <>
+      {/* Filter bar */}
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: '8px',
+          marginBottom: '24px',
+        }}
+      >
+        <span style={{ fontWeight: 600, color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+          Career Track:
+        </span>
+        {CAREER_TRACKS.map((track) => (
+          <button
+            key={track.value}
+            onClick={() => setActiveTrack(track.value)}
+            className={
+              activeTrack === track.value ? 'app-btn app-btn--accent' : 'app-btn app-btn--secondary'
+            }
+            style={{
+              fontSize: '0.8rem',
+              padding: '4px 14px',
+              borderRadius: '20px',
+              cursor: 'pointer',
+              border: 'none',
+            }}
+            aria-pressed={activeTrack === track.value}
+          >
+            {track.label}
+          </button>
+        ))}
+
+        {activeTrack !== 'all' && (
+          <button
+            onClick={handleReset}
+            className="app-btn app-btn--secondary"
+            style={{
+              fontSize: '0.75rem',
+              padding: '4px 12px',
+              borderRadius: '20px',
+              cursor: 'pointer',
+              border: 'none',
+              marginLeft: 'auto',
+            }}
+            aria-label="Reset career track filter"
+          >
+            ✕ Clear filter
+          </button>
+        )}
+      </div>
+
+      {/* Result count */}
+      <p
+        style={{
+          fontSize: '0.85rem',
+          color: 'var(--text-secondary)',
+          marginBottom: '16px',
+        }}
+      >
+        {filteredTemplates.length === 0
+          ? 'No templates match the selected filter.'
+          : `Showing ${filteredTemplates.length} template${filteredTemplates.length > 1 ? 's' : ''}`}
+      </p>
+
+      {/* Grid */}
+      <div
+        style={{
+          display: 'grid',
+          gap: '24px',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+        }}
+      >
+        {filteredTemplates.length > 0 ? (
+          filteredTemplates.map((t) => (
+            <TemplateCard
+              key={t.name}
+              name={t.name}
+              description={t.description}
+              atsNote={t.atsNote}
+              fileName={t.fileName}
+              imageSrc={t.imageSrc}
+              careerTrack={t.careerTrack}
+              designStyle={t.designStyle}
+            />
+          ))
+        ) : (
+          <div style={{ gridColumn: '1 / -1', textAlign: 'center', padding: '32px 0' }}>
+            <p style={{ color: 'var(--text-secondary)', marginBottom: '8px' }}>
+              No templates for this track yet.
+            </p>
+            <button className="app-btn app-btn--secondary" onClick={handleReset}>
+              View all templates
+            </button>
+          </div>
+        )}
+      </div>
+    </>
   )
 }


### PR DESCRIPTION

## 📝 Description

Adds a career track filter to the template gallery so users can filter templates by career track instead of scrolling through a flat list. The filter bar appears above the grid with pill-style buttons for each track. Active filter is visually highlighted, a clear/reset button appears when a non-default filter is selected, and an empty state with a "View all templates" fallback is shown when no templates match.

## 🔗 Related Issue

Closes #409 

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [x] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)

<img width="1885" height="887" alt="career" src="https://github.com/user-attachments/assets/af8bb35a-be7e-421b-9441-297b417fea56" />

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)