### PR TITLE
Validate resume uploads (PDF + size checks)

### DIFF
--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -64,6 +64,52 @@ def verify_captcha_token(token_string):
     return False
 
 
+MAX_UPLOAD_SIZE = getattr(settings, "MAX_UPLOAD_SIZE_BYTES", 5 * 1024 * 1024)  # 5MB
+
+def is_pdf_file(f):
+    """Return True if uploaded file looks like a PDF (content-type or magic bytes)."""
+    try:
+        content_type = getattr(f, "content_type", "")
+        if content_type == "application/pdf":
+            return True
+        # Try reading magic bytes; preserve file position if possible
+        try:
+            pos = f.tell()
+        except Exception:
+            pos = None
+        try:
+            header = f.read(4)
+        except Exception:
+            header = b''
+        try:
+            if pos is not None:
+                f.seek(pos)
+            else:
+                f.seek(0)
+        except Exception:
+            pass
+        return isinstance(header, (bytes, bytearray)) and header.startswith(b"%PDF")
+    except Exception:
+        return False
+
+
+def validate_uploaded_file(f, allowed_exts=(".pdf",)):
+    """Validate uploaded file: non-empty, within size limit, allowed extension, and PDF magic bytes."""
+    if not f:
+        raise ValueError("No file uploaded")
+    size = getattr(f, "size", 0)
+    if size == 0:
+        raise ValueError("Uploaded file is empty")
+    if size > MAX_UPLOAD_SIZE:
+        raise ValueError(f"File exceeds maximum allowed size of {MAX_UPLOAD_SIZE // (1024*1024)}MB")
+    name = getattr(f, "name", "")
+    if not any(name.lower().endswith(ext) for ext in allowed_exts):
+        raise ValueError("Only PDF files are allowed")
+    if not is_pdf_file(f):
+        raise ValueError("Uploaded file is not a valid PDF")
+    return True
+
+
 @api_view(["POST"])
 @permission_classes([AllowAny])
 def signup(request):
@@ -96,6 +142,13 @@ def upload_resume(request):
     url = request.data.get("url") or request.data.get("resume_url")
     target_role = request.data.get("role", "")
     job_desc = request.data.get("job_description", "")[:2000]
+
+    # Server-side validation for direct uploads (always enforce on backend)
+    if file and not url:
+        try:
+            validate_uploaded_file(file)
+        except ValueError as ve:
+            return Response({"error": str(ve)}, status=status.HTTP_400_BAD_REQUEST)
 
     if not file and not url:
         return Response(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,6 +63,8 @@ function App() {
   const [theme, setTheme] = useState<Theme>(getInitialTheme)
   const [loading, setLoading] = useState(false)
   const [file, setFile] = useState<File | null>(null)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
   const [isDragging, setIsDragging] = useState(false)
   const [score, setScore] = useState<number | null>(null)
   const [skills, setSkills] = useState<string[]>([])
@@ -218,6 +220,10 @@ function App() {
   const uploadResume = async () => {
     if (!file) {
       alert('Please upload resume')
+      return
+    }
+    if (uploadError) {
+      alert(uploadError)
       return
     }
     if (cooldownRemaining > 0) {
@@ -376,16 +382,55 @@ function App() {
               e.preventDefault()
               setIsDragging(false)
               if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-                setFile(e.dataTransfer.files[0])
+                const f = e.dataTransfer.files[0]
+                setUploadError(null)
+                if (!f.name.toLowerCase().endsWith('.pdf') || f.type !== 'application/pdf') {
+                  setUploadError('Please upload a valid PDF file.')
+                  setFile(null)
+                  return
+                }
+                if (f.size === 0) {
+                  setUploadError('Uploaded file is empty.')
+                  setFile(null)
+                  return
+                }
+                if (f.size > MAX_FILE_SIZE) {
+                  setUploadError('File is too large. Maximum allowed size is 5MB.')
+                  setFile(null)
+                  return
+                }
+                setFile(f)
               }
             }}
           >
             <input
               type="file"
               id="fileUpload"
+              accept="application/pdf"
               hidden
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                if (e.target.files) setFile(e.target.files[0])
+                setUploadError(null)
+                const f = e.target.files && e.target.files[0] ? e.target.files[0] : null
+                if (!f) {
+                  setFile(null)
+                  return
+                }
+                if (!f.name.toLowerCase().endsWith('.pdf') || f.type !== 'application/pdf') {
+                  setUploadError('Please upload a valid PDF file.')
+                  setFile(null)
+                  return
+                }
+                if (f.size === 0) {
+                  setUploadError('Uploaded file is empty.')
+                  setFile(null)
+                  return
+                }
+                if (f.size > MAX_FILE_SIZE) {
+                  setUploadError('File is too large. Maximum allowed size is 5MB.')
+                  setFile(null)
+                  return
+                }
+                setFile(f)
               }}
             />
             <label htmlFor="fileUpload" className="upload-label">
@@ -399,8 +444,12 @@ function App() {
                 <span className="upload-text-secondary" style={{ display: 'block', marginTop: '4px' }}>
                   Selected: {file.name}
                 </span>
+              ) : uploadError ? (
+                <span className="upload-text-error" style={{ display: 'block', marginTop: '4px', color: '#ff6b6b' }}>
+                  {uploadError}
+                </span>
               ) : (
-                <span className="upload-text-secondary">Supports PDF, DOCX, TXT up to 10MB</span>
+                <span className="upload-text-secondary">PDF only, up to 5MB</span>
               )}
             </label>
           </div>


### PR DESCRIPTION
Related Issue
Closes #492 

Why
- Users can upload non-PDF, empty, or oversized files which may break analysis or waste backend resources. This change adds defensive validation to prevent malformed inputs and improve UX.

What/Approach
- Frontend: restrict file input to PDF, validate file extension + MIME type + size (5MB cap) for drag/drop and file picker flows. Show a clear inline error message when validation fails.
- Backend: enforce server-side validation for uploaded files (non-empty, max 5MB, .pdf extension, and PDF magic-byte/content-type checks) so uploads are never trusted from the client.

Notes/Tradeoffs
- Frontend uses client-side checks for early feedback but backend is the source of truth. Validation messages are intentionally short and user-friendly.
- Uses a 5MB default cap. This is configurable via settings (MAX_UPLOAD_SIZE_BYTES).

Testing
1. Upload a non-PDF (.txt/.docx/.exe) — UI should reject and show an inline error; if bypassed, backend returns 400 with a clear error.
2. Upload an empty file — rejected with an appropriate message.
3. Upload a PDF >5MB — UI rejects; backend rejects if client-side is bypassed.
4. Upload a valid PDF <=5MB — analysis proceeds as before.

Files changed (high level)
- frontend/src/App.tsx: add client-side validation and inline error UI; limit file input accept to application/pdf.
- backend/analyzer/views.py: add validate_uploaded_file + is_pdf_file helpers and enforce validation in upload endpoints.

If anything is unclear or you want the size cap changed to a different value, say so and it will be adjusted.