### PR TITLE
enhancement: add icon and styled empty state to history sidebar panel

### DIFF
--- a/frontend/src/HistorySidebar.tsx
+++ b/frontend/src/HistorySidebar.tsx
@@ -143,7 +143,13 @@ export const HistorySidebar: React.FC<HistorySidebarProps> = ({
         </div>
 
         {entries.length === 0 ? (
-          <p className="history-empty">No notifications or past analyses yet.</p>
+          <div className="history-empty">
+            <ClipboardList size={32} style={{ marginBottom: '12px', opacity: 0.45 }} />
+            <p style={{ margin: '0 0 6px', fontWeight: 600, opacity: 0.75 }}>No analyses yet</p>
+            <p style={{ margin: 0, fontSize: 'var(--text-sm)', opacity: 0.5 }}>
+              Upload a resume to see your history here.
+            </p>
+          </div>
         ) : (
           <>
             <ul className="history-list">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -735,10 +735,15 @@ h3 {
 }
 
 .history-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
-  opacity: 0.6;
-  margin-top: 40px;
+  opacity: 0.9;
+  margin-top: 48px;
+  padding: 0 16px;
   font-size: var(--text-sm);
+  color: var(--muted-text);
 }
 
 .history-list {


### PR DESCRIPTION
## 📝 Description

This PR improves the empty state of the Notifications & Past Analyses panel by adding a matching icon alongside the existing message. The updated design aligns with the application's other empty states, providing a more polished and consistent user experience.

### Changes Made

* Added an appropriate empty state icon to the Notifications & Past Analyses panel.
* Updated the empty state layout to match the styling used across the application.
* Ensured the empty state displays correctly in both light and dark mode.

## 🔗 Related Issue

Closes #411 

## ✅ Type of Change

* [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 📚 Documentation update
* [x] 💅 UI/UX improvement
* [ ] ♻️ Refactor (no functional change)
* [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

* [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
* [x] Backend tests pass (`python manage.py test analyzer`)
* [x] Manually tested in the browser / API client

  * Verified the empty state displays the icon and message correctly.
  * Confirmed visual consistency with other empty states in the application.
  * Verified proper appearance in both light and dark themes.

## 📸 Screenshots (if applicable)

<img width="1892" height="705" alt="image" src="https://github.com/user-attachments/assets/409cf770-6a83-4e18-a840-1b2e65c02e16" />


## 📋 Checklist

* [x] My code follows the project's style and conventions
* [x] I have linked the related issue above
* [x] I have read the [[Code of Conduct](https://chatgpt.com/c/CODE_OF_CONDUCT.md)](CODE_OF_CONDUCT.md)