### PR TITLE
feat: add dynamic per-result meta tags for shared result links

### DIFF
--- a/api/share.js
+++ b/api/share.js
@@ -1,0 +1,69 @@
+export default async function handler(req, res) {
+  const { id } = req.query;
+
+  try {
+    const backendUrl = process.env.VITE_BACKEND_URL || 'https://ai-resume-analyzer-backend.onrender.com';
+    const apiRes = await fetch(`${backendUrl}/api/shared/${id}/`); 
+    let data = null;
+    if (apiRes.ok) {
+      data = await apiRes.json();
+    }
+    const protocol = req.headers['x-forwarded-proto'] || 'https';
+    const host = req.headers.host;
+    const htmlRes = await fetch(`${protocol}://${host}/`);
+    let html = await htmlRes.text();
+    if (data && data.score !== undefined) {
+      const targetRole = data.target_role || 'Not specified';
+      const dynamicTitle = `Score: ${data.score}% — AI Resume Analyzer`;
+      const dynamicDesc = `Target Role: ${targetRole}. View the full ATS analysis!`;
+
+      html = html.replace(
+        /<title>.*?<\/title>/i,
+        `<title>${dynamicTitle}</title>`
+      );
+
+      html = html.replace(
+        /<meta\s+name="title"\s+content=".*?"\s*\/?>/i,
+        `<meta name="title" content="${dynamicTitle}" />`
+      );
+      html = html.replace(
+        /<meta\s+name="description"\s+content=".*?"\s*\/?>/i,
+        `<meta name="description" content="${dynamicDesc}" />`
+      );
+
+      html = html.replace(
+        /<meta\s+property="og:title"\s+content=".*?"\s*\/?>/i,
+        `<meta property="og:title" content="${dynamicTitle}" />`
+      );
+      html = html.replace(
+        /<meta\s+property="og:description"\s+content=".*?"\s*\/?>/i,
+        `<meta property="og:description" content="${dynamicDesc}" />`
+      );
+
+      html = html.replace(
+        /<meta\s+name="twitter:title"\s+content=".*?"\s*\/?>/i,
+        `<meta name="twitter:title" content="${dynamicTitle}" />`
+      );
+      html = html.replace(
+        /<meta\s+name="twitter:description"\s+content=".*?"\s*\/?>/i,
+        `<meta name="twitter:description" content="${dynamicDesc}" />`
+      );
+    }
+
+    res.setHeader('Content-Type', 'text/html');
+    res.status(200).send(html);
+
+  } catch (error) {
+    console.error('Error generating dynamic OG tags:', error);
+    try {
+      const protocol = req.headers['x-forwarded-proto'] || 'https';
+      const host = req.headers.host;
+      const fallbackHtmlRes = await fetch(`${protocol}://${host}/`);
+      const fallbackHtml = await fallbackHtmlRes.text();
+      res.setHeader('Content-Type', 'text/html');
+      res.status(200).send(fallbackHtml);
+    } catch (e) {
+      res.status(500).send('Internal Server Error');
+    }
+  }
+}

--- a/frontend/api/share.js
+++ b/frontend/api/share.js
@@ -1,0 +1,77 @@
+export default async function handler(req, res) {
+  const { id } = req.query;
+
+  try {
+    const backendUrl = process.env.VITE_BACKEND_URL || 'https://ai-resume-analyzer-backend.onrender.com';
+    const apiRes = await fetch(`${backendUrl}/api/shared/${id}/`); 
+    let data = null;
+    if (apiRes.ok) {
+      data = await apiRes.json();
+    }
+
+    const protocol = req.headers['x-forwarded-proto'] || 'https';
+    const host = req.headers.host;
+
+    const htmlRes = await fetch(`${protocol}://${host}/`);
+    let html = await htmlRes.text();
+
+    if (data && data.score !== undefined) {
+      const targetRole = data.target_role || 'Not specified';
+      const dynamicTitle = `Score: ${data.score}% — AI Resume Analyzer`;
+      const dynamicDesc = `Target Role: ${targetRole}. View the full ATS analysis!`;
+
+      
+      html = html.replace(
+        /<title>.*?<\/title>/i,
+        `<title>${dynamicTitle}</title>`
+      );
+
+      html = html.replace(
+        /<meta\s+name="title"\s+content=".*?"\s*\/?>/i,
+        `<meta name="title" content="${dynamicTitle}" />`
+      );
+      html = html.replace(
+        /<meta\s+name="description"\s+content=".*?"\s*\/?>/i,
+        `<meta name="description" content="${dynamicDesc}" />`
+      );
+
+     
+      html = html.replace(
+        /<meta\s+property="og:title"\s+content=".*?"\s*\/?>/i,
+        `<meta property="og:title" content="${dynamicTitle}" />`
+      );
+      html = html.replace(
+        /<meta\s+property="og:description"\s+content=".*?"\s*\/?>/i,
+        `<meta property="og:description" content="${dynamicDesc}" />`
+      );
+
+     
+      html = html.replace(
+        /<meta\s+name="twitter:title"\s+content=".*?"\s*\/?>/i,
+        `<meta name="twitter:title" content="${dynamicTitle}" />`
+      );
+      html = html.replace(
+        /<meta\s+name="twitter:description"\s+content=".*?"\s*\/?>/i,
+        `<meta name="twitter:description" content="${dynamicDesc}" />`
+      );
+    }
+
+    
+    res.setHeader('Content-Type', 'text/html');
+    res.status(200).send(html);
+
+  } catch (error) {
+    console.error('Error generating dynamic OG tags:', error);
+    
+    try {
+      const protocol = req.headers['x-forwarded-proto'] || 'https';
+      const host = req.headers.host;
+      const fallbackHtmlRes = await fetch(`${protocol}://${host}/`);
+      const fallbackHtml = await fallbackHtmlRes.text();
+      res.setHeader('Content-Type', 'text/html');
+      res.status(200).send(fallbackHtml);
+    } catch (e) {
+      res.status(500).send('Internal Server Error');
+    }
+  }
+}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -21,5 +21,15 @@
         }
       ]
     }
+  ],
+  "rewrites": [
+    {
+      "source": "/share/:id",
+      "destination": "/api/share?id=:id"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -21,5 +21,15 @@
         }
       ]
     }
+  ],
+  "rewrites": [
+    {
+      "source": "/share/:id",
+      "destination": "/api/share?id=:id"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
## 📝 Description

Added dynamic Open Graph (OG) meta tags for shared result URLs so that link previews display meaningful data on social platforms (e.g., showing "Score: 82% — AI Resume Analyzer" instead of generic site tags).

Because social media crawlers do not execute React/Client-Side routing reliably, this was implemented using **Vercel Serverless Functions** (`api/share.js`) and `vercel.json` rewrites.

- Requests to /share/:id are intercepted by the serverless function.
- The function fetches the specific analysis data from the Django backend.
- It injects the specific Score and Target Role into the raw index.html <meta> tags and returns it to the crawler.
- All other routes fall back normally without disrupting the Vite SPA.


(Note: `api/share.js` and `vercel.json` updates were applied to both the project root and frontend/ directory to ensure seamless deployment regardless of how the Vercel Root Directory is configured).

## 🔗 Related Issue


Closes #357 

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

<!-- Describe the steps you took to verify your change. -->
- [X] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [X] Backend tests pass (`python manage.py test analyzer`)
- [X] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)
N/A

## 📋 Checklist

- [X] My code follows the project's style and conventions
- [X] I have linked the related issue above
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
