### PR TITLE
fix: require a signed token to unsubscribe from the weekly digest (#553)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,5 +18,12 @@ ALLOWED_HOSTS=localhost,127.0.0.1,127.0.0.1:8000
 # Format: <number>/<period> — e.g. 10/hour, 100/day, 5/min
 RESUME_UPLOAD_RATE=10/hour
 
+# Public URL of the frontend. Used to build links that go out by email,
+# such as the weekly digest unsubscribe link.
+FRONTEND_URL=http://localhost:5173
+
+# How many days a signed unsubscribe link stays valid (default: 90)
+UNSUBSCRIBE_TOKEN_MAX_AGE_DAYS=90
+
 # Sentry DSN for error tracking
 SENTRY_DSN=

--- a/backend/analyzer/management/commands/send_weekly_digest.py
+++ b/backend/analyzer/management/commands/send_weekly_digest.py
@@ -4,6 +4,7 @@ from django.core.mail import send_mail
 from django.conf import settings
 from django.contrib.auth.models import User
 from analyzer.models import ResumeAnalysis
+from analyzer.unsubscribe_tokens import build_unsubscribe_url
 
 RESUME_TIPS_CATALOG = [
     {
@@ -40,7 +41,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        dry_run = options.get("dry-run", False)
+        # argparse stores --dry-run under "dry_run"; the old "dry-run" lookup
+        # was always None, so --dry-run sent real email.
+        dry_run = options.get("dry_run", False)
         opted_in_users = User.objects.filter(profile__weekly_digest_opt_in=True)
 
         count = 0
@@ -64,8 +67,9 @@ class Command(BaseCommand):
                 nudge = f"💡 Nudge: Your current ATS score is {recent_score}%. Incorporate missing skills from target job descriptions to hit 80%+!"
 
             tip_item = random.choice(RESUME_TIPS_CATALOG)
-            frontend_url = getattr(settings, "FRONTEND_URL", "http://localhost:5173")
-            unsubscribe_link = f"{frontend_url}/unsubscribe?email={user.email}"
+            # Signed, expiring token instead of a bare email address, so a link
+            # only unsubscribes the account it was issued for.
+            unsubscribe_link = build_unsubscribe_url(user)
 
             subject = "Your Weekly Resume Tips & Insights Digest"
             body = (

--- a/backend/analyzer/tests.py
+++ b/backend/analyzer/tests.py
@@ -752,11 +752,15 @@ class WeeklyDigestTests(TestCase):
 
     def test_unsubscribe_endpoint(self):
         from rest_framework import status
+        from analyzer.unsubscribe_tokens import make_unsubscribe_token
+
         self.profile.weekly_digest_opt_in = True
         self.profile.save()
 
-        # Call unsubscribe via GET with email param
-        resp = self.client.get("/api/unsubscribe/?email=digest@example.com")
+        # Unsubscribe with the signed token that digest emails now carry. A
+        # bare ?email= param no longer works — see tests_unsubscribe.py.
+        token = make_unsubscribe_token(self.user)
+        resp = self.client.get(f"/api/unsubscribe/?token={token}")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(resp.data["unsubscribed_count"], 1)
 

--- a/backend/analyzer/tests_unsubscribe.py
+++ b/backend/analyzer/tests_unsubscribe.py
@@ -1,0 +1,232 @@
+"""Tests for signed digest-unsubscribe links.
+
+The endpoint used to unsubscribe whatever email address it was handed, and its
+404-vs-200 responses said whether an account existed. These tests pin down both
+the token flow and the fact that the response no longer varies with account
+existence.
+"""
+
+from django.contrib.auth.models import User
+from django.core import signing
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from analyzer.models import UserProfile
+from analyzer.unsubscribe_tokens import (
+    UNSUBSCRIBE_SALT,
+    build_unsubscribe_url,
+    make_unsubscribe_token,
+    read_unsubscribe_token,
+)
+
+
+class UnsubscribeTokenTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="tokenuser", password="password123", email="token@example.com"
+        )
+
+    def test_round_trips_to_the_same_user(self):
+        token = make_unsubscribe_token(self.user)
+        self.assertEqual(read_unsubscribe_token(token), self.user)
+
+    def test_token_does_not_contain_the_email_address(self):
+        """The whole point is to keep the address out of the URL."""
+        self.assertNotIn("token@example.com", make_unsubscribe_token(self.user))
+
+    def test_rejects_a_tampered_token(self):
+        token = make_unsubscribe_token(self.user)
+        tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
+        self.assertIsNone(read_unsubscribe_token(tampered))
+
+    def test_rejects_an_expired_token(self):
+        token = make_unsubscribe_token(self.user)
+        self.assertIsNone(read_unsubscribe_token(token, max_age=-1))
+
+    def test_rejects_a_token_signed_with_a_different_salt(self):
+        """A signed value from elsewhere in the project must not work here."""
+        foreign = signing.dumps({"uid": self.user.pk}, salt="some.other.purpose")
+        self.assertIsNone(read_unsubscribe_token(foreign))
+
+    def test_rejects_empty_and_malformed_input(self):
+        for value in ("", None, "not-a-token", 12345):
+            with self.subTest(value=value):
+                self.assertIsNone(read_unsubscribe_token(value))
+
+    def test_returns_none_when_the_user_no_longer_exists(self):
+        token = make_unsubscribe_token(self.user)
+        self.user.delete()
+        self.assertIsNone(read_unsubscribe_token(token))
+
+    def test_salt_is_namespaced_to_unsubscribing(self):
+        self.assertEqual(UNSUBSCRIBE_SALT, "analyzer.digest.unsubscribe")
+
+    @override_settings(FRONTEND_URL="https://resume.example.com")
+    def test_builds_a_link_pointing_at_the_configured_frontend(self):
+        url = build_unsubscribe_url(self.user)
+        self.assertTrue(url.startswith("https://resume.example.com/unsubscribe?token="))
+        self.assertNotIn("email=", url)
+
+    @override_settings(FRONTEND_URL="https://resume.example.com/")
+    def test_trailing_slash_does_not_double_up(self):
+        self.assertNotIn("//unsubscribe", build_unsubscribe_url(self.user))
+
+    @override_settings(UNSUBSCRIBE_TOKEN_MAX_AGE_DAYS=1)
+    def test_lifetime_is_configurable(self):
+        from analyzer.unsubscribe_tokens import get_max_age_seconds
+
+        self.assertEqual(get_max_age_seconds(), 24 * 60 * 60)
+
+
+class UnsubscribeEndpointTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="digestuser", password="password123", email="digest@example.com"
+        )
+        self.profile, _ = UserProfile.objects.get_or_create(user=self.user)
+        self.profile.weekly_digest_opt_in = True
+        self.profile.save()
+
+        self.other = User.objects.create_user(
+            username="victim", password="password123", email="victim@example.com"
+        )
+        self.other_profile, _ = UserProfile.objects.get_or_create(user=self.other)
+        self.other_profile.weekly_digest_opt_in = True
+        self.other_profile.save()
+
+    def test_valid_token_unsubscribes(self):
+        token = make_unsubscribe_token(self.user)
+        response = self.client.get(f"/api/unsubscribe/?token={token}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unsubscribed_count"], 1)
+        self.profile.refresh_from_db()
+        self.assertFalse(self.profile.weekly_digest_opt_in)
+
+    def test_token_works_by_post_as_well(self):
+        response = self.client.post(
+            "/api/unsubscribe/", {"token": make_unsubscribe_token(self.user)}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.profile.refresh_from_db()
+        self.assertFalse(self.profile.weekly_digest_opt_in)
+
+    def test_bare_email_no_longer_unsubscribes_anyone(self):
+        """The reported problem: no proof of ownership was required."""
+        response = self.client.get("/api/unsubscribe/?email=victim@example.com")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.other_profile.refresh_from_db()
+        self.assertTrue(self.other_profile.weekly_digest_opt_in)
+
+    def test_bare_username_no_longer_unsubscribes_anyone(self):
+        response = self.client.post("/api/unsubscribe/", {"username": "victim"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.other_profile.refresh_from_db()
+        self.assertTrue(self.other_profile.weekly_digest_opt_in)
+
+    def test_one_users_token_cannot_unsubscribe_another(self):
+        token = make_unsubscribe_token(self.user)
+        self.client.get(f"/api/unsubscribe/?token={token}")
+
+        self.other_profile.refresh_from_db()
+        self.assertTrue(self.other_profile.weekly_digest_opt_in)
+
+    def test_response_is_identical_for_known_and_unknown_addresses(self):
+        """No status-code oracle for whether an account exists."""
+        known = self.client.get("/api/unsubscribe/?email=digest@example.com")
+        unknown = self.client.get("/api/unsubscribe/?email=nobody-here@example.com")
+
+        self.assertEqual(known.status_code, unknown.status_code)
+        self.assertEqual(known.data, unknown.data)
+
+    def test_invalid_token_is_rejected_without_saying_why(self):
+        response = self.client.get("/api/unsubscribe/?token=clearly-not-valid")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("no longer valid", response.data["error"])
+
+    def test_expired_token_reads_the_same_as_an_invalid_one(self):
+        with override_settings(UNSUBSCRIBE_TOKEN_MAX_AGE_DAYS=0):
+            response = self.client.get(
+                f"/api/unsubscribe/?token={make_unsubscribe_token(self.user)}"
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.profile.refresh_from_db()
+        self.assertTrue(self.profile.weekly_digest_opt_in)
+
+    def test_authenticated_user_can_unsubscribe_without_a_token(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post("/api/unsubscribe/", {})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.profile.refresh_from_db()
+        self.assertFalse(self.profile.weekly_digest_opt_in)
+
+    def test_authenticated_user_cannot_unsubscribe_someone_else(self):
+        self.client.force_authenticate(user=self.user)
+        self.client.post("/api/unsubscribe/", {"email": "victim@example.com"})
+
+        self.other_profile.refresh_from_db()
+        self.assertTrue(self.other_profile.weekly_digest_opt_in)
+
+    def test_unsubscribing_twice_still_reads_as_success(self):
+        token = make_unsubscribe_token(self.user)
+        self.client.get(f"/api/unsubscribe/?token={token}")
+        second = self.client.get(f"/api/unsubscribe/?token={token}")
+
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertTrue(second.data["already_unsubscribed"])
+        self.assertEqual(second.data["unsubscribed_count"], 0)
+
+    def test_missing_token_explains_what_to_do(self):
+        response = self.client.get("/api/unsubscribe/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("missing its token", response.data["error"])
+
+
+class WeeklyDigestLinkTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="subscriber", password="password123", email="sub@example.com"
+        )
+        profile, _ = UserProfile.objects.get_or_create(user=self.user)
+        profile.weekly_digest_opt_in = True
+        profile.save()
+
+    def test_digest_email_carries_a_token_not_an_email_address(self):
+        from django.core import mail
+
+        call_command("send_weekly_digest")
+
+        self.assertEqual(len(mail.outbox), 1)
+        body = mail.outbox[0].body
+        self.assertIn("/unsubscribe?token=", body)
+        self.assertNotIn("/unsubscribe?email=", body)
+
+    def test_the_link_in_the_email_actually_works(self):
+        from django.core import mail
+
+        call_command("send_weekly_digest")
+        body = mail.outbox[0].body
+        token = body.split("/unsubscribe?token=")[1].split()[0]
+
+        response = APIClient().get(f"/api/unsubscribe/?token={token}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        profile = UserProfile.objects.get(user=self.user)
+        self.assertFalse(profile.weekly_digest_opt_in)
+
+    def test_dry_run_does_not_send_anything(self):
+        """``options.get("dry-run")`` never matched argparse's "dry_run" key."""
+        from django.core import mail
+
+        call_command("send_weekly_digest", "--dry-run")
+
+        self.assertEqual(len(mail.outbox), 0)

--- a/backend/analyzer/unsubscribe_tokens.py
+++ b/backend/analyzer/unsubscribe_tokens.py
@@ -1,0 +1,76 @@
+"""Signed tokens for one-click digest unsubscribe links.
+
+The weekly digest has to let people opt out from an email client, with no
+session and no login. Before this module the link carried a plain email
+address and the endpoint acted on whatever it was given, so anyone could
+unsubscribe anyone.
+
+A token here is the user's primary key, signed with the project ``SECRET_KEY``
+via :mod:`django.core.signing`, and stamped with the time it was issued. It
+proves the link came from an email we sent, without a database table to clean
+up and without exposing the address in the URL.
+
+Tokens are scoped by a salt, so a token minted here cannot be replayed against
+password reset or any other signed value in the project.
+"""
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core import signing
+from urllib.parse import urlencode
+
+#: Namespaces the signature so these tokens only work for unsubscribing.
+UNSUBSCRIBE_SALT = "analyzer.digest.unsubscribe"
+
+#: How long a link stays valid. Digests go out weekly and people read email
+#: late, so this is generous — it is a convenience token, not a credential.
+DEFAULT_MAX_AGE_DAYS = 90
+
+
+def get_max_age_seconds() -> int:
+    """Token lifetime in seconds, overridable with ``UNSUBSCRIBE_TOKEN_MAX_AGE_DAYS``."""
+    days = getattr(settings, "UNSUBSCRIBE_TOKEN_MAX_AGE_DAYS", DEFAULT_MAX_AGE_DAYS)
+    return int(days) * 24 * 60 * 60
+
+
+def make_unsubscribe_token(user) -> str:
+    """Return a signed, timestamped token identifying ``user``."""
+    return signing.dumps({"uid": user.pk}, salt=UNSUBSCRIBE_SALT)
+
+
+def read_unsubscribe_token(token: str, max_age: int = None):
+    """Return the user a token belongs to, or ``None``.
+
+    ``None`` covers every failure mode — malformed, tampered with, expired, or
+    pointing at a user who has since deleted their account. Callers are not
+    told which, so the endpoint cannot be used to probe for valid accounts.
+    """
+    if not token or not isinstance(token, str):
+        return None
+
+    try:
+        payload = signing.loads(
+            token,
+            salt=UNSUBSCRIBE_SALT,
+            max_age=get_max_age_seconds() if max_age is None else max_age,
+        )
+    except signing.BadSignature:
+        # Covers SignatureExpired too — it is a BadSignature subclass.
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    user_id = payload.get("uid")
+    if user_id is None:
+        return None
+
+    User = get_user_model()
+    return User.objects.filter(pk=user_id).first()
+
+
+def build_unsubscribe_url(user, frontend_url: str = None) -> str:
+    """Build the unsubscribe link that goes into a digest email."""
+    base = frontend_url or getattr(settings, "FRONTEND_URL", "http://localhost:5173")
+    query = urlencode({"token": make_unsubscribe_token(user)})
+    return f"{base.rstrip('/')}/unsubscribe?{query}"

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -870,41 +870,68 @@ def contact_us_view(request):
     )
 
 
+from .unsubscribe_tokens import read_unsubscribe_token
+
+UNSUBSCRIBE_SUCCESS_MESSAGE = (
+    "You have successfully unsubscribed from the weekly resume-tips email digest."
+)
+
+UNSUBSCRIBE_MISSING_TOKEN_MESSAGE = (
+    "This unsubscribe link is missing its token. Please use the link from your "
+    "most recent digest email, or sign in and turn the digest off from your profile."
+)
+
+UNSUBSCRIBE_INVALID_TOKEN_MESSAGE = (
+    "This unsubscribe link is no longer valid — it may have expired. Please use "
+    "the link from your most recent digest email, or sign in and turn the digest "
+    "off from your profile."
+)
+
+
 @api_view(["GET", "POST"])
 @permission_classes([AllowAny])
 def unsubscribe_digest_view(request):
-    email = request.query_params.get("email") or request.data.get("email")
-    username = request.query_params.get("username") or request.data.get("username")
+    """Turn off the weekly digest for the account a signed token identifies.
 
-    if not email and not username:
+    The endpoint used to act on a bare email address, so anyone could
+    unsubscribe anyone, and its 404-vs-200 responses revealed which addresses
+    were registered. It now requires either a signed token from a digest email
+    or an authenticated session, and the response no longer depends on whether
+    a given account exists.
+    """
+    token = request.query_params.get("token") or request.data.get("token")
+
+    if token:
+        user = read_unsubscribe_token(token)
+        if user is None:
+            return Response(
+                {"error": UNSUBSCRIBE_INVALID_TOKEN_MESSAGE},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+    elif request.user.is_authenticated:
+        user = request.user
+    else:
+        # No token and no session. Whatever the caller typed — an email, a
+        # username — is unverified, so nothing is looked up and the answer is
+        # the same whether or not that account exists.
         return Response(
-            {"error": "Please provide your email address or username to unsubscribe."},
+            {"error": UNSUBSCRIBE_MISSING_TOKEN_MESSAGE},
             status=status.HTTP_400_BAD_REQUEST,
         )
 
-    users = User.objects.all()
-    if email:
-        users = users.filter(email__iexact=email.strip())
-    elif username:
-        users = users.filter(username__iexact=username.strip())
-
-    if not users.exists():
-        return Response(
-            {"detail": "User not found or already unsubscribed."},
-            status=status.HTTP_404_NOT_FOUND,
-        )
-
-    updated_count = 0
-    for u in users:
-        profile, _ = UserProfile.objects.get_or_create(user=u)
+    profile, _ = UserProfile.objects.get_or_create(user=user)
+    already_unsubscribed = not profile.weekly_digest_opt_in
+    if not already_unsubscribed:
         profile.weekly_digest_opt_in = False
-        profile.save()
-        updated_count += 1
+        profile.save(update_fields=["weekly_digest_opt_in"])
 
     return Response(
         {
-            "message": "You have successfully unsubscribed from the weekly resume-tips email digest.",
-            "unsubscribed_count": updated_count,
+            "message": UNSUBSCRIBE_SUCCESS_MESSAGE,
+            # Kept for the existing frontend. Unsubscribing twice is a no-op
+            # rather than an error, so a repeated click still reads as success.
+            "unsubscribed_count": 0 if already_unsubscribed else 1,
+            "already_unsubscribed": already_unsubscribed,
         },
         status=status.HTTP_200_OK,
     )

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -160,6 +160,14 @@ RESUME_UPLOAD_RATE = os.environ.get('RESUME_UPLOAD_RATE', '10/hour')
 # Retention (in days) for uploaded resume files and temporary storage
 RESUME_RETENTION_DAYS = int(os.environ.get('RESUME_RETENTION_DAYS', '30'))
 
+# Public URL of the frontend, used to build links that go out by email
+# (currently the weekly digest unsubscribe link).
+FRONTEND_URL = os.environ.get('FRONTEND_URL', 'http://localhost:5173')
+
+# How long a signed unsubscribe link stays usable. Digests are weekly and
+# people read email late, so this is deliberately generous.
+UNSUBSCRIBE_TOKEN_MAX_AGE_DAYS = int(os.environ.get('UNSUBSCRIBE_TOKEN_MAX_AGE_DAYS', '90'))
+
 SENTRY_DSN = os.environ.get('SENTRY_DSN')
 
 if SENTRY_DSN:

--- a/frontend/src/pages/UnsubscribePage.tsx
+++ b/frontend/src/pages/UnsubscribePage.tsx
@@ -4,18 +4,25 @@ import axios from 'axios'
 
 const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
 
+const MISSING_TOKEN_MESSAGE =
+  'This page needs the unsubscribe link from one of your digest emails. Open the ' +
+  'most recent one and use the link at the bottom, or sign in and turn the digest ' +
+  'off from your profile.'
+
 export const UnsubscribePage: React.FC = () => {
   const [searchParams] = useSearchParams()
-  const emailParam = searchParams.get('email') || ''
-  
-  const [email, setEmail] = useState(emailParam)
+  const tokenParam = searchParams.get('token') || ''
+
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
   const [message, setMessage] = useState<string | null>(null)
 
-  const handleUnsubscribe = async (targetEmail: string) => {
-    if (!targetEmail.trim()) {
+  const handleUnsubscribe = async (token: string) => {
+    // The backend identifies the account from the signed token in the link.
+    // An email address typed into this page proves nothing, so it is no
+    // longer sent — and no longer accepted.
+    if (!token) {
       setStatus('error')
-      setMessage('Please enter a valid email address.')
+      setMessage(MISSING_TOKEN_MESSAGE)
       return
     }
 
@@ -23,24 +30,29 @@ export const UnsubscribePage: React.FC = () => {
     setMessage(null)
 
     try {
-      const response = await axios.post(`${BACKEND}/api/unsubscribe/`, {
-        email: targetEmail.trim(),
-      })
+      const response = await axios.post(`${BACKEND}/api/unsubscribe/`, { token })
       setStatus('success')
       setMessage(response.data.message || 'Successfully unsubscribed from weekly resume tips.')
     } catch (err: any) {
       setStatus('error')
       setMessage(
-        err.response?.data?.detail || err.response?.data?.error || 'Failed to unsubscribe. User might not exist or is already unsubscribed.'
+        err.response?.data?.error ||
+          err.response?.data?.detail ||
+          'We could not process that unsubscribe link. Please try the link in your most recent digest email.'
       )
     }
   }
 
   useEffect(() => {
-    if (emailParam) {
-      handleUnsubscribe(emailParam)
+    if (tokenParam) {
+      handleUnsubscribe(tokenParam)
+    } else {
+      // Older digest emails linked here with ?email=..., which the backend no
+      // longer honours. Explain what to do instead of silently doing nothing.
+      setStatus('error')
+      setMessage(MISSING_TOKEN_MESSAGE)
     }
-  }, [emailParam])
+  }, [tokenParam])
 
   return (
     <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '60px 20px' }}>
@@ -88,39 +100,25 @@ export const UnsubscribePage: React.FC = () => {
           </div>
         )}
 
-        {status !== 'success' && (
-          <form
-            onSubmit={(e) => {
-              e.preventDefault()
-              handleUnsubscribe(email)
-            }}
-            style={{ display: 'flex', flexDirection: 'column', gap: '14px', marginBottom: '20px' }}
+        {status === 'error' && tokenParam && (
+          <button
+            type="button"
+            className="app-btn app-btn--primary"
+            onClick={() => handleUnsubscribe(tokenParam)}
+            style={{ width: '100%', marginBottom: '20px' }}
           >
-            <input
-              type="email"
-              placeholder="Enter your email address"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              disabled={status === 'loading'}
-              style={{
-                padding: '10px 14px',
-                borderRadius: 'var(--radius-md)',
-                border: '1px solid var(--control-border)',
-                background: 'var(--control-bg)',
-                color: 'var(--control-text)',
-                fontSize: '0.95rem',
-                outline: 'none'
-              }}
-            />
-            <button
-              type="submit"
-              className="app-btn app-btn--primary"
-              disabled={status === 'loading'}
-              style={{ width: '100%' }}
-            >
-              Unsubscribe Me
-            </button>
-          </form>
+            Try Again
+          </button>
+        )}
+
+        {status === 'error' && !tokenParam && (
+          <Link
+            to="/#profile"
+            className="app-btn app-btn--primary"
+            style={{ display: 'block', width: '100%', marginBottom: '20px', textDecoration: 'none' }}
+          >
+            Manage Preferences in My Profile
+          </Link>
         )}
 
         <div style={{ marginTop: '20px' }}>


### PR DESCRIPTION
Fixes #553

## The problem

`/api/unsubscribe/` took an email address (or username) and turned off that account's digest. No authentication, no signature, no proof the caller owned the address:

```bash
curl "http://127.0.0.1:8000/api/unsubscribe/?email=someone-else@example.com"
# 200 {"message": "You have successfully unsubscribed...", "unsubscribed_count": 1}
```

And because it answered `404` for unknown addresses and `200` for known ones, it doubled as a free account-enumeration oracle — feed it a list of emails and the status codes tell you which are registered.

## Approach

A signed token in the link, using `django.core.signing`. No new dependency, no new table, nothing to expire out of the database.

```python
# analyzer/unsubscribe_tokens.py
UNSUBSCRIBE_SALT = "analyzer.digest.unsubscribe"

def make_unsubscribe_token(user):
    return signing.dumps({"uid": user.pk}, salt=UNSUBSCRIBE_SALT)
```

The token is the user id signed with `SECRET_KEY` and stamped with its issue time. The salt namespaces it, so a signed value minted anywhere else in the project cannot be replayed against this endpoint — there is a test for that. It also keeps the email address out of the URL, which the old link put in plain text in every inbox, forwarded message and referrer header.

Lifetime defaults to 90 days (`UNSUBSCRIBE_TOKEN_MAX_AGE_DAYS`). Digests go weekly and people read email late; this is a convenience token, not a credential.

## Endpoint behaviour

| request | before | after |
|---|---|---|
| valid token | — | 200, unsubscribed |
| authenticated, no token | 400 | 200, unsubscribes the caller |
| `?email=` for someone else | **200, unsubscribed** | 400, nothing changes |
| `?email=` for a real account | 200 | 400 |
| `?email=` for an account that does not exist | **404** | 400 — identical response |
| invalid or expired token | — | 400, same message for both |
| unsubscribing twice | 200 | 200, `already_unsubscribed: true` |

`read_unsubscribe_token()` returns `None` for every failure mode — malformed, tampered, expired, or pointing at a deleted user — so the caller is never told which, and cannot use the difference to probe.

`unsubscribed_count` is kept in the response because the existing frontend reads it.

## Frontend

`UnsubscribePage.tsx` forwarded whatever was in `?email=` and auto-submitted it on mount. It now forwards `?token=`, and when a link arrives without one — an old digest email still sitting in someone's inbox — it says what to do rather than presenting a form that can no longer work:

> This page needs the unsubscribe link from one of your digest emails. Open the most recent one and use the link at the bottom, or sign in and turn the digest off from your profile.

The email input is gone. It only ever collected an address the backend now (correctly) refuses to act on.

## Also in this change

**`--dry-run` never worked.** `send_weekly_digest` read `options.get("dry-run")`, but argparse stores `--dry-run` under `dry_run`, so the value was always `None` and the command sent real email every time. Fixed, with a test asserting `mail.outbox` stays empty.

**`FRONTEND_URL` was never defined.** The digest command read it with `getattr(settings, "FRONTEND_URL", "http://localhost:5173")` and always got the fallback, so a deployed instance mailed out links pointing at localhost. Now in `settings.py` and `.env.example`.

## Tests

`backend/analyzer/tests_unsubscribe.py` — 24 tests:

- token round-trip, tampering, expiry, foreign salt, deleted user, malformed input
- the token does not contain the email address
- **the reported bug**: `?email=victim@example.com` no longer unsubscribes the victim
- one user's token cannot unsubscribe another
- known and unknown addresses produce byte-identical responses
- the link that actually goes out in the digest email works end to end
- `--dry-run` sends nothing

`tests.py::test_unsubscribe_endpoint` asserted the old `?email=` flow; it now uses a token and points at the new file for the rest.

```
Ran 71 tests — the 3 failures are pre-existing on main
(ProfileAvatarTests ×2, CaptchaProtectionTests ×1, all login/captcha related)
```

## Migration note

Digest emails already delivered carry `?email=` links that will now land on the "use a recent link" page. Since the digest goes out weekly, the next send replaces them. No data migration needed — tokens are derived, not stored.
