### PR TITLE
feat: offload PDF processing to Celery background tasks (fixes #526)

### DIFF
--- a/backend/analyzer/tasks.py
+++ b/backend/analyzer/tasks.py
@@ -1,0 +1,14 @@
+from celery import shared_task
+from .services import analyze_resume
+
+@shared_task
+def analyze_resume_task(file_path, target_role, file_name, user_id=None, job_description=None, cover_letter_path=None, cover_letter_name=None):
+    return analyze_resume(
+        file_path=file_path,
+        target_role=target_role,
+        file_name=file_name,
+        user_id=user_id,
+        job_description=job_description,
+        cover_letter_path=cover_letter_path,
+        cover_letter_name=cover_letter_name
+    )

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -24,10 +24,12 @@ from .views import (
     compare_bulk_jds_view,
     skills_leaderboard_view,
     unsubscribe_digest_view,
+    task_status,
 )
 
 urlpatterns = [
     path("upload/", upload_resume),
+    path("status/<str:task_id>/", task_status),
     path("compare-uploads/", compare_uploads),
     path("analyze-jd/", analyze_jd_view),
     path("compare-bulk-jds/", compare_bulk_jds_view),

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -31,6 +31,8 @@ from .serializers import (
     UserProfileSerializer,
 )
 from .services import analyze_resume, extract_text_from_file
+from .tasks import analyze_resume_task
+from celery.result import AsyncResult
 from .skill_matcher import extract_skills
 from .url_fetcher import download_and_validate_url
 from django.shortcuts import get_object_or_404
@@ -192,7 +194,7 @@ def upload_resume(request):
             else None
         )
 
-        result = analyze_resume(
+        task = analyze_resume_task.delay(
             file_path=file_path,
             target_role=target_role,
             file_name=file_name,
@@ -202,7 +204,7 @@ def upload_resume(request):
             cover_letter_name=cover_letter_name,
         )
 
-        return Response(result)
+        return Response({"task_id": task.id})
 
     except Exception as e:
         import traceback
@@ -211,6 +213,17 @@ def upload_resume(request):
             {"error": str(e)},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def task_status(request, task_id):
+    task = AsyncResult(task_id)
+    if task.state == 'FAILURE':
+        return Response({"state": task.state, "error": str(task.info)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    elif task.state == 'SUCCESS':
+        return Response({"state": task.state, "result": task.result})
+    else:
+        return Response({"state": task.state})
 
 @api_view(["POST"])
 @parser_classes([MultiPartParser, FormParser])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,5 @@ pytest>=8.0.0
 pytest-django>=4.12.0
 
 argon2-cffi>=25.1.0
+celery>=5.4.0
+redis>=5.2.0

--- a/backend/resume_analyzer/__init__.py
+++ b/backend/resume_analyzer/__init__.py
@@ -1,1 +1,3 @@
-# This file intentionally left blank.
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/backend/resume_analyzer/celery.py
+++ b/backend/resume_analyzer/celery.py
@@ -1,0 +1,8 @@
+import os
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'resume_analyzer.settings')
+
+app = Celery('resume_analyzer')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -133,6 +133,12 @@ MEDIA_ROOT = BASE_DIR / "media"
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+# Celery configuration
+CELERY_BROKER_URL = 'redis://localhost:6379/1'
+CELERY_RESULT_BACKEND = 'redis://localhost:6379/1'
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+
 CORS_ALLOWED_ORIGINS = [
     "https://ai-resume-analyzer-nine-brown.vercel.app",
     "http://localhost:5173",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -176,13 +176,26 @@ function App() {
       const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
       const headers = user ? { Authorization: `Bearer ${user.token}` } : {}
       const res = await axios.post(`${backendUrl}/api/upload/`, formData, { headers })
+      const taskId = res.data.task_id
 
-      setScore(res.data.score)
-      setSkills(res.data.skills_found || [])
-      setSuggestions(res.data.suggestions || [])
-      setMatchedSkills(res.data.matched_skills || [])
-      setMissingSkills(res.data.missing_skills || [])
-      setResumeText(res.data.resume_text || '')
+      let result = null
+      while (true) {
+        const statusRes = await axios.get(`${backendUrl}/api/status/${taskId}/`)
+        if (statusRes.data.state === 'SUCCESS') {
+          result = statusRes.data.result
+          break
+        } else if (statusRes.data.state === 'FAILURE') {
+          throw new Error(statusRes.data.error || 'Analysis failed')
+        }
+        await new Promise(r => setTimeout(r, 1000))
+      }
+
+      setScore(result.score)
+      setSkills(result.skills_found || [])
+      setSuggestions(result.suggestions || [])
+      setMatchedSkills(result.matched_skills || [])
+      setMissingSkills(result.missing_skills || [])
+      setResumeText(result.resume_text || '')
       setActiveFileName(fileToAnalyze.name)
 
       setLoading(false)


### PR DESCRIPTION
feat: offload PDF processing to Celery background tasks (fixes #526)

### Summary
Introduced Celery and Redis to handle CPU-bound PDF text extraction and NLP processing asynchronously, improving API concurrency and eliminating HTTP timeouts.

### Motivation
Fixes #526
The `/upload/` endpoint previously blocked the main thread while synchronously parsing PDFs and running NLP analysis. This resulted in timeouts and scalability limits. By offloading this work to a background worker queue, the API now responds instantly with a task ID, and the client polls for the result, allowing the main thread to handle more traffic concurrently.

### Changes
- **Backend Config**: Added celery and redis to requirements.txt. Set up Celery config in settings.py and initialized it in celery.py.
- **Background Task**: Defined `@shared_task` analyze_resume_task in tasks.py to wrap the analyze_resume function.
- **API Endpoints**: Modified upload_resume view to dispatch the Celery task via `.delay()` and return `{"task_id": <id>}`. Created a new task_status view (routed at `/status/<task_id>/`) to return the status of the job and the result upon completion.
- **Frontend**: Updated runAnalysis in App.tsx to handle the new async flow. It now receives the task ID and polls `/api/status/<task_id>/` every second until the job succeeds or fails, updating the UI accordingly.

### Acceptance Criteria
- [x] Integrate a background task queue (Celery backed by Redis).
- [x] Offload CPU-bound extraction asynchronously.
- [x] Return a task_id immediately from the endpoint.
- [x] Client polls a new `/status/<task_id>` endpoint to retrieve the result.

### Impact & Side Effects
- **Breaking Change**: The `POST /api/upload/` endpoint response signature changed from the direct result object to `{"task_id": <string>}`.
- **Deployment**: A Celery worker instance (`celery -A resume_analyzer worker`) must now be run alongside the main Django WSGI server in production, and Redis must be available.

### How to Test
1. Ensure Redis is running locally (`redis-server`).
2. Start the Celery worker: `python -m celery -A resume_analyzer worker -l info`.
3. Start the Django server.
4. Upload a resume via the frontend UI and observe the loading state while the frontend polls the status endpoint.

### Quality Checklist
- [x] Code follows project conventions
- [x] Frontend gracefully handles polling and errors
- [x] Backend safely serializes background task parameters
