### PR TITLE
feat: auto-purge uploaded resumes after retention period

### DIFF
--- a/backend/analyzer/management/commands/purge_expired_resumes.py
+++ b/backend/analyzer/management/commands/purge_expired_resumes.py
@@ -1,0 +1,93 @@
+import os
+import time
+from datetime import timedelta
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.utils.timezone import now
+from analyzer.models import Resume
+
+
+def remove_old_files_in_dir(dir_path, cutoff_ts, stdout):
+    deleted = 0
+    if not os.path.isdir(dir_path):
+        return deleted
+
+    for fname in os.listdir(dir_path):
+        fpath = os.path.join(dir_path, fname)
+        try:
+            if os.path.isfile(fpath):
+                mtime = os.path.getmtime(fpath)
+                if mtime < cutoff_ts:
+                    try:
+                        os.remove(fpath)
+                        deleted += 1
+                        stdout.write(f"Deleted file: {fpath}")
+                    except Exception as e:
+                        stdout.write(f"Failed to delete {fpath}: {e}")
+        except Exception as e:
+            stdout.write(f"Error inspecting {fpath}: {e}")
+    return deleted
+
+
+class Command(BaseCommand):
+    help = "Purge uploaded resume files (tmp and media/resumes) older than RESUME_RETENTION_DAYS setting."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show files that would be deleted without removing them.",
+        )
+
+    def handle(self, *args, **options):
+        days = getattr(settings, "RESUME_RETENTION_DAYS", 30)
+        dry_run = options.get("dry_run", False)
+
+        try:
+            days = int(days)
+        except Exception:
+            days = 30
+
+        cutoff = now() - timedelta(days=days)
+        cutoff_ts = cutoff.timestamp()
+
+        total_deleted = 0
+        self.stdout.write(f"Purging resume files older than {days} days (cutoff: {cutoff.isoformat()})")
+
+        # 1) Clean tmp directory used by uploads
+        tmp_dir = os.path.join(settings.BASE_DIR, "tmp")
+        if dry_run:
+            self.stdout.write(f"[DRY-RUN] Would scan tmp dir: {tmp_dir}")
+        else:
+            deleted_tmp = remove_old_files_in_dir(tmp_dir, cutoff_ts, self.stdout)
+            total_deleted += deleted_tmp
+
+        # 2) Clean media/resumes directory (files not tracked by model or direct uploads)
+        media_resumes_dir = os.path.join(settings.MEDIA_ROOT, "resumes")
+        if dry_run:
+            self.stdout.write(f"[DRY-RUN] Would scan media resumes dir: {media_resumes_dir}")
+        else:
+            deleted_media = remove_old_files_in_dir(media_resumes_dir, cutoff_ts, self.stdout)
+            total_deleted += deleted_media
+
+        # 3) Delete Resume model instances and associated files older than cutoff
+        try:
+            expired_qs = Resume.objects.filter(uploaded_at__lt=cutoff)
+            count_qs = expired_qs.count()
+            self.stdout.write(f"Found {count_qs} Resume model instance(s) older than cutoff.")
+
+            if not dry_run:
+                for r in expired_qs:
+                    try:
+                        if r.file:
+                            # delete the file from storage
+                            r.file.delete(save=False)
+                        r.delete()
+                        total_deleted += 1
+                        self.stdout.write(f"Deleted Resume model and file for id={r.id}")
+                    except Exception as e:
+                        self.stdout.write(f"Failed to delete Resume id={r.id}: {e}")
+        except Exception as e:
+            self.stdout.write(f"Failed to query Resume model: {e}")
+
+        self.stdout.write(self.style.SUCCESS(f"Purge complete. Total deleted items: {total_deleted}"))

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -151,6 +151,8 @@ REST_FRAMEWORK = {
 
 # Rate limiting: resume upload endpoint
 RESUME_UPLOAD_RATE = os.environ.get('RESUME_UPLOAD_RATE', '10/hour')
+# Retention (in days) for uploaded resume files and temporary storage
+RESUME_RETENTION_DAYS = int(os.environ.get('RESUME_RETENTION_DAYS', '30'))
 
 SENTRY_DSN = os.environ.get('SENTRY_DSN')
 


### PR DESCRIPTION
Related Issue
Closes #477 

Why

Uploaded resume files (and temporary upload artifacts) can contain sensitive personal data and should not be retained indefinitely. This change implements an automated purge to improve privacy hygiene for one-off or anonymous analyses.

Approach

- Adds RESUME_RETENTION_DAYS setting (default 30 days) to backend/resume_analyzer/settings.py so operators can configure retention via env var.
- Adds a Django management command analyzer.management.commands.purge_expired_resumes which:
  - Scans BASE_DIR/tmp and MEDIA_ROOT/resumes and deletes files older than RESUME_RETENTION_DAYS.
  - Deletes Resume model instances (and their stored files) older than the cutoff.
  - Supports a --dry-run mode for safe inspection.

Testing

- Dry run: python manage.py purge_expired_resumes --dry-run
- Actual run: python manage.py purge_expired_resumes

Deployment / scheduling

- Schedule daily (example cron):
  0 3 * * * cd /path/to/project && /path/to/venv/bin/python manage.py purge_expired_resumes
- Alternatively use platform scheduler (Heroku scheduler, systemd timer, GitHub Actions workflow, etc.).

Config

- Override default retention via RESUME_RETENTION_DAYS env var (integer days).

Notes / considerations

- The command deletes files in tmp/ and media/resumes and removes Resume model rows older than the retention cutoff. ResumeAnalysis records are not touched by this change.
- No additional dependencies added. Command is idempotent and safe to run frequently.
- Recommend scheduling as part of regular maintenance to enforce privacy retention.
