### PR TITLE
docs: add 'search existing issues first' in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,10 +206,23 @@ refactor: simplify parser logic
 
 Before creating a new issue:
 
-- Search existing issues first.
+- Search existing issues first (see below for more details).
 - Include clear steps to reproduce.
 - Attach screenshots if applicable.
 - Mention your operating system and browser when relevant.
+
+## 🔍 Search Existing Issues First
+
+Before opening a new issue, please take a moment to search the existing issues to see if your bug report, feature request, or question has already been discussed. This helps reduce duplicates and keeps issue discussions organized.
+
+**Tip:** Use GitHub's issue search filters to narrow your results. For example:
+
+```text
+is:issue is:open label:bug login
+```
+
+This searches for open issues labeled `bug` containing the keyword `login`. You can replace `bug` and `login` with labels or keywords relevant to your issue.
+
 
 ---
 


### PR DESCRIPTION
## 📝 Description

Added a new "Search Existing Issues First" section to CONTRIBUTING.md, encouraging contributors to search for existing issues before opening a new one. The section also includes a concise example of GitHub issue search filters to help contributors quickly find related discussions and reduce duplicate issues.

## 🔗 Related Issue

Closes #501 

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

<!-- Describe the steps you took to verify your change. -->
- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`)
- [ ] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)

N/A.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)