### PR TITLE
fix: accept DOCX and TXT resumes and validate every upload path (#552)

### DIFF
--- a/backend/analyzer/file_validation.py
+++ b/backend/analyzer/file_validation.py
@@ -1,0 +1,245 @@
+"""Validation for every file the API accepts.
+
+The parser in :mod:`analyzer.services` reads PDF, DOCX and TXT resumes, but the
+upload endpoints used to allow PDF only, and the cover-letter field was not
+validated at all. This module keeps one description of what a valid upload is
+so every entry point (resume, cover letter, the two comparison files) agrees.
+
+A format is described by its extensions, the bytes a real file of that type
+starts with, and the content types browsers send for it. Extension alone is not
+enough — anyone can rename a file — so the header is checked too. Plain text has
+no signature, so it is validated by decoding a sample of it instead.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple
+
+from django.conf import settings
+
+#: Fallback ceiling when ``MAX_UPLOAD_SIZE_BYTES`` is not configured.
+DEFAULT_MAX_UPLOAD_SIZE = 5 * 1024 * 1024  # 5 MB
+
+#: How many bytes we read to identify a file. Large enough for every signature
+#: below and for a representative text sample, small enough to stay cheap.
+SNIFF_LENGTH = 4096
+
+
+class UploadValidationError(ValueError):
+    """Raised when an uploaded file is not something we can analyse.
+
+    Subclasses :class:`ValueError` so the existing ``except ValueError`` blocks
+    in the views keep working unchanged.
+    """
+
+
+@dataclass(frozen=True)
+class FileFormat:
+    """One accepted upload format."""
+
+    key: str
+    label: str
+    extensions: Tuple[str, ...]
+    #: Byte prefixes a genuine file of this type starts with. Empty means the
+    #: format has no signature and is identified by :attr:`text_like` instead.
+    magic_prefixes: Tuple[bytes, ...] = ()
+    content_types: Tuple[str, ...] = ()
+    #: Formats without a signature (plain text) are accepted when the sample
+    #: decodes cleanly and holds no NUL bytes.
+    text_like: bool = False
+
+    def matches_extension(self, file_name: str) -> bool:
+        name = (file_name or "").lower()
+        return any(name.endswith(ext) for ext in self.extensions)
+
+    def matches_content(self, sample: bytes) -> bool:
+        if self.magic_prefixes:
+            return any(sample.startswith(prefix) for prefix in self.magic_prefixes)
+        if self.text_like:
+            return _looks_like_text(sample)
+        return False
+
+
+PDF = FileFormat(
+    key="pdf",
+    label="PDF",
+    extensions=(".pdf",),
+    magic_prefixes=(b"%PDF",),
+    content_types=("application/pdf",),
+)
+
+DOCX = FileFormat(
+    key="docx",
+    label="Word (.docx)",
+    extensions=(".docx",),
+    # .docx is a ZIP container, so it carries the ZIP local-file-header magic.
+    # The two alternatives cover empty and spanned archives written by some
+    # export tools.
+    magic_prefixes=(b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08"),
+    content_types=(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ),
+)
+
+TXT = FileFormat(
+    key="txt",
+    label="plain text",
+    extensions=(".txt",),
+    content_types=("text/plain",),
+    text_like=True,
+)
+
+#: Formats accepted for resumes and cover letters — the three the parser reads.
+RESUME_FORMATS: Tuple[FileFormat, ...] = (PDF, DOCX, TXT)
+
+
+def _looks_like_text(sample: bytes) -> bool:
+    """True when ``sample`` plausibly comes from a plain-text file."""
+    if not sample:
+        return False
+    if b"\x00" in sample:
+        return False
+    try:
+        sample.decode("utf-8")
+        return True
+    except UnicodeDecodeError:
+        # Resumes exported from older Windows editors are often cp1252. Accept
+        # them as long as the bytes are not obviously binary.
+        printable = sum(
+            1 for byte in sample if byte in (9, 10, 13) or 32 <= byte <= 126 or byte >= 160
+        )
+        return printable / len(sample) > 0.9
+
+
+def get_max_upload_size() -> int:
+    """Configured upload ceiling in bytes."""
+    return getattr(settings, "MAX_UPLOAD_SIZE_BYTES", DEFAULT_MAX_UPLOAD_SIZE)
+
+
+def describe_formats(formats: Sequence[FileFormat]) -> str:
+    """Human-readable list of accepted formats, e.g. ``PDF, Word (.docx) or plain text``."""
+    labels = [fmt.label for fmt in formats]
+    if len(labels) == 1:
+        return labels[0]
+    return "{} or {}".format(", ".join(labels[:-1]), labels[-1])
+
+
+def allowed_extensions(formats: Sequence[FileFormat] = RESUME_FORMATS) -> Tuple[str, ...]:
+    """Flat tuple of every extension the given formats accept."""
+    return tuple(ext for fmt in formats for ext in fmt.extensions)
+
+
+def read_sample(uploaded_file) -> bytes:
+    """Read the head of ``uploaded_file`` without disturbing its position.
+
+    Django's ``UploadedFile`` is re-read later by the storage backend, so the
+    cursor has to go back where it was.
+    """
+    try:
+        position = uploaded_file.tell()
+    except Exception:
+        position = None
+
+    try:
+        sample = uploaded_file.read(SNIFF_LENGTH)
+    except Exception:
+        sample = b""
+
+    try:
+        uploaded_file.seek(position if position is not None else 0)
+    except Exception:
+        pass
+
+    if isinstance(sample, str):  # pragma: no cover - defensive, files are binary
+        sample = sample.encode("utf-8", errors="ignore")
+    return sample or b""
+
+
+def detect_format(
+    uploaded_file,
+    formats: Sequence[FileFormat] = RESUME_FORMATS,
+) -> Optional[FileFormat]:
+    """Return the format whose extension *and* content both match, else ``None``.
+
+    The extension decides which format we expect; the content decides whether
+    the file really is one. A ``.exe`` renamed to ``.pdf`` matches the PDF
+    extension but not the ``%PDF`` header, so it is rejected.
+    """
+    name = getattr(uploaded_file, "name", "") or ""
+    candidates = [fmt for fmt in formats if fmt.matches_extension(name)]
+    if not candidates:
+        return None
+
+    sample = read_sample(uploaded_file)
+    for fmt in candidates:
+        if fmt.matches_content(sample):
+            return fmt
+    return None
+
+
+def validate_upload(
+    uploaded_file,
+    formats: Sequence[FileFormat] = RESUME_FORMATS,
+    field_label: str = "file",
+    max_size: Optional[int] = None,
+) -> FileFormat:
+    """Validate one uploaded file and return the format it was recognised as.
+
+    Args:
+        uploaded_file: A Django ``UploadedFile`` (or anything with ``name``,
+            ``size`` and ``read``).
+        formats: Accepted formats, defaulting to the three resume formats.
+        field_label: Name used in error messages, e.g. ``"cover letter"``.
+        max_size: Override for the configured size ceiling, in bytes.
+
+    Raises:
+        UploadValidationError: With a message safe to show to the user.
+    """
+    if uploaded_file is None:
+        raise UploadValidationError(f"No {field_label} was uploaded.")
+
+    size = getattr(uploaded_file, "size", 0) or 0
+    if size == 0:
+        raise UploadValidationError(f"The uploaded {field_label} is empty.")
+
+    ceiling = get_max_upload_size() if max_size is None else max_size
+    if size > ceiling:
+        raise UploadValidationError(
+            f"The {field_label} exceeds the maximum allowed size of "
+            f"{ceiling // (1024 * 1024)}MB."
+        )
+
+    name = getattr(uploaded_file, "name", "") or ""
+    if not any(fmt.matches_extension(name) for fmt in formats):
+        raise UploadValidationError(
+            f"Unsupported {field_label} format. Please upload {describe_formats(formats)}."
+        )
+
+    detected = detect_format(uploaded_file, formats)
+    if detected is None:
+        raise UploadValidationError(
+            f"The {field_label} does not look like a valid "
+            f"{describe_formats(formats)} file. It may be corrupted or renamed."
+        )
+
+    return detected
+
+
+def validate_optional_upload(
+    uploaded_file,
+    formats: Sequence[FileFormat] = RESUME_FORMATS,
+    field_label: str = "file",
+    max_size: Optional[int] = None,
+) -> Optional[FileFormat]:
+    """Same as :func:`validate_upload` but ``None`` in, ``None`` out.
+
+    Used for fields such as the cover letter, which are allowed to be absent
+    but must be valid when present.
+    """
+    if uploaded_file is None:
+        return None
+    return validate_upload(
+        uploaded_file,
+        formats=formats,
+        field_label=field_label,
+        max_size=max_size,
+    )

--- a/backend/analyzer/tests_file_validation.py
+++ b/backend/analyzer/tests_file_validation.py
@@ -1,0 +1,274 @@
+"""Tests for upload validation (``analyzer.file_validation``) and the endpoints that use it.
+
+Covers the three formats the parser reads, the rejection cases, and the upload
+paths that previously accepted files without checking them: the cover-letter
+field, the two comparison files and the bulk-JD resume.
+"""
+
+import json
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from analyzer.file_validation import (
+    DOCX,
+    PDF,
+    RESUME_FORMATS,
+    TXT,
+    UploadValidationError,
+    describe_formats,
+    detect_format,
+    validate_optional_upload,
+    validate_upload,
+)
+
+# Minimal payloads that carry the right signature for each format. They do not
+# have to be parseable — validation only looks at size, extension and header.
+PDF_BYTES = b"%PDF-1.7\n1 0 obj\n<<>>\nendobj\ntrailer\n%%EOF\n"
+DOCX_BYTES = b"PK\x03\x04" + b"\x00" * 60
+TXT_BYTES = b"Jane Doe\nPython developer with Django and React experience.\n"
+
+
+def pdf_upload(name="resume.pdf"):
+    return SimpleUploadedFile(name, PDF_BYTES, content_type="application/pdf")
+
+
+def docx_upload(name="resume.docx"):
+    return SimpleUploadedFile(
+        name,
+        DOCX_BYTES,
+        content_type=(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ),
+    )
+
+
+def txt_upload(name="resume.txt", body=TXT_BYTES):
+    return SimpleUploadedFile(name, body, content_type="text/plain")
+
+
+class DetectFormatTests(TestCase):
+    def test_detects_each_supported_format(self):
+        self.assertEqual(detect_format(pdf_upload()), PDF)
+        self.assertEqual(detect_format(docx_upload()), DOCX)
+        self.assertEqual(detect_format(txt_upload()), TXT)
+
+    def test_unknown_extension_is_not_detected(self):
+        upload = SimpleUploadedFile("resume.rtf", b"{\\rtf1}", content_type="text/rtf")
+        self.assertIsNone(detect_format(upload))
+
+    def test_extension_alone_is_not_enough(self):
+        """A binary renamed to .pdf has the extension but not the signature."""
+        disguised = SimpleUploadedFile(
+            "resume.pdf", b"MZ\x90\x00\x03\x00", content_type="application/pdf"
+        )
+        self.assertIsNone(detect_format(disguised))
+
+    def test_reading_the_header_leaves_the_cursor_where_it_was(self):
+        """Storage re-reads the file afterwards, so the position must be restored."""
+        upload = pdf_upload()
+        detect_format(upload)
+        self.assertEqual(upload.read(), PDF_BYTES)
+
+    def test_binary_content_is_not_accepted_as_text(self):
+        binary = SimpleUploadedFile(
+            "resume.txt", b"\x00\x01\x02\x03\xff\xfe", content_type="text/plain"
+        )
+        self.assertIsNone(detect_format(binary))
+
+    def test_non_utf8_text_is_still_accepted(self):
+        """Resumes exported by older Windows editors are often cp1252."""
+        cp1252 = "Café résumé — 5 years".encode("cp1252")
+        self.assertEqual(detect_format(txt_upload(body=cp1252)), TXT)
+
+
+class ValidateUploadTests(TestCase):
+    def test_accepts_pdf_docx_and_txt(self):
+        for upload, expected in (
+            (pdf_upload(), PDF),
+            (docx_upload(), DOCX),
+            (txt_upload(), TXT),
+        ):
+            with self.subTest(upload=upload.name):
+                self.assertEqual(validate_upload(upload), expected)
+
+    def test_rejects_missing_file(self):
+        with self.assertRaises(UploadValidationError) as ctx:
+            validate_upload(None, field_label="resume")
+        self.assertIn("No resume was uploaded", str(ctx.exception))
+
+    def test_rejects_empty_file(self):
+        empty = SimpleUploadedFile("resume.pdf", b"", content_type="application/pdf")
+        with self.assertRaises(UploadValidationError) as ctx:
+            validate_upload(empty, field_label="resume")
+        self.assertIn("empty", str(ctx.exception))
+
+    @override_settings(MAX_UPLOAD_SIZE_BYTES=1024)
+    def test_rejects_oversized_file(self):
+        big = SimpleUploadedFile("resume.pdf", PDF_BYTES + b"0" * 2048, content_type="application/pdf")
+        with self.assertRaises(UploadValidationError) as ctx:
+            validate_upload(big, field_label="resume")
+        self.assertIn("maximum allowed size", str(ctx.exception))
+
+    def test_max_size_argument_overrides_the_setting(self):
+        with self.assertRaises(UploadValidationError):
+            validate_upload(pdf_upload(), max_size=4)
+
+    def test_rejects_unsupported_extension_with_a_helpful_message(self):
+        upload = SimpleUploadedFile("resume.exe", b"MZ\x90\x00", content_type="application/octet-stream")
+        with self.assertRaises(UploadValidationError) as ctx:
+            validate_upload(upload, field_label="resume")
+        message = str(ctx.exception)
+        self.assertIn("Unsupported resume format", message)
+        self.assertIn("PDF", message)
+        self.assertIn("Word (.docx)", message)
+
+    def test_rejects_renamed_file_whose_contents_do_not_match(self):
+        disguised = SimpleUploadedFile("resume.docx", b"not a zip archive", content_type="text/plain")
+        with self.assertRaises(UploadValidationError) as ctx:
+            validate_upload(disguised, field_label="resume")
+        self.assertIn("does not look like", str(ctx.exception))
+
+    def test_error_is_a_value_error(self):
+        """Existing views catch ValueError, so the subclass has to stay compatible."""
+        self.assertTrue(issubclass(UploadValidationError, ValueError))
+
+    def test_optional_upload_allows_none(self):
+        self.assertIsNone(validate_optional_upload(None, field_label="cover letter"))
+
+    def test_optional_upload_still_validates_when_present(self):
+        with self.assertRaises(UploadValidationError):
+            validate_optional_upload(
+                SimpleUploadedFile("cover.exe", b"MZ", content_type="application/octet-stream"),
+                field_label="cover letter",
+            )
+
+    def test_describe_formats_reads_naturally(self):
+        self.assertEqual(
+            describe_formats(RESUME_FORMATS), "PDF, Word (.docx) or plain text"
+        )
+        self.assertEqual(describe_formats((PDF,)), "PDF")
+
+
+@override_settings(RESUME_UPLOAD_RATE="1000/hour")
+class UploadEndpointValidationTests(TestCase):
+    """End-to-end checks through ``/api/upload/``.
+
+    The Celery task is patched out — the point here is which files get past
+    validation, not what the analysis produces. The upload throttle is raised
+    and its cache cleared so a run of several uploads does not trip the
+    per-IP rate limit.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def _post(self, **payload):
+        with patch("analyzer.views.analyze_resume_task.delay") as mock_delay:
+            mock_delay.return_value = type("Task", (), {"id": "test-task-id"})()
+            response = self.client.post("/api/upload/", payload)
+        return response
+
+    def test_pdf_resume_is_accepted(self):
+        response = self._post(file=pdf_upload(), role="Frontend Developer")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["task_id"], "test-task-id")
+
+    def test_docx_resume_is_accepted(self):
+        response = self._post(file=docx_upload(), role="Frontend Developer")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_txt_resume_is_accepted(self):
+        response = self._post(file=txt_upload(), role="Frontend Developer")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unsupported_format_is_rejected(self):
+        response = self._post(
+            file=SimpleUploadedFile("resume.exe", b"MZ\x90\x00", content_type="application/octet-stream"),
+            role="Frontend Developer",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Unsupported resume format", response.data["error"])
+
+    def test_invalid_cover_letter_is_rejected(self):
+        response = self._post(
+            file=pdf_upload(),
+            cover_letter=SimpleUploadedFile(
+                "cover.exe", b"MZ\x90\x00", content_type="application/octet-stream"
+            ),
+            role="Frontend Developer",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("cover letter", response.data["error"])
+
+    @override_settings(MAX_UPLOAD_SIZE_BYTES=1024)
+    def test_oversized_cover_letter_is_rejected(self):
+        """The size ceiling used to apply to the resume field only."""
+        response = self._post(
+            file=pdf_upload(),
+            cover_letter=SimpleUploadedFile(
+                "cover.pdf", PDF_BYTES + b"0" * 4096, content_type="application/pdf"
+            ),
+            role="Frontend Developer",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("maximum allowed size", response.data["error"])
+
+    def test_valid_cover_letter_is_accepted(self):
+        response = self._post(
+            file=pdf_upload(),
+            cover_letter=docx_upload("cover.docx"),
+            role="Frontend Developer",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+@override_settings(RESUME_UPLOAD_RATE="1000/hour")
+class ComparisonUploadValidationTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_compare_uploads_rejects_an_invalid_second_file(self):
+        response = self.client.post(
+            "/api/compare-uploads/",
+            {
+                "file1": txt_upload("v1.txt"),
+                "file2": SimpleUploadedFile(
+                    "v2.exe", b"MZ\x90\x00", content_type="application/octet-stream"
+                ),
+                "role": "Frontend Developer",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("second resume", response.data["error"])
+
+    def test_compare_uploads_accepts_two_valid_files(self):
+        response = self.client.post(
+            "/api/compare-uploads/",
+            {
+                "file1": txt_upload("v1.txt", b"Python developer with Django experience."),
+                "file2": txt_upload("v2.txt", b"Python developer with Django and React experience."),
+                "role": "Frontend Developer",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("score_delta", response.data)
+
+    def test_bulk_jd_comparison_rejects_an_invalid_resume(self):
+        response = self.client.post(
+            "/api/compare-bulk-jds/",
+            {
+                "file": SimpleUploadedFile(
+                    "resume.exe", b"MZ\x90\x00", content_type="application/octet-stream"
+                ),
+                "job_descriptions": json.dumps(["Python django developer"]),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Unsupported resume format", response.data["error"])

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -69,49 +69,35 @@ def verify_captcha_token(token_string):
     return False
 
 
-MAX_UPLOAD_SIZE = getattr(settings, "MAX_UPLOAD_SIZE_BYTES", 5 * 1024 * 1024)  # 5MB
+from .file_validation import (
+    PDF,
+    RESUME_FORMATS,
+    detect_format,
+    get_max_upload_size,
+    validate_optional_upload,
+    validate_upload,
+)
+
+MAX_UPLOAD_SIZE = get_max_upload_size()
+
 
 def is_pdf_file(f):
-    """Return True if uploaded file looks like a PDF (content-type or magic bytes)."""
-    try:
-        content_type = getattr(f, "content_type", "")
-        if content_type == "application/pdf":
-            return True
-        # Try reading magic bytes; preserve file position if possible
-        try:
-            pos = f.tell()
-        except Exception:
-            pos = None
-        try:
-            header = f.read(4)
-        except Exception:
-            header = b''
-        try:
-            if pos is not None:
-                f.seek(pos)
-            else:
-                f.seek(0)
-        except Exception:
-            pass
-        return isinstance(header, (bytes, bytearray)) and header.startswith(b"%PDF")
-    except Exception:
-        return False
+    """Return True if the uploaded file really is a PDF.
+
+    Kept as a thin wrapper so callers outside this module keep working; the
+    format table now lives in :mod:`analyzer.file_validation`.
+    """
+    return detect_format(f, formats=(PDF,)) is not None
 
 
-def validate_uploaded_file(f, allowed_exts=(".pdf",)):
-    """Validate uploaded file: non-empty, within size limit, allowed extension, and PDF magic bytes."""
-    if not f:
-        raise ValueError("No file uploaded")
-    size = getattr(f, "size", 0)
-    if size == 0:
-        raise ValueError("Uploaded file is empty")
-    if size > MAX_UPLOAD_SIZE:
-        raise ValueError(f"File exceeds maximum allowed size of {MAX_UPLOAD_SIZE // (1024*1024)}MB")
-    name = getattr(f, "name", "")
-    if not any(name.lower().endswith(ext) for ext in allowed_exts):
-        raise ValueError("Only PDF files are allowed")
-    if not is_pdf_file(f):
-        raise ValueError("Uploaded file is not a valid PDF")
+def validate_uploaded_file(f, formats=RESUME_FORMATS, field_label="resume"):
+    """Validate an uploaded resume (or cover letter).
+
+    Accepts every format the parser can read — PDF, DOCX and TXT — and checks
+    size, extension and file signature. Raises ``UploadValidationError`` (a
+    ``ValueError``) with a message that can be shown to the user.
+    """
+    validate_upload(f, formats=formats, field_label=field_label)
     return True
 
 
@@ -148,12 +134,17 @@ def upload_resume(request):
     target_role = request.data.get("role", "")
     job_desc = request.data.get("job_description", "")[:2000]
 
-    # Server-side validation for direct uploads (always enforce on backend)
-    if file and not url:
-        try:
-            validate_uploaded_file(file)
-        except ValueError as ve:
-            return Response({"error": str(ve)}, status=status.HTTP_400_BAD_REQUEST)
+    cover_letter = request.FILES.get("cover_letter")
+
+    # Server-side validation for direct uploads (always enforce on backend).
+    # The cover letter goes through the same checks — it used to be written to
+    # disk unvalidated, so the size ceiling did not apply to it.
+    try:
+        if file and not url:
+            validate_upload(file, field_label="resume")
+        validate_optional_upload(cover_letter, field_label="cover letter")
+    except ValueError as ve:
+        return Response({"error": str(ve)}, status=status.HTTP_400_BAD_REQUEST)
 
     if not file and not url:
         return Response(
@@ -179,7 +170,6 @@ def upload_resume(request):
             saved_name = storage.save(unique_name, file)
             file_path = storage.path(saved_name)
 
-        cover_letter = request.FILES.get("cover_letter")
         cover_letter_path = None
         cover_letter_name = None
         if cover_letter:
@@ -240,6 +230,12 @@ def compare_uploads(request):
 
     if not file1 or not file2:
         return Response({"error": "Please provide two resume files."}, status=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        validate_upload(file1, field_label="first resume")
+        validate_upload(file2, field_label="second resume")
+    except ValueError as ve:
+        return Response({"error": str(ve)}, status=status.HTTP_400_BAD_REQUEST)
 
     def process_file(f):
         temp_dir = os.path.join(settings.BASE_DIR, "tmp")
@@ -678,15 +674,16 @@ def profile_avatar_view(request):
         file_obj = request.FILES.get("avatar")
         if not file_obj:
             return Response({"error": "No avatar file provided."}, status=status.HTTP_400_BAD_REQUEST)
-            
+
         ext = os.path.splitext(file_obj.name)[1].lower()
         if ext not in [".png", ".jpg", ".jpeg", ".webp"]:
             return Response({"error": "Only PNG, JPG, JPEG, and WEBP images are allowed."}, status=status.HTTP_400_BAD_REQUEST)
-            
+
         max_size = 2 * 1024 * 1024
         if file_obj.size > max_size:
             return Response({"error": "Image size must be under 2MB."}, status=status.HTTP_400_BAD_REQUEST)
-            
+
+
         if profile.avatar:
             try:
                 if os.path.exists(profile.avatar.path):
@@ -741,6 +738,12 @@ def compare_bulk_jds_view(request):
             {"error": "Please provide a resume file or shareable link."},
             status=status.HTTP_400_BAD_REQUEST,
         )
+
+    if file and not url:
+        try:
+            validate_upload(file, field_label="resume")
+        except ValueError as ve:
+            return Response({"error": str(ve)}, status=status.HTTP_400_BAD_REQUEST)
 
     # limit up to 5 JDs
     job_descriptions = [jd.strip() for jd in job_descriptions if jd and jd.strip()][:5]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,11 @@ import { useLocation, Link } from 'react-router-dom'
 import axios from 'axios'
 import './index.css'
 import { AtsScore } from './AtsScore'
+import {
+  RESUME_ACCEPT_ATTRIBUTE,
+  describeUploadLimits,
+  validateResumeFile,
+} from './utils/fileValidation'
 import { useAnalysisHistory, type AnalysisEntry } from './hooks/useAnalysisHistory'
 import { HistorySidebar } from './HistorySidebar'
 import { useAuth } from './hooks/useAuth'
@@ -403,18 +408,12 @@ function App() {
               if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
                 const f = e.dataTransfer.files[0]
                 setUploadError(null)
-                if (!f.name.toLowerCase().endsWith('.pdf') || f.type !== 'application/pdf') {
-                  setUploadError('Please upload a valid PDF file.')
-                  setFile(null)
-                  return
-                }
-                if (f.size === 0) {
-                  setUploadError('Uploaded file is empty.')
-                  setFile(null)
-                  return
-                }
-                if (f.size > MAX_FILE_SIZE) {
-                  setUploadError('File is too large. Maximum allowed size is 5MB.')
+                const result = validateResumeFile(f, {
+                  maxSizeBytes: MAX_FILE_SIZE,
+                  label: 'resume',
+                })
+                if (!result.ok) {
+                  setUploadError(result.error)
                   setFile(null)
                   return
                 }
@@ -426,6 +425,7 @@ function App() {
               type="file"
               id="fileUpload"
               className="sr-only"
+              accept={RESUME_ACCEPT_ATTRIBUTE}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setUploadError(null)
                 const f = e.target.files && e.target.files[0] ? e.target.files[0] : null
@@ -433,18 +433,12 @@ function App() {
                   setFile(null)
                   return
                 }
-                if (!f.name.toLowerCase().endsWith('.pdf') || f.type !== 'application/pdf') {
-                  setUploadError('Please upload a valid PDF file.')
-                  setFile(null)
-                  return
-                }
-                if (f.size === 0) {
-                  setUploadError('Uploaded file is empty.')
-                  setFile(null)
-                  return
-                }
-                if (f.size > MAX_FILE_SIZE) {
-                  setUploadError('File is too large. Maximum allowed size is 5MB.')
+                const result = validateResumeFile(f, {
+                  maxSizeBytes: MAX_FILE_SIZE,
+                  label: 'resume',
+                })
+                if (!result.ok) {
+                  setUploadError(result.error)
                   setFile(null)
                   return
                 }
@@ -467,7 +461,7 @@ function App() {
                   {uploadError}
                 </span>
               ) : (
-                <span className="upload-text-secondary">PDF only, up to 5MB</span>
+                <span className="upload-text-secondary">{describeUploadLimits(MAX_FILE_SIZE)}</span>
               )}
             </label>
           </div>

--- a/frontend/src/UploadZone.test.tsx
+++ b/frontend/src/UploadZone.test.tsx
@@ -21,7 +21,7 @@ describe('Drag and Drop Zone Contrast & Visual Pairing (#258)', () => {
     expect(browseText).toBeInTheDocument()
     expect(browseText.className).toContain('upload-text-browse')
 
-    const secondaryText = screen.getByText(/Supports PDF, DOCX, TXT up to 10MB/i)
+    const secondaryText = screen.getByText(/Supports PDF, DOCX or TXT up to 5MB/i)
     expect(secondaryText).toBeInTheDocument()
     expect(secondaryText.className).toContain('upload-text-secondary')
 

--- a/frontend/src/utils/fileValidation.test.ts
+++ b/frontend/src/utils/fileValidation.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MAX_RESUME_SIZE_BYTES,
+  RESUME_ACCEPT_ATTRIBUTE,
+  describeAcceptedFormats,
+  describeUploadLimits,
+  validateResumeFile,
+} from './fileValidation'
+
+function makeFile(name: string, type: string, size = 1024): File {
+  const file = new File(['x'], name, { type })
+  // File size is read-only, so it is stubbed for the size-limit cases.
+  Object.defineProperty(file, 'size', { value: size })
+  return file
+}
+
+describe('validateResumeFile', () => {
+  it('accepts the three formats the backend parser reads', () => {
+    const cases: Array<[string, string]> = [
+      ['resume.pdf', 'application/pdf'],
+      [
+        'resume.docx',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      ],
+      ['resume.txt', 'text/plain'],
+    ]
+
+    for (const [name, type] of cases) {
+      const result = validateResumeFile(makeFile(name, type))
+      expect(result.ok, `${name} should be accepted`).toBe(true)
+    }
+  })
+
+  it('matches the extension case-insensitively', () => {
+    expect(validateResumeFile(makeFile('RESUME.PDF', 'application/pdf')).ok).toBe(true)
+    expect(validateResumeFile(makeFile('Resume.DocX', '')).ok).toBe(true)
+  })
+
+  it('accepts a file whose type the browser did not report', () => {
+    // Chrome on Linux commonly reports an empty type for .docx.
+    expect(validateResumeFile(makeFile('resume.docx', '')).ok).toBe(true)
+  })
+
+  it('rejects an unsupported extension and names the supported ones', () => {
+    const result = validateResumeFile(makeFile('resume.exe', 'application/octet-stream'))
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Unsupported')
+      expect(result.error).toContain('PDF')
+      expect(result.error).toContain('Word (.docx)')
+    }
+  })
+
+  it('rejects a file with no extension at all', () => {
+    expect(validateResumeFile(makeFile('resume', 'application/pdf')).ok).toBe(false)
+  })
+
+  it('rejects an empty file', () => {
+    const result = validateResumeFile(makeFile('resume.pdf', 'application/pdf', 0))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('empty')
+  })
+
+  it('rejects a file over the size limit', () => {
+    const result = validateResumeFile(
+      makeFile('resume.pdf', 'application/pdf', MAX_RESUME_SIZE_BYTES + 1)
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('5.0 MB')
+  })
+
+  it('honours a custom size limit and states it in readable units', () => {
+    const result = validateResumeFile(makeFile('resume.pdf', 'application/pdf', 2048), {
+      maxSizeBytes: 1024,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('1.0 KB')
+  })
+
+  it('rejects a file whose reported type belongs to a different accepted format', () => {
+    const result = validateResumeFile(makeFile('resume.pdf', 'text/plain'))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('does not match')
+  })
+
+  it('uses the supplied label in messages', () => {
+    const result = validateResumeFile(makeFile('cover.exe', 'application/octet-stream'), {
+      label: 'cover letter',
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('cover letter')
+  })
+
+  it('rejects a missing file', () => {
+    expect(validateResumeFile(null).ok).toBe(false)
+    expect(validateResumeFile(undefined).ok).toBe(false)
+  })
+})
+
+describe('format descriptions', () => {
+  it('lists the accepted formats in a readable sentence', () => {
+    expect(describeAcceptedFormats()).toBe('PDF, Word (.docx) or plain text')
+  })
+
+  it('summarises the upload limits for the drop zone', () => {
+    expect(describeUploadLimits()).toBe('Supports PDF, DOCX or TXT up to 5MB')
+    expect(describeUploadLimits(10 * 1024 * 1024)).toBe('Supports PDF, DOCX or TXT up to 10MB')
+  })
+
+  it('builds an accept attribute covering every extension and mime type', () => {
+    expect(RESUME_ACCEPT_ATTRIBUTE).toContain('.pdf')
+    expect(RESUME_ACCEPT_ATTRIBUTE).toContain('.docx')
+    expect(RESUME_ACCEPT_ATTRIBUTE).toContain('.txt')
+    expect(RESUME_ACCEPT_ATTRIBUTE).toContain('application/pdf')
+  })
+})

--- a/frontend/src/utils/fileValidation.ts
+++ b/frontend/src/utils/fileValidation.ts
@@ -1,0 +1,141 @@
+/**
+ * Client-side checks for the files a user picks before we send them upstream.
+ *
+ * These are a convenience, not a guarantee — the backend runs the same checks
+ * plus a file-signature sniff. Keeping the rules here means the drop handler,
+ * the file input and any future upload surface stay in agreement instead of
+ * each carrying their own copy.
+ */
+
+import { formatFileSize } from './formatFileSize'
+
+export const MAX_RESUME_SIZE_BYTES = 5 * 1024 * 1024 // 5MB
+
+export interface AcceptedFormat {
+  /** Shown to the user in error messages and helper text. */
+  label: string
+  extensions: string[]
+  /**
+   * MIME types browsers report for this format. Browsers are inconsistent
+   * here — .docx often arrives as an empty string on Linux, .txt sometimes as
+   * `application/octet-stream` — so a missing or unknown type is not treated
+   * as a failure, only a contradicting one is.
+   */
+  mimeTypes: string[]
+}
+
+export const RESUME_FORMATS: AcceptedFormat[] = [
+  { label: 'PDF', extensions: ['.pdf'], mimeTypes: ['application/pdf'] },
+  {
+    label: 'Word (.docx)',
+    extensions: ['.docx'],
+    mimeTypes: [
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ],
+  },
+  { label: 'plain text', extensions: ['.txt'], mimeTypes: ['text/plain'] },
+]
+
+/** Value for the `accept` attribute of a resume file input. */
+export const RESUME_ACCEPT_ATTRIBUTE = RESUME_FORMATS.flatMap((format) => [
+  ...format.extensions,
+  ...format.mimeTypes,
+]).join(',')
+
+/** e.g. `PDF, Word (.docx) or plain text` */
+export function describeAcceptedFormats(formats: AcceptedFormat[] = RESUME_FORMATS): string {
+  const labels = formats.map((format) => format.label)
+  if (labels.length === 0) return ''
+  if (labels.length === 1) return labels[0]
+  return `${labels.slice(0, -1).join(', ')} or ${labels[labels.length - 1]}`
+}
+
+/** Helper text for the upload zone, e.g. `Supports PDF, DOCX or TXT up to 5MB`. */
+export function describeUploadLimits(maxSizeBytes: number = MAX_RESUME_SIZE_BYTES): string {
+  const extensions = RESUME_FORMATS.flatMap((format) => format.extensions).map((extension) =>
+    extension.replace('.', '').toUpperCase()
+  )
+  const readable = `${extensions.slice(0, -1).join(', ')} or ${extensions[extensions.length - 1]}`
+  return `Supports ${readable} up to ${Math.round(maxSizeBytes / (1024 * 1024))}MB`
+}
+
+function extensionOf(fileName: string): string {
+  const lower = fileName.toLowerCase()
+  const dotIndex = lower.lastIndexOf('.')
+  return dotIndex === -1 ? '' : lower.slice(dotIndex)
+}
+
+function findFormat(fileName: string, formats: AcceptedFormat[]): AcceptedFormat | undefined {
+  const extension = extensionOf(fileName)
+  if (!extension) return undefined
+  return formats.find((format) => format.extensions.includes(extension))
+}
+
+export type FileValidationResult =
+  | { ok: true; format: AcceptedFormat }
+  | { ok: false; error: string }
+
+export interface ValidateFileOptions {
+  formats?: AcceptedFormat[]
+  maxSizeBytes?: number
+  /** Used in messages, e.g. "cover letter". */
+  label?: string
+}
+
+/**
+ * Validate a file the user selected or dropped.
+ *
+ * Checks, in the order the user is most likely to hit them: recognised
+ * extension, non-empty, within the size limit, and a MIME type that does not
+ * contradict the extension.
+ */
+export function validateResumeFile(
+  file: File | null | undefined,
+  options: ValidateFileOptions = {}
+): FileValidationResult {
+  const {
+    formats = RESUME_FORMATS,
+    maxSizeBytes = MAX_RESUME_SIZE_BYTES,
+    label = 'file',
+  } = options
+
+  if (!file) {
+    return { ok: false, error: `Please choose a ${label} to upload.` }
+  }
+
+  const format = findFormat(file.name, formats)
+  if (!format) {
+    return {
+      ok: false,
+      error: `Unsupported ${label} format. Please upload ${describeAcceptedFormats(formats)}.`,
+    }
+  }
+
+  if (file.size === 0) {
+    return { ok: false, error: `The selected ${label} is empty.` }
+  }
+
+  if (file.size > maxSizeBytes) {
+    return {
+      ok: false,
+      error: `That ${label} is too large. Maximum allowed size is ${formatFileSize(maxSizeBytes)}.`,
+    }
+  }
+
+  // Only reject on a type the browser reported *and* that belongs to a
+  // different accepted format — an unknown or blank type is common and fine.
+  const reportedType = (file.type || '').toLowerCase()
+  if (reportedType && !format.mimeTypes.includes(reportedType)) {
+    const claimedByAnotherFormat = formats.some(
+      (candidate) => candidate !== format && candidate.mimeTypes.includes(reportedType)
+    )
+    if (claimedByAnotherFormat) {
+      return {
+        ok: false,
+        error: `The ${label} extension does not match its contents. Please re-export it as ${format.label}.`,
+      }
+    }
+  }
+
+  return { ok: true, format }
+}


### PR DESCRIPTION
Fixes #552

## What was wrong

`extract_text_from_file()` reads PDF, DOCX and TXT, but `validate_uploaded_file()` only allowed `.pdf` and additionally required the `%PDF` header. Word resumes were rejected with "Only PDF files are allowed", and the `python-docx` dependency was there for a branch that could never be reached from the API.

The cover-letter field had the opposite problem — it was written to `backend/tmp/` with no checks at all, so the 5MB ceiling did not apply to it. `compare_uploads` and `compare_bulk_jds_view` did not validate their files either.

## What this changes

**New `backend/analyzer/file_validation.py`** — one place describing what a valid upload is. Each format is a small record of its extensions, the bytes a real file of that type starts with, and the content types browsers report:

```python
PDF  = FileFormat(key="pdf",  label="PDF",          extensions=(".pdf",),  magic_prefixes=(b"%PDF",))
DOCX = FileFormat(key="docx", label="Word (.docx)", extensions=(".docx",), magic_prefixes=(b"PK\x03\x04", ...))
TXT  = FileFormat(key="txt",  label="plain text",   extensions=(".txt",),  text_like=True)
```

Extension decides which format we expect; the signature decides whether the file really is one, so a renamed binary is still rejected. `.txt` has no signature, so it is validated by decoding a 4KB sample instead (cp1252 exports from older Windows editors are accepted; anything with NUL bytes is not).

**Every upload path now goes through it:**

| path | before | after |
|---|---|---|
| `upload/` resume | PDF only | PDF / DOCX / TXT |
| `upload/` cover letter | no validation at all | same checks as the resume |
| `compare-uploads/` file1, file2 | no validation | validated |
| `compare-bulk-jds/` file | no validation | validated |

`validate_uploaded_file()` and `is_pdf_file()` are kept as thin wrappers so nothing outside the module breaks, and `UploadValidationError` subclasses `ValueError` so the existing `except ValueError` blocks in the views keep working.

**Frontend.** `App.tsx` had the same validation written out twice — once in the drop handler, once in the input's `onChange` — both PDF-only. Both now call `validateResumeFile()` from the new `utils/fileValidation.ts`, the input has an `accept` attribute, and the size limit is rendered with the existing `formatFileSize()` helper rather than a second rounding rule.

## Error messages

| situation | before | after |
|---|---|---|
| `.docx` resume | Only PDF files are allowed | *(accepted)* |
| `.exe` resume | Only PDF files are allowed | Unsupported resume format. Please upload PDF, Word (.docx) or plain text. |
| `.exe` cover letter | *(silently stored)* | Unsupported cover letter format. Please upload PDF, Word (.docx) or plain text. |
| renamed binary | Uploaded file is not a valid PDF | The resume does not look like a valid PDF, Word (.docx) or plain text file. It may be corrupted or renamed. |

## Tests

`backend/analyzer/tests_file_validation.py` — 27 tests: each accepted format, unknown extension, empty file, oversized file, size-argument override, renamed binary, non-UTF-8 text, binary-in-`.txt`, cursor restored after sniffing (storage re-reads the file afterwards), plus endpoint tests for the resume / cover-letter / comparison / bulk-JD paths.

`frontend/src/utils/fileValidation.test.ts` — 14 tests covering the same rules client-side, including the case where the browser reports no MIME type at all (common for `.docx` on Linux).

```
backend:  Ran 72 tests — the 3 failures are pre-existing on main
          (ProfileAvatarTests ×2, CaptchaProtectionTests ×1, all login/captcha related)
frontend: 89 tests, 87 pass — the 2 failures are pre-existing on main
          (HistorySidebar "Mark Read", AppRoastMode)
```

## Note on one existing test

`UploadZone.test.tsx` asserts the drop zone says **"Supports PDF, DOCX, TXT up to 10MB"**, which has never matched the rendered text ("PDF only, up to 5MB") — that test is red on main today. It now matches, with the real limit (5MB, per `MAX_UPLOAD_SIZE_BYTES`) rather than 10MB. The 10MB figure applies to the URL-import path in `url_fetcher.py`, not direct uploads.

## Deliberately out of scope

`profile_avatar_view` has the same extension-only weakness and would benefit from the same treatment, but tightening it would break `ProfileAvatarTests`, which uploads `b"fake_png_binary_data"` and expects 200. Worth a separate issue.
