### PR TITLE
fix: upgrade password hashing to Argon2 with PBKDF2 migration path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Authentication modal enhancements.
 - Resume thumbnail/file preview (name, size, type icon) shown immediately after file selection, before analysis (#140).
 ### Changed
+- Password hashing now uses Argon2 as the primary hasher, with PBKDF2 retained as a fallback so existing users are transparently migrated to Argon2 on their next successful login (#478).
 - Compressed static raster images and added WebP optimized assets reducing total image bundle size from ~1.15 MB to ~956 KB (16.8% reduction) with no visible quality loss (#353).
 - Improved onboarding experience and user interface consistency.
 - Enhanced visual styling across the application.

--- a/backend/SECURITY_AUDIT.md
+++ b/backend/SECURITY_AUDIT.md
@@ -1,0 +1,43 @@
+﻿# Password Hashing Audit — Issue #478
+
+## Scope
+Reviewed how user passwords are hashed, stored, and verified across
+signup, login, and password-reset flows.
+
+## Findings
+
+- The project uses Django's built-in `django.contrib.auth.models.User`.
+- No `PASSWORD_HASHERS` override existed previously, so Django's
+  default hasher list applied — headed by `PBKDF2PasswordHasher`
+  (SHA256), which on Django >=4.2 uses 720,000+ iterations. This
+  already meets OWASP's minimum recommendation and was **not** weak
+  or outdated.
+- Signup (`SignupSerializer.create`) uses
+  `User.objects.create_user(**validated_data)`, which calls Django's
+  `set_password()` internally — passwords are always hashed, never
+  stored in plaintext.
+- Password reset (`PasswordResetConfirmView`) calls
+  `user.set_password(new_password)` — also correctly hashed.
+- No plaintext or reversibly-encrypted password storage was found
+  anywhere in the codebase.
+
+## Change made
+
+`PASSWORD_HASHERS` in `settings.py` now explicitly lists
+`Argon2PasswordHasher` first (OWASP's top recommendation), keeping
+`PBKDF2PasswordHasher` / `PBKDF2SHA1PasswordHasher` as fallback
+verifiers.
+
+## Migration path for existing users
+
+No bulk migration is required. Django checks a user's stored hash
+against the *first* hasher in `PASSWORD_HASHERS` on every login; if it
+was hashed with an older algorithm still present in the list (PBKDF2),
+it verifies successfully and is transparently re-hashed to Argon2
+before the request completes. Users who never log in again keep their
+PBKDF2 hash, which remains valid and secure.
+
+## Dependency
+
+Added `argon2-cffi` to `backend/requirements.txt` (required by Django
+for `Argon2PasswordHasher` to function).

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ textstat>=0.7.13
 pytest>=8.0.0
 pytest-django>=4.8.0
 
+argon2-cffi>=23.1.0

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -83,6 +83,18 @@ DATABASES = {
     }
 }
 
+# Password hashing: Argon2 (OWASP-recommended, winner of the Password
+# Hashing Competition) is tried first for all new/changed passwords.
+# PBKDF2 hashers stay listed so existing users' current PBKDF2 hashes
+# still verify correctly on login. Django transparently re-hashes each
+# user's password to Argon2 the moment they next log in successfully —
+# no bulk migration script needed. See SECURITY_AUDIT.md for the full
+# audit writeup (issue #478).
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+]
 
 AUTH_PASSWORD_VALIDATORS = [
     {


### PR DESCRIPTION
Closes #478

## 📝 Description
Audited the password hashing implementation (see `backend/SECURITY_AUDIT.md`
for full findings). The existing setup used Django's default PBKDF2
hasher, which was already adequate (720,000+ iterations on Django
>=4.2) and not weak or outdated — no plaintext or reversible storage
was found anywhere in the signup, login, or password-reset flows.

Upgraded `PASSWORD_HASHERS` to try Argon2 (OWASP's top recommendation)
first, while keeping PBKDF2 listed so existing users' hashes still
verify. Django transparently re-hashes each user's password to Argon2
on their next successful login — no bulk migration script needed.

## 🔗 Related Issue
Closes #478

## ✅ Type of Change
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## 🧪 How Has This Been Tested?
- [x] Backend tests pass (`python manage.py test analyzer`) — ran on
      both a clean `upstream/main` and this branch. 3 pre-existing
      failures (`CaptchaProtectionTests`, `ProfileAvatarTests`)
      reproduce identically on clean `main` and are unrelated to this
      change (missing local CAPTCHA env config, not touched by this
      PR). No new failures introduced.
- [x] Manually verified in Django shell that `make_password()` now
      produces `argon2$argon2id$...` hashes and `check_password()`
      verifies them correctly.
- [ ] Frontend builds/lints — not applicable, this PR only touches
      backend files plus documentation.

**Note for maintainer:** found a pre-existing migration graph conflict
on `main` (three `0009_merge_*` leaf nodes in `analyzer/migrations/`),
unrelated to this change. Happy to open a separate issue/PR for that
if useful.

## 📋 Checklist
- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the Code of Conduct