### PR TITLE
fix: point Workspace Top footer link to #main-content instead of bare hash

### DIFF
--- a/frontend/src/Footer.tsx
+++ b/frontend/src/Footer.tsx
@@ -78,7 +78,7 @@ export const Footer: React.FC = () => {
           >
             <li>
               <a
-                href="#"
+                href="#main-content"
                 style={{
                   color: '#94a3b8',
                   fontSize: 'var(--font-size-sm)',


### PR DESCRIPTION
## 📝 Description
Verified both footer navigation links per issue #448. "Career Tracks" (href="#roleSelect") already correctly targets the career-track selector in App.tsx and needed no change. "Workspace Top" was `href="#"` — a bare hash with no real anchor — and only appeared to work via the browser's default scroll-to-top behavior rather than an intentional link.

Fixed "Workspace Top" to point at the existing `main-content` id on the landing page's `<main>` element (App.tsx), matching the pattern the Career Tracks link already uses.

## 🔗 Related Issue
Closes #448

## ✅ Type of Change
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## 🧪 How Has This Been Tested?
- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)
N/A — one-line link target change, no visual difference.

## 📋 Checklist
- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the Code of Conduct

 