### PR TITLE
feat: Add browser extension for one-click resume upload from job sites (#385)

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,32 @@
+# AI Resume Analyzer - Job Scraper Browser Extension
+
+This lightweight Manifest V3 browser extension allows you to scrape job titles and description bodies directly from sites like **LinkedIn** and **Indeed** and launch the AI Resume Analyzer web application with a single click.
+
+## Features
+- **Scrape Job Postings**: Automatically extracts the job role and detailed description from supported sites.
+- **Context Menu Integration**: Right-click anywhere on a job posting page and choose **"Analyze Job Posting with AI Resume Analyzer"** to launch the analysis.
+- **One-Click Extension Popup**: Quick access button from your toolbar.
+- **Default Resume Support**: Pre-loads your default resume from the web application's local storage automatically.
+
+---
+
+## Installation Instructions
+
+1. Open your browser and go to the Extensions page:
+   - **Chrome**: `chrome://extensions/`
+   - **Edge**: `edge://extensions/`
+   - **Brave**: `brave://extensions/`
+2. Enable **Developer mode** (typically a toggle switch in the upper-right corner).
+3. Click the **Load unpacked** button in the top-left.
+4. Select the `extension/` folder inside this repository root.
+5. Pin the extension to your toolbar for quick access!
+
+---
+
+## How to Set a Default Resume in the Web App
+
+To ensure the extension can preload a resume:
+1. Open the web app (e.g. `http://localhost:5173/`).
+2. Go to the **Profile** / **Settings** page (click your username in the top-right navbar).
+3. Under the **Default Resume** section, upload or select your primary resume, and click **Save as Default**.
+4. When launched from the extension, this resume will be pre-loaded and selected automatically!

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,47 @@
+// Context menu option
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: "analyze-job",
+    title: "Analyze Job Posting with AI Resume Analyzer",
+    contexts: ["all"]
+  });
+});
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === "analyze-job" && tab && tab.id) {
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ["content.js"]
+    }, (results) => {
+      if (chrome.runtime.lastError || !results || !results[0]) {
+        console.error("Scraping failed:", chrome.runtime.lastError);
+        return;
+      }
+      const data = results[0].result;
+      openApp(data);
+    });
+  }
+});
+
+// Listener for message from popup script
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "analyze") {
+    openApp(message.data);
+    sendResponse({ success: true });
+  }
+});
+
+function openApp(data) {
+  const baseUrl = "http://localhost:5173/";
+  const queryParams = new URLSearchParams();
+  
+  if (data.role) {
+    queryParams.append("role", data.role.trim());
+  }
+  if (data.job_description) {
+    queryParams.append("job_description", data.job_description.trim());
+  }
+  
+  const targetUrl = `${baseUrl}?${queryParams.toString()}`;
+  chrome.tabs.create({ url: targetUrl });
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,76 @@
+(() => {
+  // Scraper selectors
+  const selectors = {
+    linkedin: {
+      role: [
+        ".job-details-jobs-unified-top-card__job-title",
+        ".jobs-unified-top-card__job-title",
+        "h1.t-24",
+        "h1"
+      ],
+      description: [
+        "#job-details",
+        ".jobs-description-content__text",
+        ".jobs-description__content",
+        ".jobs-box__html-content"
+      ]
+    },
+    indeed: {
+      role: [
+        ".jobsearch-JobInfoHeader-title",
+        "h1.jobsearch-JobInfoHeader-title",
+        "h1"
+      ],
+      description: [
+        "#jobDescriptionText",
+        ".jobsearch-jobDescriptionText"
+      ]
+    }
+  };
+
+  const getElementText = (selectorList) => {
+    for (const selector of selectorList) {
+      const el = document.querySelector(selector);
+      if (el && el.innerText.trim()) {
+        return el.innerText.trim();
+      }
+    }
+    return "";
+  };
+
+  const host = window.location.hostname.toLowerCase();
+  let role = "";
+  let job_description = "";
+
+  if (host.includes("linkedin.com")) {
+    role = getElementText(selectors.linkedin.role);
+    job_description = getElementText(selectors.linkedin.description);
+  } else if (host.includes("indeed.com")) {
+    role = getElementText(selectors.indeed.role);
+    job_description = getElementText(selectors.indeed.description);
+  }
+
+  // Fallbacks
+  if (!role) {
+    // Attempt general heading
+    const mainHeading = document.querySelector("h1");
+    role = mainHeading ? mainHeading.innerText.trim() : document.title.split("-")[0].trim();
+  }
+
+  if (!job_description) {
+    // Attempt to grab selected text
+    const selectedText = window.getSelection().toString().trim();
+    if (selectedText) {
+      job_description = selectedText;
+    } else {
+      // Fallback to body text or article content
+      const article = document.querySelector("article");
+      job_description = article ? article.innerText.trim() : document.body.innerText.trim();
+    }
+  }
+
+  return {
+    role: role || "Frontend Developer",
+    job_description: job_description || ""
+  };
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "AI Resume Analyzer - Job Scraper",
+  "version": "1.0.0",
+  "description": "Scrapes job descriptions and titles to analyze against your resume in one click.",
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "contextMenus"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icon.png",
+      "48": "icon.png",
+      "128": "icon.png"
+    }
+  },
+  "icons": {
+    "16": "icon.png",
+    "48": "icon.png",
+    "128": "icon.png"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body {
+      width: 280px;
+      padding: 16px;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: #0f172a;
+      color: #f8fafc;
+      margin: 0;
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      border-bottom: 1px solid #334155;
+      padding-bottom: 12px;
+      margin-bottom: 16px;
+    }
+    .logo {
+      font-size: 1.5rem;
+    }
+    .title {
+      font-size: 1.1rem;
+      font-weight: 700;
+      background: linear-gradient(135deg, #3b82f6 0%, #a855f7 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin: 0;
+    }
+    .description {
+      font-size: 0.85rem;
+      color: #94a3b8;
+      line-height: 1.4;
+      margin-bottom: 18px;
+    }
+    .btn {
+      width: 100%;
+      background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+      color: #ffffff;
+      border: none;
+      padding: 10px 14px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      border-radius: 8px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      transition: opacity 0.2s ease;
+    }
+    .btn:hover {
+      opacity: 0.9;
+    }
+    .btn:active {
+      transform: scale(0.98);
+    }
+    .status {
+      font-size: 0.8rem;
+      color: #22c55e;
+      text-align: center;
+      margin-top: 10px;
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <span class="logo">🚀</span>
+    <h1 class="title">Resume Scraper</h1>
+  </div>
+  <p class="description">
+    Click the button below to scrape the job details from the current page and open them in the AI Resume Analyzer app.
+  </p>
+  <button id="scrape-btn" class="btn">
+    ⚡ Analyze Job Posting
+  </button>
+  <div id="status" class="status">Launching Analyzer App...</div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,50 @@
+document.getElementById("scrape-btn").addEventListener("click", async () => {
+  const statusDiv = document.getElementById("status");
+  statusDiv.style.display = "block";
+  statusDiv.innerText = "Scraping page details...";
+
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab || !tab.id) {
+      statusDiv.innerText = "Error: Active tab not found.";
+      statusDiv.style.color = "#ef4444";
+      return;
+    }
+
+    // Execute the scraper content script
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ["content.js"]
+    }, (results) => {
+      if (chrome.runtime.lastError || !results || !results[0]) {
+        console.error("Scrape failed:", chrome.runtime.lastError);
+        statusDiv.innerText = "Could not scrape. Opening default app...";
+        statusDiv.style.color = "#fbbf24";
+        
+        // Open app anyway with empty data
+        chrome.runtime.sendMessage({
+          action: "analyze",
+          data: { role: "", job_description: "" }
+        }, () => {
+          setTimeout(() => window.close(), 1500);
+        });
+        return;
+      }
+
+      const data = results[0].result;
+      statusDiv.innerText = "Launching Analyzer App...";
+      statusDiv.style.color = "#22c55e";
+
+      chrome.runtime.sendMessage({
+        action: "analyze",
+        data: data
+      }, () => {
+        setTimeout(() => window.close(), 1000);
+      });
+    });
+  } catch (err) {
+    console.error("Popup handler error:", err);
+    statusDiv.innerText = "Error launching app.";
+    statusDiv.style.color = "#ef4444";
+  }
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1424,7 +1424,8 @@ function App() {
                       </div>
 
                       {uploadMode === 'file' ? (
-                        <div
+                        <>
+                          <div
                           className={`upload-box mb-3 ${isDragging ? 'dragging' : ''}`}
                           style={{ width: '100%', maxWidth: '100%' }}
                           onDragOver={handleDragOver}
@@ -1581,6 +1582,7 @@ function App() {
                             </label>
                           </div>
                         )}
+                        </>
                       ) : (
                         <div className="mb-3" style={{ textAlign: 'left' }}>
                           <label

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -287,6 +287,8 @@ function App() {
   const [theme, setTheme] = useState<Theme>(getInitialTheme)
   const [loading, setLoading] = useState(false)
   const [file, setFile] = useState<File | null>(null)
+  const [useDefaultResume, setUseDefaultResume] = useState(false)
+  const [defaultResumeName, setDefaultResumeName] = useState<string | null>(null)
   const [retryAfter, setRetryAfter] = useState<number | null>(null)
   const [retryDisabled, setRetryDisabled] = useState(false)
   const [score, setScore] = useState<number | null>(null)
@@ -478,6 +480,37 @@ function App() {
   useEffect(() => {
     if (user) fetchDbHistory(user.token)
   }, [user, fetchDbHistory])
+
+  useEffect(() => {
+    try {
+      const savedName = localStorage.getItem('default_resume_name')
+      if (savedName) {
+        setDefaultResumeName(savedName)
+      }
+    } catch {
+      /* ignore */
+    }
+
+    const params = new URLSearchParams(window.location.search)
+    const urlRole = params.get('role')
+    const urlJd = params.get('job_description')
+
+    if (urlRole) {
+      setTargetRole(urlRole)
+    }
+    if (urlJd) {
+      setJobDesc(urlJd)
+    }
+
+    try {
+      const savedName = localStorage.getItem('default_resume_name')
+      if ((urlRole || urlJd) && savedName) {
+        setUseDefaultResume(true)
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [])
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
@@ -783,6 +816,22 @@ function App() {
     }
   }
 
+  const saveAsDefaultResume = (fileToSave: File) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      try {
+        localStorage.setItem('default_resume_base64', reader.result as string)
+        localStorage.setItem('default_resume_name', fileToSave.name)
+        localStorage.setItem('default_resume_type', fileToSave.type)
+        setDefaultResumeName(fileToSave.name)
+        alert(`Successfully set "${fileToSave.name}" as your default resume!`)
+      } catch (err) {
+        alert('Failed to save default resume to local storage.')
+      }
+    }
+    reader.readAsDataURL(fileToSave)
+  }
+
   const uploadResume = async () => {
     let hasError = false
 
@@ -793,8 +842,32 @@ function App() {
       setRoleError(null)
     }
 
+    let fileToAnalyze: File | null = file
+
     if (uploadMode === 'file') {
-      if (!file) {
+      if (useDefaultResume) {
+        try {
+          const b64 = localStorage.getItem('default_resume_base64')
+          const name = localStorage.getItem('default_resume_name')
+          const type = localStorage.getItem('default_resume_type')
+          if (b64 && name && type) {
+            const byteString = atob(b64.split(',')[1])
+            const ab = new ArrayBuffer(byteString.length)
+            const ia = new Uint8Array(ab)
+            for (let i = 0; i < byteString.length; i++) {
+              ia[i] = byteString.charCodeAt(i)
+            }
+            fileToAnalyze = new File([ab], name, { type })
+            setFileError(null)
+          } else {
+            setFileError('No default resume is currently saved.')
+            hasError = true
+          }
+        } catch {
+          setFileError('Failed to load the default resume. Please upload manually.')
+          hasError = true
+        }
+      } else if (!file) {
         setFileError('Please upload a resume file before analyzing.')
         hasError = true
       } else {
@@ -825,7 +898,7 @@ function App() {
 
     await requestNotificationPermission()
     if (uploadMode === 'file') {
-      await runAnalysis(file!, 'upload')
+      await runAnalysis(fileToAnalyze, 'upload')
     } else {
       await runAnalysis(null, 'upload', resumeUrl.trim())
     }
@@ -1415,8 +1488,42 @@ function App() {
                               )}
                             </div>
                             <div style={{ textAlign: 'center' }}>
-                              {file ? (
-                                <strong className="upload-file-name">{file.name}</strong>
+                              {useDefaultResume && defaultResumeName ? (
+                                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px' }}>
+                                  <span style={{ fontSize: '1.5rem' }}>✅</span>
+                                  <strong className="upload-file-name" style={{ color: '#4ade80' }}>
+                                    Default Resume Pre-loaded: {defaultResumeName}
+                                  </strong>
+                                  <span style={{ fontSize: '0.78rem', color: '#94a3b8' }}>
+                                    (Uncheck the default option below to upload another file)
+                                  </span>
+                                </div>
+                              ) : file ? (
+                                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px' }}>
+                                  <strong className="upload-file-name">{file.name}</strong>
+                                  {defaultResumeName !== file.name && (
+                                    <button
+                                      type="button"
+                                      onClick={(e) => {
+                                        e.preventDefault()
+                                        e.stopPropagation()
+                                        saveAsDefaultResume(file)
+                                      }}
+                                      style={{
+                                        padding: '4px 10px',
+                                        fontSize: '0.78rem',
+                                        borderRadius: 'var(--radius-sm)',
+                                        border: '1px solid var(--color-primary)',
+                                        background: 'rgba(99, 102, 241, 0.1)',
+                                        color: '#a5b4fc',
+                                        cursor: 'pointer',
+                                        transition: 'background 0.2s'
+                                      }}
+                                    >
+                                      💾 Save as Default
+                                    </button>
+                                  )}
+                                </div>
                               ) : (
                                 <>
                                   <span className="upload-text-primary">
@@ -1431,6 +1538,49 @@ function App() {
                             </div>
                           </label>
                         </div>
+
+                        {defaultResumeName && (
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              gap: '8px',
+                              marginTop: '-8px',
+                              marginBottom: '16px',
+                              background: 'rgba(99, 102, 241, 0.05)',
+                              border: '1px solid rgba(99, 102, 241, 0.2)',
+                              borderRadius: 'var(--radius-md)',
+                              padding: '10px 14px'
+                            }}
+                          >
+                            <input
+                              type="checkbox"
+                              id="useDefaultResume"
+                              checked={useDefaultResume}
+                              onChange={(e) => {
+                                setUseDefaultResume(e.target.checked)
+                                if (e.target.checked) {
+                                  setFile(null)
+                                  setFileError(null)
+                                }
+                              }}
+                              style={{ width: '16px', height: '16px', cursor: 'pointer' }}
+                            />
+                            <label
+                              htmlFor="useDefaultResume"
+                              style={{
+                                color: '#e2e8f0',
+                                fontSize: '0.88rem',
+                                cursor: 'pointer',
+                                fontWeight: '500',
+                                userSelect: 'none'
+                              }}
+                            >
+                              📂 Use saved default resume: <span style={{ color: '#a5b4fc', fontWeight: '600' }}>{defaultResumeName}</span>
+                            </label>
+                          </div>
+                        )}
                       ) : (
                         <div className="mb-3" style={{ textAlign: 'left' }}>
                           <label


### PR DESCRIPTION
Resolves #385. Builds a lightweight Manifest V3 browser extension to scrape job details (title and description) from sites like LinkedIn/Indeed and launch the app in one click. Integrates default resume pre-loading in the frontend web application and adds loading instructions in extension/README.md.
