### PR TITLE
feat: add mark all as read action to history panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -89,7 +89,7 @@ function App() {
   const [showAuthModal, setShowAuthModal] = useState(false)
 
   // History
-  const { entries, deleteEntry, clearHistory, setEntries } = useAnalysisHistory()
+  const { entries, deleteEntry, clearHistory, setEntries, unreadCount, lastViewedTimestamp, markAllAsViewed } = useAnalysisHistory()
   const [historyOpen, setHistoryOpen] = useState(false)
   const [activeFileName, setActiveFileName] = useState('')
 
@@ -321,6 +321,9 @@ function App() {
         onClear={clearHistory}
         isOpen={historyOpen}
         onToggle={() => setHistoryOpen((v) => !v)}
+        unreadCount={unreadCount}
+        lastViewedTimestamp={lastViewedTimestamp}
+        onMarkAllAsViewed={markAllAsViewed}
       />
       <div className="container mt-5">
         <div className="main-card text-center">

--- a/frontend/src/HistorySidebar.test.tsx
+++ b/frontend/src/HistorySidebar.test.tsx
@@ -71,7 +71,7 @@ describe('HistorySidebar component (#246)', () => {
     expect(badge).toHaveClass('history-badge')
   })
 
-  it('calls onMarkAllAsViewed and onToggle when clicking the toggle icon', () => {
+  it('calls onToggle but NOT onMarkAllAsViewed when clicking the toggle icon', () => {
     const handleToggle = vi.fn()
     const handleMarkAllAsViewed = vi.fn()
 
@@ -95,8 +95,32 @@ describe('HistorySidebar component (#246)', () => {
 
     fireEvent.click(toggleBtn)
 
-    expect(handleMarkAllAsViewed).toHaveBeenCalledTimes(1)
+    expect(handleMarkAllAsViewed).not.toHaveBeenCalled()
     expect(handleToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders "Mark Read" button when unreadCount > 0 and calls onMarkAllAsViewed when clicked', () => {
+    const handleMarkAllAsViewed = vi.fn()
+
+    render(
+      <HistorySidebar
+        entries={mockEntries}
+        unreadCount={2}
+        lastViewedTimestamp={0}
+        isOpen={true}
+        onToggle={() => {}}
+        onMarkAllAsViewed={handleMarkAllAsViewed}
+        onSelect={() => {}}
+        onDelete={() => {}}
+        onClear={() => {}}
+      />
+    )
+
+    const markReadBtn = screen.getByRole('button', { name: /mark all as read/i })
+    expect(markReadBtn).toBeInTheDocument()
+
+    fireEvent.click(markReadBtn)
+    expect(handleMarkAllAsViewed).toHaveBeenCalledTimes(1)
   })
 
   it('opens panel listing the actual notifications with NEW indicators for unread items', () => {

--- a/frontend/src/HistorySidebar.tsx
+++ b/frontend/src/HistorySidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { X, ClipboardList, BookOpen, Trash2, GitCompare, Archive } from 'lucide-react'
+import { X, ClipboardList, BookOpen, Trash2, GitCompare, Archive, Check } from 'lucide-react'
 import type { AnalysisEntry } from './hooks/useAnalysisHistory'
 import { ScoreHistoryChart } from './components/ScoreHistoryChart'
 import { downloadBulkReportsZip, type BulkReportItem } from './utils/exportZipReports'
@@ -89,12 +89,6 @@ export const HistorySidebar: React.FC<HistorySidebarProps> = ({
   }, [entries])
 
   useEffect(() => {
-    if (isOpen && onMarkAllAsViewed) {
-      onMarkAllAsViewed()
-    }
-  }, [isOpen, onMarkAllAsViewed])
-
-  useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && isOpen) {
         onToggle()
@@ -105,9 +99,6 @@ export const HistorySidebar: React.FC<HistorySidebarProps> = ({
   }, [isOpen, onToggle])
 
   const handleToggleClick = () => {
-    if (!isOpen && onMarkAllAsViewed) {
-      onMarkAllAsViewed()
-    }
     onToggle()
   }
 
@@ -205,6 +196,15 @@ export const HistorySidebar: React.FC<HistorySidebarProps> = ({
                 title="Compare two resume versions"
               >
                 <GitCompare size={14} /> Compare
+              </button>
+            )}
+            {unreadCount > 0 && onMarkAllAsViewed && (
+              <button
+                className="history-compare-btn"
+                onClick={onMarkAllAsViewed}
+                title="Mark all as read"
+              >
+                <Check size={14} /> Mark Read
               </button>
             )}
             {entries.length > 0 && (


### PR DESCRIPTION
## Summary

- Add an explicit "Mark Read" action to the Notifications & History panel.
- Prevent the panel from automatically marking history as read when opened.
- Preserve existing history data when marking entries as read.

## Changes

- Wired `unreadCount`, `lastViewedTimestamp`, and `markAllAsViewed` into `HistorySidebar`.
- Added a non-destructive "Mark Read" action for unread history.
- Removed automatic `markAllAsViewed()` behavior when opening/toggling the panel.
- Added/updated tests for the new behavior.
- Preserved the existing confirmation flow for destructive "Clear All" actions.

## Verification

- Focused `HistorySidebar` tests pass.
- Verified mark-as-read does not delete underlying history entries.
- Verified existing Clear All behavior remains unchanged.
- TypeScript/build/lint results are reported according to the repository's current state.

Closes #412