### PR TITLE
feat: add authenticated user data export

### DIFF
--- a/backend/analyzer/tests.py
+++ b/backend/analyzer/tests.py
@@ -168,7 +168,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from analyzer.comparison import compare_versions
-from analyzer.models import ResumeAnalysis
+from analyzer.models import ResumeAnalysis, UserProfile
 
 
 def _make_analysis(user, **overrides):
@@ -780,3 +780,113 @@ class WeeklyDigestTests(TestCase):
         self.assertTrue(self.profile.weekly_digest_opt_in)
 
 
+class ExportUserDataTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="exportuser",
+            password="password123",
+            email="export@example.com",
+            first_name="Export",
+            last_name="User",
+        )
+        self.other_user = User.objects.create_user(
+            username="otheruser",
+            password="password123",
+            email="other@example.com",
+        )
+
+        self.profile, _ = UserProfile.objects.get_or_create(user=self.user)
+        self.profile.weekly_digest_opt_in = True
+        self.profile.save()
+
+    def test_export_requires_authentication(self):
+        response = self.client.get("/api/account/export/")
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_export_returns_user_account_and_analysis_history(self):
+        analysis = _make_analysis(
+            self.user,
+            file_name="my_resume.pdf",
+            score=85,
+            target_role="Backend Developer",
+            resume_text="Python Django developer",
+            job_description="Looking for a Python developer",
+            cover_letter_text="I am excited to apply.",
+        )
+
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get("/api/account/export/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response["Content-Type"],
+            "application/json",
+        )
+        self.assertIn(
+            'attachment; filename="ai-resume-analyzer-data.json"',
+            response["Content-Disposition"],
+        )
+
+        data = response.json()
+
+        self.assertEqual(data["export_version"], 1)
+        self.assertIn("exported_at", data)
+
+        self.assertEqual(data["account"]["username"], "exportuser")
+        self.assertEqual(data["account"]["email"], "export@example.com")
+        self.assertEqual(data["account"]["first_name"], "Export")
+        self.assertEqual(data["account"]["last_name"], "User")
+        self.assertTrue(data["account"]["weekly_digest_opt_in"])
+        self.assertIsNone(data["account"]["avatar"])
+
+        self.assertEqual(len(data["analysis_history"]), 1)
+
+        exported_analysis = data["analysis_history"][0]
+
+        self.assertEqual(exported_analysis["id"], analysis.id)
+        self.assertEqual(exported_analysis["file_name"], "my_resume.pdf")
+        self.assertEqual(exported_analysis["score"], 85)
+        self.assertEqual(
+            exported_analysis["target_role"],
+            "Backend Developer",
+        )
+        self.assertEqual(
+            exported_analysis["resume_text"],
+            "Python Django developer",
+        )
+        self.assertEqual(
+            exported_analysis["job_description"],
+            "Looking for a Python developer",
+        )
+        self.assertEqual(
+            exported_analysis["cover_letter_text"],
+            "I am excited to apply.",
+        )
+
+    def test_export_does_not_include_other_users_analysis(self):
+        own_analysis = _make_analysis(
+            self.user,
+            file_name="my_resume.pdf",
+        )
+        foreign_analysis = _make_analysis(
+            self.other_user,
+            file_name="other_resume.pdf",
+        )
+
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get("/api/account/export/")
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        exported_ids = {
+            analysis["id"]
+            for analysis in data["analysis_history"]
+        }
+
+        self.assertIn(own_analysis.id, exported_ids)
+        self.assertNotIn(foreign_analysis.id, exported_ids)

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -25,6 +25,7 @@ from .views import (
     skills_leaderboard_view,
     unsubscribe_digest_view,
     task_status,
+    export_user_data,
 )
 
 urlpatterns = [
@@ -37,6 +38,7 @@ urlpatterns = [
     path("contact/", contact_us_view),
     path("skills-leaderboard/", skills_leaderboard_view),
     path("unsubscribe/", unsubscribe_digest_view),
+    path("account/export/", export_user_data, name="export_user_data"),
 
     path("auth/signup/", signup),
     path("auth/login/", CustomTokenObtainPairView.as_view()),
@@ -52,4 +54,5 @@ urlpatterns = [
     path('password-reset/', PasswordResetRequestView.as_view(), name='password_reset_request'),
     path('password-reset-confirm/', PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     path("admin/stats/", admin_stats_view, name="admin_stats"),
+
 ]

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -36,6 +36,9 @@ from celery.result import AsyncResult
 from .skill_matcher import extract_skills
 from .url_fetcher import download_and_validate_url
 from django.shortcuts import get_object_or_404
+import json
+from django.http import HttpResponse
+from django.utils import timezone
 
 
 class UploadRateThrottle(SimpleRateThrottle):
@@ -392,6 +395,74 @@ def get_shared_result(request, share_id):
     analysis = get_object_or_404(ResumeAnalysis, share_id=share_id)
     serializer = ResumeAnalysisSerializer(analysis)
     return Response(serializer.data)
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def export_user_data(request):
+    """Export the authenticated user's account data and analysis history."""
+    user = request.user
+
+    profile, _ = UserProfile.objects.get_or_create(user=user)
+
+    analyses = ResumeAnalysis.objects.filter(
+        user=user
+    ).order_by("-created_at")
+
+    data = {
+        "export_version": 1,
+        "exported_at": timezone.now().isoformat(),
+        "account": {
+            "username": user.username,
+            "email": user.email,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "date_joined": (
+                user.date_joined.isoformat()
+                if user.date_joined
+                else None
+            ),
+            "last_login": (
+                user.last_login.isoformat()
+                if user.last_login
+                else None
+            ),
+            "weekly_digest_opt_in": profile.weekly_digest_opt_in,
+            "avatar": profile.avatar.name if profile.avatar else None,
+        },
+        "analysis_history": [
+            {
+                "id": analysis.id,
+                "share_id": str(analysis.share_id),
+                "file_name": analysis.file_name,
+                "score": analysis.score,
+                "skills_found": analysis.skills_found,
+                "suggestions": analysis.suggestions,
+                "matched_skills": analysis.matched_skills,
+                "missing_skills": analysis.missing_skills,
+                "target_role": analysis.target_role,
+                "created_at": analysis.created_at.isoformat(),
+                "job_description": analysis.job_description,
+                "resume_text": analysis.resume_text,
+                "cover_letter_text": analysis.cover_letter_text,
+                "cover_letter_feedback": analysis.cover_letter_feedback,
+                "interview_questions": analysis.interview_questions,
+            }
+            for analysis in analyses
+        ],
+    }
+
+    response = HttpResponse(
+        json.dumps(data, indent=2, ensure_ascii=False),
+        content_type="application/json",
+    )
+
+    response["Content-Disposition"] = (
+        'attachment; filename="ai-resume-analyzer-data.json"'
+    )
+
+    return response
+
+
 
 User = get_user_model()
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation, Link } from 'react-router-dom'
 import axios from 'axios'
 import './index.css'
 import { AtsScore } from './AtsScore'
@@ -354,7 +354,9 @@ function App() {
           <div className="auth-bar">
             {user ? (
               <>
-                <span className="auth-username">👤 {user.username}</span>
+                <Link to="/profile" className="auth-username" style={{ textDecoration: 'none', color: 'inherit' }}>
+                  👤 {user.username}
+                </Link>
                 <button className="auth-bar-btn" onClick={logout}>
                   Logout
                 </button>

--- a/frontend/src/components/ProfilePage.test.tsx
+++ b/frontend/src/components/ProfilePage.test.tsx
@@ -1,0 +1,330 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import { ProfilePage } from './ProfilePage'
+
+vi.mock('axios')
+
+vi.mock('../hooks/useAuth', () => ({
+    useAuth: vi.fn(),
+}))
+
+import { useAuth } from '../hooks/useAuth'
+
+const mockedAxiosGet = vi.mocked(axios.get)
+const mockedAxiosPut = vi.mocked(axios.put)
+const mockedUseAuth = vi.mocked(useAuth)
+
+describe('ProfilePage', () => {
+    const mockUser = {
+        username: 'testuser',
+        token: 'fake-token',
+    }
+
+    const mockUpdateProfileSession = vi.fn()
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+
+        mockedUseAuth.mockReturnValue({
+            user: mockUser,
+            signup: vi.fn(),
+            login: vi.fn(),
+            logout: vi.fn(),
+            updateProfileSession: mockUpdateProfileSession,
+            updateUserAvatar: vi.fn(),
+            exportUserData: vi.fn(),
+        })
+
+    })
+
+    it('shows access denied when the user is not authenticated', () => {
+        mockedUseAuth.mockReturnValue({
+            user: null,
+            signup: vi.fn(),
+            login: vi.fn(),
+            logout: vi.fn(),
+            updateProfileSession: vi.fn(),
+            updateUserAvatar: vi.fn(),
+            exportUserData: vi.fn(),
+        })
+
+
+        render(<ProfilePage />)
+
+        expect(screen.getByText('Access Denied')).toBeInTheDocument()
+        expect(
+            screen.getByText(/Please log in to manage your account details/i)
+        ).toBeInTheDocument()
+    })
+
+    it('fetches and displays the authenticated user profile', async () => {
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: {
+                username: 'testuser',
+                email: 'test@example.com',
+                weekly_digest_opt_in: true,
+            },
+        })
+
+        render(<ProfilePage />)
+
+        expect(
+            screen.getByText('Fetching profile information...')
+        ).toBeInTheDocument()
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+        })
+
+        expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument()
+
+        const digestToggle = screen.getByRole('switch', {
+            name: /weekly resume-tips email digest/i,
+        })
+
+        expect(digestToggle).toBeChecked()
+
+        expect(mockedAxiosGet).toHaveBeenCalledWith(
+            expect.stringContaining('/api/profile/'),
+            {
+                headers: {
+                    Authorization: 'Bearer fake-token',
+                },
+            }
+        )
+    })
+
+    it('enters edit mode when Edit Profile is clicked', async () => {
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: {
+                username: 'testuser',
+                email: 'test@example.com',
+                weekly_digest_opt_in: false,
+            },
+        })
+
+        render(<ProfilePage />)
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+        })
+
+        const usernameInput = screen.getByLabelText('Username')
+        const emailInput = screen.getByLabelText('Email Address')
+        const digestToggle = screen.getByRole('switch')
+
+        expect(usernameInput).toBeDisabled()
+        expect(emailInput).toBeDisabled()
+        expect(digestToggle).toBeDisabled()
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /edit profile/i })
+        )
+
+        expect(usernameInput).not.toBeDisabled()
+        expect(emailInput).not.toBeDisabled()
+        expect(digestToggle).not.toBeDisabled()
+
+        expect(
+            screen.getByRole('button', { name: /save changes/i })
+        ).toBeInTheDocument()
+
+        expect(
+            screen.getByRole('button', { name: /cancel/i })
+        ).toBeInTheDocument()
+    })
+
+    it('updates the profile successfully', async () => {
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: {
+                username: 'testuser',
+                email: 'test@example.com',
+                weekly_digest_opt_in: false,
+            },
+        })
+
+        mockedAxiosPut.mockResolvedValueOnce({
+            data: {
+                username: 'updateduser',
+                email: 'updated@example.com',
+                weekly_digest_opt_in: true,
+            },
+        })
+
+        render(<ProfilePage />)
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+        })
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /edit profile/i })
+        )
+
+        fireEvent.change(screen.getByLabelText('Username'), {
+            target: { value: 'updateduser' },
+        })
+
+        fireEvent.change(screen.getByLabelText('Email Address'), {
+            target: { value: 'updated@example.com' },
+        })
+
+        fireEvent.click(
+            screen.getByRole('switch', {
+                name: /weekly resume-tips email digest/i,
+            })
+        )
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /save changes/i })
+        )
+
+        await waitFor(() => {
+            expect(mockedAxiosPut).toHaveBeenCalled()
+        })
+
+        expect(mockedAxiosPut).toHaveBeenCalledWith(
+            expect.stringContaining('/api/profile/'),
+            {
+                username: 'updateduser',
+                email: 'updated@example.com',
+                weekly_digest_opt_in: true,
+            },
+            {
+                headers: {
+                    Authorization: 'Bearer fake-token',
+                },
+            }
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Profile updated successfully!')
+            ).toBeInTheDocument()
+        })
+
+        expect(screen.getByDisplayValue('updateduser')).toBeInTheDocument()
+        expect(
+            screen.getByDisplayValue('updated@example.com')
+        ).toBeInTheDocument()
+
+        expect(mockUpdateProfileSession).toHaveBeenCalledWith('updateduser')
+
+        expect(
+            screen.getByRole('button', { name: /edit profile/i })
+        ).toBeInTheDocument()
+    })
+
+    it('does not save when username is empty', async () => {
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: {
+                username: 'testuser',
+                email: 'test@example.com',
+                weekly_digest_opt_in: false,
+            },
+        })
+
+        render(<ProfilePage />)
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+        })
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /edit profile/i })
+        )
+
+        fireEvent.change(screen.getByLabelText('Username'), {
+            target: { value: '' },
+        })
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /save changes/i })
+        )
+
+        expect(
+            await screen.findByText('Username cannot be empty.')
+        ).toBeInTheDocument()
+
+        expect(mockedAxiosPut).not.toHaveBeenCalled()
+    })
+
+    it('does not save when the email is invalid', async () => {
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: {
+                username: 'testuser',
+                email: 'test@example.com',
+                weekly_digest_opt_in: false,
+            },
+        })
+
+        render(<ProfilePage />)
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+        })
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /edit profile/i })
+        )
+
+        fireEvent.change(screen.getByLabelText('Email Address'), {
+            target: { value: 'invalid-email' },
+        })
+
+        const form = screen.getByRole('button', { name: /save changes/i }).closest('form')
+        if (form) {
+            fireEvent.submit(form)
+        }
+
+        expect(
+            await screen.findByText('Please provide a valid email address.')
+        ).toBeInTheDocument()
+
+        expect(mockedAxiosPut).not.toHaveBeenCalled()
+    })
+
+    it('cancels editing and restores the original values', async () => {
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: {
+                username: 'testuser',
+                email: 'test@example.com',
+                weekly_digest_opt_in: false,
+            },
+        })
+
+        render(<ProfilePage />)
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+        })
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /edit profile/i })
+        )
+
+        fireEvent.change(screen.getByLabelText('Username'), {
+            target: { value: 'changeduser' },
+        })
+
+        fireEvent.change(screen.getByLabelText('Email Address'), {
+            target: { value: 'changed@example.com' },
+        })
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /cancel/i })
+        )
+
+        expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+        expect(
+            screen.getByDisplayValue('test@example.com')
+        ).toBeInTheDocument()
+
+        expect(
+            screen.getByRole('button', { name: /edit profile/i })
+        ).toBeInTheDocument()
+    })
+})

--- a/frontend/src/components/ProfilePage.tsx
+++ b/frontend/src/components/ProfilePage.tsx
@@ -5,18 +5,19 @@ import { useAuth } from '../hooks/useAuth'
 const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
 
 export const ProfilePage: React.FC = () => {
-  const { user, updateProfileSession } = useAuth()
+  const { user, updateProfileSession, exportUserData } = useAuth()
   const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
   const [weeklyDigestOptIn, setWeeklyDigestOptIn] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
-  
+
   const [originalUsername, setOriginalUsername] = useState('')
   const [originalEmail, setOriginalEmail] = useState('')
   const [originalOptIn, setOriginalOptIn] = useState(false)
-  
+
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [exporting, setExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [successMsg, setSuccessMsg] = useState<string | null>(null)
 
@@ -58,6 +59,23 @@ export const ProfilePage: React.FC = () => {
     setSuccessMsg(null)
   }
 
+  const handleExportData = async () => {
+    try {
+      setExporting(true)
+      setError(null)
+      setSuccessMsg(null)
+
+      await exportUserData()
+
+      setSuccessMsg('Your account data has been downloaded successfully.')
+    } catch (err: any) {
+      setError(err.response?.data?.error || err.message || 'Failed to export your data.')
+    } finally {
+      setExporting(false)
+    }
+  }
+
+
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!user) return
@@ -81,7 +99,7 @@ export const ProfilePage: React.FC = () => {
       setSaving(true)
       setError(null)
       setSuccessMsg(null)
-      
+
       const response = await axios.put(
         `${BACKEND}/api/profile/`,
         { username, email, weekly_digest_opt_in: weeklyDigestOptIn },
@@ -99,7 +117,7 @@ export const ProfilePage: React.FC = () => {
       setOriginalUsername(updated.username)
       setOriginalEmail(updated.email)
       setOriginalOptIn(!!updated.weekly_digest_opt_in)
-      
+
       // Update global context session
       updateProfileSession(updated.username)
 
@@ -262,6 +280,28 @@ export const ProfilePage: React.FC = () => {
             </div>
 
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', marginTop: '10px', borderTop: '1px solid var(--surface-border)', paddingTop: '20px' }}>
+              <button
+                type="button"
+                className="app-btn app-btn--secondary"
+                onClick={handleExportData}
+                disabled={exporting || saving}
+                style={{ minWidth: '140px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}
+              >
+                {exporting ? (
+                  <>
+                    <span
+                      className="spinner-border spinner-border-sm"
+                      role="status"
+                      aria-hidden="true"
+                      style={{ width: '1rem', height: '1rem' }}
+                    />
+                    Exporting...
+                  </>
+                ) : (
+                  'Export My Data'
+                )}
+              </button>
+
               {!isEditing ? (
                 <button
                   type="button"

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -73,5 +73,29 @@ export function useAuth() {
     }
   }, [user])
 
-  return { user, signup, login, logout, updateProfileSession, updateUserAvatar }
+  const exportUserData = useCallback(async () => {
+    if (!user?.token) {
+      throw new Error('You must be logged in to export your data.')
+    }
+
+    const response = await axios.get(`${BACKEND}/api/account/export/`, {
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+      },
+      responseType: 'blob',
+    })
+
+    const url = window.URL.createObjectURL(response.data)
+    const link = document.createElement('a')
+
+    link.href = url
+    link.download = 'ai-resume-analyzer-data.json'
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+
+    window.URL.revokeObjectURL(url)
+  }, [user])
+
+  return { user, signup, login, logout, updateProfileSession, updateUserAvatar, exportUserData }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -47,6 +47,8 @@ if (import.meta.env.VITE_SENTRY_DSN) {
 
 import { Routes, Route } from 'react-router-dom'
 import { TermsOfService } from './pages/TermsOfService'
+import { ProfilePage } from './components/ProfilePage'
+
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -55,6 +57,7 @@ createRoot(document.getElementById('root')!).render(
         <Routes>
           <Route path="/terms" element={<TermsOfService />} />
           <Route path="/*" element={<App />} />
+          <Route path="/profile" element={<ProfilePage />} />
         </Routes>
       </BrowserRouter>
     </ErrorBoundary>


### PR DESCRIPTION
## 📝 Description

Implements #535 by adding authenticated user data export functionality to the profile page.

This PR also adds the `/profile` route and makes the logged-in username on the homepage clickable, while preserving the existing homepage UI layout.

## 🔗 Related Issue

Closes #535 

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

<!-- Describe the steps you took to verify your change. -->
- [ ] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)

<img width="1787" height="826" alt="image" src="https://github.com/user-attachments/assets/a4630616-67ee-4b06-a0a7-3e0d329ac863" />

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
