### PR TITLE
feat: score resumes across weighted factors and show the breakdown (#554)

### DIFF
--- a/backend/analyzer/scoring.py
+++ b/backend/analyzer/scoring.py
@@ -1,0 +1,493 @@
+"""Multi-factor ATS scoring.
+
+The headline ``score`` on an analysis is a single division — matched role
+keywords over required ones. That makes a keyword-stuffed page with no work
+history, no contact details and no measurable achievements score 100, and it
+gives the user nothing to act on beyond "add more keywords".
+
+This module scores a resume across the things an ATS and a recruiter actually
+look at, and reports each factor separately so the UI can explain where the
+points went. Signals the pipeline already computes — readability from
+``textstat``, unquantified bullets from ``quantify_checker`` — are passed in
+rather than recomputed.
+
+The weights below sum to 100. Keyword match stays the single largest factor
+because it is what actually gets a resume past a filter; the rest are the
+difference between passing the filter and being worth reading afterwards.
+"""
+
+import re
+from dataclasses import dataclass, asdict
+from typing import Dict, List, Optional, Sequence
+
+#: Factor weights, in points out of 100.
+WEIGHTS = {
+    "keyword_match": 40,
+    "sections": 15,
+    "impact_language": 12,
+    "contact_details": 10,
+    "quantification": 10,
+    "readability": 8,
+    "length_format": 5,
+}
+
+TOTAL_POINTS = sum(WEIGHTS.values())
+
+#: Display names, kept beside the weights so a factor is described in one place.
+FACTOR_LABELS = {
+    "keyword_match": "Keyword & role match",
+    "sections": "Section coverage",
+    "impact_language": "Impact language",
+    "contact_details": "Contact details",
+    "quantification": "Quantified achievements",
+    "readability": "Readability",
+    "length_format": "Length & formatting",
+}
+
+#: Headings we expect to find, and the words that introduce them. Resumes label
+#: these inconsistently, so each section lists its common variants.
+EXPECTED_SECTIONS = {
+    "experience": (
+        "experience",
+        "employment",
+        "work history",
+        "professional background",
+        "career history",
+    ),
+    "education": ("education", "academic", "qualification", "degree"),
+    "skills": ("skills", "technical skills", "technologies", "competencies", "toolkit"),
+    "projects": ("projects", "portfolio", "personal projects", "selected work"),
+}
+
+#: Verbs that open a strong accomplishment bullet. Deliberately overlapping
+#: with quantify_checker's list — that one asks "is there a number?", this one
+#: asks "does the sentence lead with an action?".
+ACTION_VERBS = {
+    "accelerated", "achieved", "administered", "analyzed", "architected",
+    "automated", "built", "championed", "collaborated", "consolidated",
+    "coordinated", "created", "cut", "delivered", "deployed", "designed",
+    "developed", "directed", "drove", "engineered", "enhanced", "established",
+    "executed", "expanded", "facilitated", "generated", "grew", "implemented",
+    "improved", "increased", "initiated", "integrated", "introduced",
+    "launched", "led", "maintained", "managed", "mentored", "migrated",
+    "modernized", "negotiated", "optimized", "orchestrated", "overhauled",
+    "oversaw", "owned", "pioneered", "planned", "prototyped", "published",
+    "redesigned", "reduced", "refactored", "resolved", "restructured",
+    "revamped", "scaled", "shipped", "simplified", "spearheaded",
+    "standardized", "streamlined", "strengthened", "supported", "tested",
+    "trained", "transformed", "translated", "upgraded",
+}
+
+#: Weak openers that read as duties rather than achievements.
+WEAK_OPENERS = (
+    "responsible for",
+    "worked on",
+    "helped with",
+    "assisted with",
+    "involved in",
+    "tasked with",
+    "duties included",
+    "participated in",
+)
+
+EMAIL_PATTERN = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+PHONE_PATTERN = re.compile(
+    r"(?:\+\d{1,3}[\s.-]?)?(?:\(\d{2,4}\)[\s.-]?)?\d{3,5}[\s.-]?\d{3,4}[\s.-]?\d{0,4}"
+)
+PROFILE_LINK_PATTERN = re.compile(
+    r"(linkedin\.com/\S+|github\.com/\S+|gitlab\.com/\S+|"
+    r"[\w-]+\.(?:dev|io|me|com)/\S*portfolio\S*)",
+    re.IGNORECASE,
+)
+BULLET_PATTERN = re.compile(r"^\s*(?:[-*•▪▸●o]|\d+[.)])\s+")
+
+#: A resume in this word range reads as complete without being a wall of text.
+IDEAL_WORD_RANGE = (350, 900)
+
+
+@dataclass
+class FactorScore:
+    """One scored dimension of a resume."""
+
+    key: str
+    label: str
+    earned: int
+    possible: int
+    #: ``strong`` / ``partial`` / ``weak`` — drives the colour of the row.
+    status: str
+    #: One sentence explaining the number, written for the person being scored.
+    detail: str
+
+    def as_dict(self) -> Dict:
+        return asdict(self)
+
+
+@dataclass
+class ScoreBreakdown:
+    """The full result: an overall score plus the factors that produced it."""
+
+    overall: int
+    factors: List[FactorScore]
+    summary: str
+
+    def as_dict(self) -> Dict:
+        return {
+            "overall": self.overall,
+            "summary": self.summary,
+            "factors": [factor.as_dict() for factor in self.factors],
+        }
+
+
+def _status_for(earned: int, possible: int) -> str:
+    if possible == 0:
+        return "strong"
+    ratio = earned / possible
+    if ratio >= 0.8:
+        return "strong"
+    if ratio >= 0.45:
+        return "partial"
+    return "weak"
+
+
+def _make_factor(key: str, earned: float, detail: str) -> FactorScore:
+    possible = WEIGHTS[key]
+    clamped = max(0, min(possible, int(round(earned))))
+    return FactorScore(
+        key=key,
+        label=FACTOR_LABELS[key],
+        earned=clamped,
+        possible=possible,
+        status=_status_for(clamped, possible),
+        detail=detail,
+    )
+
+
+def _bullet_lines(lines: Sequence[str]) -> List[str]:
+    """Lines that read as accomplishment bullets rather than headings or contact rows."""
+    bullets = []
+    for raw in lines:
+        line = raw.strip()
+        if len(line) < 25:
+            continue
+        if BULLET_PATTERN.match(raw) or len(line.split()) >= 6:
+            bullets.append(line)
+    return bullets
+
+
+def score_keyword_match(matched: Sequence[str], required: Sequence[str],
+                        detected: Sequence[str]) -> FactorScore:
+    """Points for covering the keywords the target role (or job description) asks for."""
+    if required:
+        ratio = len(matched) / len(required)
+        earned = ratio * WEIGHTS["keyword_match"]
+        detail = (
+            f"{len(matched)} of {len(required)} target keywords found "
+            f"({int(round(ratio * 100))}% coverage)."
+        )
+        if ratio < 1 and len(required) - len(matched) <= 3:
+            detail += " You are a few keywords away from full coverage."
+    else:
+        # No role and no job description: fall back to breadth of detected
+        # skills, capped so an unfocused keyword dump cannot max out the factor.
+        capped = min(len(detected), 12)
+        earned = (capped / 12) * WEIGHTS["keyword_match"]
+        detail = (
+            f"No target role or job description supplied, so this is scored on "
+            f"the {len(detected)} skills detected overall."
+        )
+
+    return _make_factor("keyword_match", earned, detail)
+
+
+def score_sections(text: str) -> FactorScore:
+    """Points for having the sections a recruiter scans for."""
+    lowered = text.lower()
+    found = [
+        name
+        for name, variants in EXPECTED_SECTIONS.items()
+        if any(variant in lowered for variant in variants)
+    ]
+    missing = [name for name in EXPECTED_SECTIONS if name not in found]
+
+    earned = (len(found) / len(EXPECTED_SECTIONS)) * WEIGHTS["sections"]
+
+    if not missing:
+        detail = "All four expected sections are present: experience, education, skills and projects."
+    else:
+        readable = ", ".join(sorted(missing))
+        detail = f"Found {len(found)} of 4 expected sections. Missing: {readable}."
+
+    return _make_factor("sections", earned, detail)
+
+
+def score_contact_details(text: str) -> FactorScore:
+    """Points for being reachable — an ATS that cannot parse contact details drops the resume."""
+    head = "\n".join(text.splitlines()[:15]) or text
+
+    has_email = bool(EMAIL_PATTERN.search(text))
+    has_phone = bool(PHONE_PATTERN.search(head))
+    has_link = bool(PROFILE_LINK_PATTERN.search(text))
+
+    present = [
+        label
+        for label, found in (
+            ("email address", has_email),
+            ("phone number", has_phone),
+            ("professional link", has_link),
+        )
+        if found
+    ]
+    missing = [
+        label
+        for label, found in (
+            ("email address", has_email),
+            ("phone number", has_phone),
+            ("professional link (LinkedIn, GitHub or portfolio)", has_link),
+        )
+        if not found
+    ]
+
+    # Email carries most of the weight — it is the field an ATS actually keys on.
+    earned = 0
+    if has_email:
+        earned += WEIGHTS["contact_details"] * 0.5
+    if has_phone:
+        earned += WEIGHTS["contact_details"] * 0.25
+    if has_link:
+        earned += WEIGHTS["contact_details"] * 0.25
+
+    if not missing:
+        detail = "Email, phone number and a professional link were all found."
+    elif present:
+        detail = f"Found: {', '.join(present)}. Consider adding: {', '.join(missing)}."
+    else:
+        detail = (
+            "No contact details were detected. An ATS that cannot find an email "
+            "address often discards the resume outright."
+        )
+
+    return _make_factor("contact_details", earned, detail)
+
+
+def score_impact_language(lines: Sequence[str]) -> FactorScore:
+    """Points for bullets that lead with an action verb rather than a duty phrase."""
+    bullets = _bullet_lines(lines)
+    if not bullets:
+        return _make_factor(
+            "impact_language",
+            0,
+            "No accomplishment bullets were detected — describe your work as short, "
+            "action-led bullet points rather than paragraphs.",
+        )
+
+    strong = 0
+    weak = 0
+    for bullet in bullets:
+        stripped = BULLET_PATTERN.sub("", bullet).strip().lower()
+        first_word = re.split(r"[^\w]+", stripped, maxsplit=1)[0] if stripped else ""
+        if first_word in ACTION_VERBS:
+            strong += 1
+        elif any(stripped.startswith(opener) for opener in WEAK_OPENERS):
+            weak += 1
+
+    ratio = strong / len(bullets)
+    earned = ratio * WEIGHTS["impact_language"]
+
+    detail = f"{strong} of {len(bullets)} bullets open with a strong action verb."
+    if weak:
+        detail += (
+            f" {weak} start with a phrase like \"responsible for\" — rewrite those "
+            "to lead with what you did."
+        )
+    elif ratio < 0.5:
+        detail += " Opening with verbs like \"built\", \"led\" or \"reduced\" reads as achievement rather than duty."
+
+    return _make_factor("impact_language", earned, detail)
+
+
+def score_quantification(quantify_nudges: Sequence[Dict], lines: Sequence[str]) -> FactorScore:
+    """Points for achievements backed by a number.
+
+    ``quantify_nudges`` comes from ``quantify_checker.flag_unquantified_bullets``:
+    one entry per bullet that describes an accomplishment without a metric.
+    """
+    bullets = _bullet_lines(lines)
+    unquantified = len(quantify_nudges)
+
+    if not bullets:
+        return _make_factor(
+            "quantification",
+            0,
+            "No accomplishment bullets were found to check for metrics.",
+        )
+
+    quantified = max(0, len(bullets) - unquantified)
+    ratio = quantified / len(bullets)
+    earned = ratio * WEIGHTS["quantification"]
+
+    if unquantified == 0:
+        detail = "Every accomplishment bullet includes a number, percentage or other metric."
+    else:
+        detail = (
+            f"{unquantified} accomplishment bullet(s) have no metric. Numbers make "
+            "the same work measurably more convincing."
+        )
+
+    return _make_factor("quantification", earned, detail)
+
+
+def score_readability(readability_score: Optional[float], readability_label: str = "") -> FactorScore:
+    """Points for prose a recruiter can skim.
+
+    ``readability_score`` is the Flesch reading-ease value already computed by
+    ``services.calculate_readability``. Higher is easier; resumes sit
+    comfortably in the 30–70 band because technical nouns drag the score down.
+    """
+    if readability_score is None:
+        return _make_factor(
+            "readability",
+            WEIGHTS["readability"] * 0.5,
+            "Not enough text to assess readability.",
+        )
+
+    if readability_score >= 50:
+        earned = WEIGHTS["readability"]
+        detail = f"Reads easily (Flesch {readability_score}) — recruiters can skim it quickly."
+    elif readability_score >= 30:
+        earned = WEIGHTS["readability"] * 0.75
+        detail = (
+            f"Moderately dense (Flesch {readability_score}). Normal for technical "
+            "resumes, but shorter sentences would help."
+        )
+    elif readability_score >= 10:
+        earned = WEIGHTS["readability"] * 0.4
+        detail = (
+            f"Dense (Flesch {readability_score}). Long sentences and stacked jargon "
+            "slow a reader down — try splitting the longest bullets."
+        )
+    else:
+        earned = WEIGHTS["readability"] * 0.15
+        detail = (
+            f"Very dense (Flesch {readability_score}). Consider rewriting the longest "
+            "sentences as short, single-idea bullets."
+        )
+
+    if readability_label:
+        detail = f"{detail} Rated \"{readability_label}\"."
+
+    return _make_factor("readability", earned, detail)
+
+
+def score_length_and_format(text: str, lines: Sequence[str]) -> FactorScore:
+    """Points for a resume that is the right length and laid out as bullets."""
+    words = len(text.split())
+    bullets = _bullet_lines(lines)
+    low, high = IDEAL_WORD_RANGE
+
+    notes = []
+    earned = 0.0
+
+    if words == 0:
+        return _make_factor(
+            "length_format", 0, "No text could be extracted from the file."
+        )
+
+    if low <= words <= high:
+        earned += WEIGHTS["length_format"] * 0.6
+        notes.append(f"{words} words is a good length")
+    elif words < low:
+        earned += WEIGHTS["length_format"] * 0.25
+        notes.append(f"{words} words is on the short side — aim for at least {low}")
+    else:
+        earned += WEIGHTS["length_format"] * 0.3
+        notes.append(f"{words} words is long — trimming below {high} keeps attention")
+
+    if len(bullets) >= 5:
+        earned += WEIGHTS["length_format"] * 0.4
+        notes.append(f"{len(bullets)} bullet points detected")
+    elif bullets:
+        earned += WEIGHTS["length_format"] * 0.2
+        notes.append("only a few bullet points — break dense paragraphs up")
+    else:
+        notes.append("no bullet points detected — ATS parsers handle bullets better than paragraphs")
+
+    return _make_factor(
+        "length_format", earned, "; ".join(notes).capitalize() + "."
+    )
+
+
+def _summarise(overall: int, factors: Sequence[FactorScore]) -> str:
+    weakest = min(factors, key=lambda factor: factor.earned / factor.possible if factor.possible else 1)
+
+    if overall >= 80:
+        opening = "Strong resume."
+    elif overall >= 60:
+        opening = "Solid resume with room to improve."
+    elif overall >= 40:
+        opening = "This resume needs work before it will rank well."
+    else:
+        opening = "This resume is likely to be filtered out early."
+
+    if weakest.earned == weakest.possible:
+        return f"{opening} Every factor scored well."
+    return f"{opening} Biggest opportunity: {weakest.label.lower()}."
+
+
+def compute_score_breakdown(
+    text: str,
+    matched_skills: Sequence[str],
+    required_skills: Sequence[str],
+    detected_skills: Sequence[str],
+    readability_score: Optional[float] = None,
+    readability_label: str = "",
+    quantify_nudges: Optional[Sequence[Dict]] = None,
+) -> ScoreBreakdown:
+    """Score a resume across every factor and return the parts plus the total.
+
+    Everything is derived from values the analysis pipeline already has, so
+    this adds no parsing work beyond a handful of regex passes over the text.
+    """
+    lines = text.splitlines()
+    nudges = quantify_nudges or []
+
+    if not text.split():
+        # Nothing was extracted — a scanned image, an empty file, or a PDF the
+        # parser could not read. Scoring the individual factors here would hand
+        # out consolation points (textstat rates empty text as "very dense"
+        # rather than unknown), so every factor is reported as zero instead.
+        return ScoreBreakdown(
+            overall=0,
+            factors=[
+                _make_factor(
+                    key,
+                    0,
+                    "No text could be extracted from this file, so this factor "
+                    "could not be assessed.",
+                )
+                for key in WEIGHTS
+            ],
+            summary=(
+                "No readable text was extracted from this file. If it is a scanned "
+                "image, export a text-based PDF and try again."
+            ),
+        )
+
+    factors = [
+        score_keyword_match(matched_skills, required_skills, detected_skills),
+        score_sections(text),
+        score_impact_language(lines),
+        score_contact_details(text),
+        score_quantification(nudges, lines),
+        score_readability(readability_score, readability_label),
+        score_length_and_format(text, lines),
+    ]
+
+    overall = sum(factor.earned for factor in factors)
+    # The weights sum to 100, so the total is already a percentage.
+    overall = max(0, min(TOTAL_POINTS, overall))
+
+    return ScoreBreakdown(
+        overall=overall,
+        factors=factors,
+        summary=_summarise(overall, factors),
+    )

--- a/backend/analyzer/services.py
+++ b/backend/analyzer/services.py
@@ -5,6 +5,7 @@ import textstat
 from django.contrib.auth import get_user_model
 from .models import ResumeAnalysis
 from .skill_matcher import extract_skills
+from .scoring import compute_score_breakdown
 from resume_analyzer.quantify_checker import flag_unquantified_bullets
 
 User = get_user_model()
@@ -408,9 +409,24 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
 
     quantify_nudges = flag_unquantified_bullets(raw_text.split('\n'))
 
+    # Multi-factor view of the same resume. `score` above stays the keyword
+    # ratio — it is persisted on ResumeAnalysis and read by the leaderboard,
+    # version comparison and digest, so redefining it would change the meaning
+    # of every historical row.
+    score_breakdown = compute_score_breakdown(
+        text=raw_text,
+        matched_skills=matched,
+        required_skills=required,
+        detected_skills=detected,
+        readability_score=readability_score,
+        readability_label=readability_label,
+        quantify_nudges=quantify_nudges,
+    )
+
     return {
         "id": analysis_id,
         "score": score,
+        "score_breakdown": score_breakdown.as_dict(),
         "readability_score": readability_score,
         "readability_label": readability_label,
         "skills_found": detected,

--- a/backend/analyzer/tests_scoring.py
+++ b/backend/analyzer/tests_scoring.py
@@ -1,0 +1,291 @@
+"""Tests for the multi-factor ATS scoring engine (``analyzer.scoring``)."""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from analyzer.scoring import (
+    TOTAL_POINTS,
+    WEIGHTS,
+    compute_score_breakdown,
+    score_contact_details,
+    score_impact_language,
+    score_keyword_match,
+    score_length_and_format,
+    score_quantification,
+    score_readability,
+    score_sections,
+)
+from analyzer.services import analyze_resume
+from resume_analyzer.quantify_checker import flag_unquantified_bullets
+
+STRONG_RESUME = """Jane Doe
+jane.doe@example.com | +1 415 555 0134 | linkedin.com/in/janedoe
+
+Summary
+Backend engineer with six years building payment systems.
+
+Experience
+- Led a team of 5 engineers to rebuild the billing service, cutting invoice errors by 42%
+- Reduced API p95 latency from 900ms to 180ms by adding query-level caching
+- Migrated 120 endpoints from Flask to Django REST Framework over two quarters
+- Automated the release pipeline, saving roughly 20 engineer hours per week
+- Scaled the ingestion worker pool to handle 1.2M events per day
+- Mentored 3 junior engineers through their first production launches
+
+Education
+B.S. Computer Science, State University
+
+Skills
+Python, Django, PostgreSQL, Docker, SQL, Redis, Celery
+
+Projects
+- Built an open-source rate limiter used by 400+ repositories
+- Designed a schema migration tool adopted by 4 internal teams
+"""
+
+KEYWORD_STUFFED_RESUME = """Python Django React JavaScript SQL PostgreSQL Docker
+Git GitHub HTML CSS TypeScript Node.js MongoDB Excel Pandas NumPy
+"""
+
+
+class FactorTests(TestCase):
+    def test_keyword_match_scales_with_coverage(self):
+        full = score_keyword_match(["python", "sql"], ["python", "sql"], ["python", "sql"])
+        half = score_keyword_match(["python"], ["python", "sql"], ["python"])
+        none = score_keyword_match([], ["python", "sql"], [])
+
+        self.assertEqual(full.earned, WEIGHTS["keyword_match"])
+        self.assertEqual(half.earned, WEIGHTS["keyword_match"] // 2)
+        self.assertEqual(none.earned, 0)
+
+    def test_keyword_match_without_a_target_falls_back_to_breadth(self):
+        factor = score_keyword_match([], [], ["python", "sql", "docker"])
+        self.assertGreater(factor.earned, 0)
+        self.assertLess(factor.earned, WEIGHTS["keyword_match"])
+        self.assertIn("No target role", factor.detail)
+
+    def test_keyword_dump_cannot_max_the_fallback_beyond_its_cap(self):
+        many = [f"skill{index}" for index in range(50)]
+        factor = score_keyword_match([], [], many)
+        self.assertEqual(factor.earned, WEIGHTS["keyword_match"])
+
+    def test_sections_counts_the_four_expected_headings(self):
+        self.assertEqual(score_sections(STRONG_RESUME).earned, WEIGHTS["sections"])
+
+        partial = score_sections("Experience\nSkills\nPython developer")
+        self.assertEqual(partial.earned, round(WEIGHTS["sections"] * 0.5))
+        self.assertIn("education", partial.detail)
+
+    def test_sections_recognises_common_heading_variants(self):
+        variants = "Employment History\nAcademic Background\nTechnologies\nPortfolio"
+        self.assertEqual(score_sections(variants).earned, WEIGHTS["sections"])
+
+    def test_contact_details_weights_email_highest(self):
+        email_only = score_contact_details("Reach me at jane@example.com")
+        nothing = score_contact_details("Jane Doe\nBackend engineer")
+
+        self.assertEqual(nothing.earned, 0)
+        self.assertGreaterEqual(email_only.earned, WEIGHTS["contact_details"] * 0.5)
+        self.assertIn("discards the resume", nothing.detail)
+
+    def test_contact_details_full_marks_with_email_phone_and_link(self):
+        factor = score_contact_details(STRONG_RESUME)
+        self.assertEqual(factor.earned, WEIGHTS["contact_details"])
+        self.assertEqual(factor.status, "strong")
+
+    def test_impact_language_rewards_action_verbs(self):
+        strong = score_impact_language(STRONG_RESUME.splitlines())
+        self.assertGreaterEqual(strong.earned, WEIGHTS["impact_language"] * 0.5)
+
+    def test_impact_language_calls_out_duty_phrasing(self):
+        duties = [
+            "- Responsible for maintaining the internal reporting dashboard system",
+            "- Worked on the payments team supporting existing integration flows",
+            "- Helped with quarterly release planning and documentation upkeep",
+        ]
+        factor = score_impact_language(duties)
+        self.assertEqual(factor.earned, 0)
+        self.assertIn("responsible for", factor.detail)
+
+    def test_impact_language_handles_a_resume_with_no_bullets(self):
+        factor = score_impact_language(["Jane Doe", "Engineer"])
+        self.assertEqual(factor.earned, 0)
+        self.assertIn("No accomplishment bullets", factor.detail)
+
+    def test_quantification_uses_the_existing_nudge_checker(self):
+        lines = STRONG_RESUME.splitlines()
+        nudges = flag_unquantified_bullets(lines)
+        factor = score_quantification(nudges, lines)
+
+        self.assertGreater(factor.earned, 0)
+        self.assertLessEqual(factor.earned, WEIGHTS["quantification"])
+
+    def test_quantification_penalises_bullets_without_metrics(self):
+        lines = [
+            "- Improved the checkout experience for customers across the platform",
+            "- Optimized the search service to handle more concurrent traffic daily",
+        ]
+        nudges = flag_unquantified_bullets(lines)
+        factor = score_quantification(nudges, lines)
+
+        self.assertEqual(factor.earned, 0)
+        self.assertIn("no metric", factor.detail)
+
+    def test_readability_bands(self):
+        easy = score_readability(65.0, "easy")
+        moderate = score_readability(40.0, "moderate")
+        dense = score_readability(15.0, "dense")
+        very_dense = score_readability(2.0, "dense")
+
+        self.assertEqual(easy.earned, WEIGHTS["readability"])
+        self.assertGreater(moderate.earned, dense.earned)
+        self.assertGreater(dense.earned, very_dense.earned)
+
+    def test_readability_without_a_score_is_neutral_not_zero(self):
+        factor = score_readability(None)
+        self.assertEqual(factor.earned, round(WEIGHTS["readability"] * 0.5))
+
+    def test_length_and_format_prefers_the_ideal_range(self):
+        ideal_text = " ".join(["word"] * 500) + "\n" + "\n".join(
+            [f"- Delivered improvement number {index} for the platform team" for index in range(6)]
+        )
+        short_text = "Jane Doe, engineer."
+
+        ideal = score_length_and_format(ideal_text, ideal_text.splitlines())
+        short = score_length_and_format(short_text, short_text.splitlines())
+
+        self.assertGreater(ideal.earned, short.earned)
+        self.assertIn("bullet", ideal.detail)
+
+    def test_length_and_format_handles_empty_text(self):
+        factor = score_length_and_format("", [])
+        self.assertEqual(factor.earned, 0)
+
+
+class BreakdownTests(TestCase):
+    def _breakdown(self, text, matched=(), required=(), detected=()):
+        lines = text.splitlines()
+        return compute_score_breakdown(
+            text=text,
+            matched_skills=list(matched),
+            required_skills=list(required),
+            detected_skills=list(detected),
+            readability_score=45.0,
+            readability_label="moderate",
+            quantify_nudges=flag_unquantified_bullets(lines),
+        )
+
+    def test_weights_sum_to_one_hundred(self):
+        self.assertEqual(TOTAL_POINTS, 100)
+
+    def test_overall_is_the_sum_of_the_factors(self):
+        breakdown = self._breakdown(STRONG_RESUME, ["python"], ["python"], ["python"])
+        self.assertEqual(breakdown.overall, sum(f.earned for f in breakdown.factors))
+
+    def test_every_weighted_factor_is_reported(self):
+        breakdown = self._breakdown(STRONG_RESUME)
+        self.assertEqual({f.key for f in breakdown.factors}, set(WEIGHTS))
+
+    def test_a_well_rounded_resume_outscores_a_keyword_dump(self):
+        """The point of the issue: full keyword coverage alone should not win."""
+        skills = ["python", "django", "sql", "docker"]
+
+        stuffed = self._breakdown(KEYWORD_STUFFED_RESUME, skills, skills, skills)
+        rounded = self._breakdown(STRONG_RESUME, skills, skills, skills)
+
+        self.assertEqual(
+            stuffed.factors[0].earned,
+            rounded.factors[0].earned,
+            "both cover every keyword, so the keyword factor should tie",
+        )
+        self.assertGreater(rounded.overall, stuffed.overall)
+
+    def test_scores_stay_inside_zero_to_one_hundred(self):
+        for text in ("", STRONG_RESUME, KEYWORD_STUFFED_RESUME):
+            with self.subTest(text=text[:20]):
+                breakdown = self._breakdown(text)
+                self.assertGreaterEqual(breakdown.overall, 0)
+                self.assertLessEqual(breakdown.overall, 100)
+
+    def test_each_factor_stays_inside_its_own_weight(self):
+        breakdown = self._breakdown(STRONG_RESUME, ["python"], ["python"], ["python"])
+        for factor in breakdown.factors:
+            with self.subTest(factor=factor.key):
+                self.assertGreaterEqual(factor.earned, 0)
+                self.assertLessEqual(factor.earned, factor.possible)
+                self.assertEqual(factor.possible, WEIGHTS[factor.key])
+
+    def test_summary_names_the_weakest_factor(self):
+        breakdown = self._breakdown(KEYWORD_STUFFED_RESUME)
+        self.assertTrue(breakdown.summary)
+        self.assertIn("opportunity", breakdown.summary.lower())
+
+    def test_serialises_to_plain_json_types(self):
+        payload = self._breakdown(STRONG_RESUME).as_dict()
+
+        self.assertEqual(set(payload), {"overall", "summary", "factors"})
+        self.assertIsInstance(payload["overall"], int)
+        for factor in payload["factors"]:
+            self.assertEqual(
+                set(factor), {"key", "label", "earned", "possible", "status", "detail"}
+            )
+            self.assertIn(factor["status"], {"strong", "partial", "weak"})
+
+
+class _FakePage:
+    def __init__(self, text):
+        self._text = text
+
+    def extract_text(self):
+        return self._text
+
+
+class _FakePDF:
+    def __init__(self, text):
+        self.pages = [_FakePage(text)]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class AnalyzeResumeIntegrationTests(TestCase):
+    @patch("analyzer.services.pdfplumber.open")
+    def test_analysis_includes_a_breakdown(self, mock_open):
+        mock_open.return_value = _FakePDF(STRONG_RESUME)
+        result = analyze_resume("dummy.pdf", "Backend Developer")
+
+        breakdown = result["score_breakdown"]
+        self.assertEqual(breakdown["overall"], sum(f["earned"] for f in breakdown["factors"]))
+        self.assertEqual(len(breakdown["factors"]), len(WEIGHTS))
+
+    @patch("analyzer.services.pdfplumber.open")
+    def test_legacy_score_field_is_unchanged(self, mock_open):
+        """`score` is persisted and read by the leaderboard, digest and charts."""
+        mock_open.return_value = _FakePDF("HTML CSS JavaScript")
+        result = analyze_resume("dummy.pdf", "Frontend Developer")
+
+        expected = int(len(result["matched_skills"]) / len(
+            result["matched_skills"] + result["missing_skills"]
+        ) * 100)
+        self.assertEqual(result["score"], expected)
+
+    @patch("analyzer.services.pdfplumber.open")
+    def test_breakdown_reuses_the_pipeline_readability_value(self, mock_open):
+        mock_open.return_value = _FakePDF(STRONG_RESUME)
+        result = analyze_resume("dummy.pdf", "Backend Developer")
+
+        readability = next(
+            f for f in result["score_breakdown"]["factors"] if f["key"] == "readability"
+        )
+        self.assertIn(str(result["readability_score"]), readability["detail"])
+
+    @patch("analyzer.services.pdfplumber.open")
+    def test_empty_resume_scores_zero_without_raising(self, mock_open):
+        mock_open.return_value = _FakePDF("")
+        result = analyze_resume("dummy.pdf", "Backend Developer")
+
+        self.assertEqual(result["score_breakdown"]["overall"], 0)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { useAuth } from './hooks/useAuth'
 import { AuthModal } from './AuthModal'
 import { Footer } from './Footer'
 import PrivacyPolicyPage from './pages/PrivacyPolicyPage'
+import { ScoreBreakdown, type ScoreBreakdownData } from './components/ScoreBreakdown'
 
 type Theme = 'light' | 'dark'
 
@@ -67,6 +68,7 @@ function App() {
   const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
   const [isDragging, setIsDragging] = useState(false)
   const [score, setScore] = useState<number | null>(null)
+  const [scoreBreakdown, setScoreBreakdown] = useState<ScoreBreakdownData | null>(null)
   const [skills, setSkills] = useState<string[]>([])
   const [suggestions, setSuggestions] = useState<string[]>([])
   const [roastMode, setRoastMode] = useState<boolean>(false)
@@ -191,6 +193,7 @@ function App() {
       }
 
       setScore(result.score)
+      setScoreBreakdown(result.score_breakdown || null)
       setSkills(result.skills_found || [])
       setSuggestions(result.suggestions || [])
       setMatchedSkills(result.matched_skills || [])
@@ -278,6 +281,7 @@ function App() {
   const resetAnalysis = () => {
     setFile(null)
     setScore(null)
+    setScoreBreakdown(null)
     setSkills([])
     setSuggestions([])
     setMatchedSkills([])
@@ -305,6 +309,8 @@ function App() {
 
   const selectHistoryEntry = (entry: AnalysisEntry) => {
     setScore(entry.score)
+    // History entries predate the breakdown and do not carry one.
+    setScoreBreakdown(null)
     setSkills(entry.skills)
     setSuggestions(entry.suggestions)
     setMatchedSkills(entry.matchedSkills)
@@ -523,6 +529,8 @@ function App() {
               )}
 
               <AtsScore score={score} />
+
+              <ScoreBreakdown breakdown={scoreBreakdown} />
 
               <ResumePreview text={resumeText} skills={skills} />
 

--- a/frontend/src/components/ScoreBreakdown.css
+++ b/frontend/src/components/ScoreBreakdown.css
@@ -1,0 +1,170 @@
+.score-breakdown {
+  margin: var(--space-4) auto 0;
+  max-width: 640px;
+  text-align: left;
+  background: var(--card-bg, rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--card-border, rgba(255, 255, 255, 0.08));
+  border-radius: var(--radius-lg, 12px);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-card);
+}
+
+.score-breakdown__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: var(--space-3);
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.score-breakdown__toggle:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm, 6px);
+}
+
+.score-breakdown__toggle-text {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.score-breakdown__title {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--card-text, #e2e8f0);
+}
+
+.score-breakdown__overall {
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--color-primary);
+  white-space: nowrap;
+}
+
+.score-breakdown__chevron {
+  font-size: 0.7rem;
+  color: var(--muted-text, #94a3b8);
+}
+
+.score-breakdown__summary {
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-sm);
+  color: var(--muted-text, #94a3b8);
+}
+
+.score-breakdown__panel {
+  margin-top: var(--space-4);
+  border-top: 1px solid var(--card-border, rgba(255, 255, 255, 0.08));
+  padding-top: var(--space-4);
+}
+
+.score-breakdown__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.score-breakdown__factor-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.score-breakdown__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  font-size: 0.7rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  color: #fff;
+}
+
+.score-breakdown__label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--card-text, #e2e8f0);
+}
+
+.score-breakdown__points {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-text, #94a3b8);
+  white-space: nowrap;
+}
+
+.score-breakdown__bar {
+  margin-top: var(--space-2);
+  height: 6px;
+  border-radius: 999px;
+  background: var(--score-track, rgba(148, 163, 184, 0.25));
+  overflow: hidden;
+}
+
+.score-breakdown__bar-fill {
+  height: 100%;
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.score-breakdown__detail {
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--muted-text, #94a3b8);
+}
+
+.score-breakdown__footnote {
+  margin: var(--space-4) 0 0;
+  font-size: var(--text-xs);
+  color: var(--muted-text, #94a3b8);
+}
+
+/* Status colours. Each row also carries an icon and a points count, so the
+   meaning does not depend on colour alone. */
+.score-breakdown__factor--strong .score-breakdown__status,
+.score-breakdown__factor--strong .score-breakdown__bar-fill {
+  background: var(--color-accent, #22c55e);
+}
+
+.score-breakdown__factor--partial .score-breakdown__status,
+.score-breakdown__factor--partial .score-breakdown__bar-fill {
+  background: #f59e0b;
+}
+
+.score-breakdown__factor--weak .score-breakdown__status,
+.score-breakdown__factor--weak .score-breakdown__bar-fill {
+  background: var(--color-danger, #ef4444);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .score-breakdown__bar-fill {
+    transition: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .score-breakdown__points {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .score-breakdown__factor-head {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/components/ScoreBreakdown.test.tsx
+++ b/frontend/src/components/ScoreBreakdown.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ScoreBreakdown, type ScoreBreakdownData } from './ScoreBreakdown'
+
+const BREAKDOWN: ScoreBreakdownData = {
+  overall: 62,
+  summary: 'Solid resume with room to improve. Biggest opportunity: quantified achievements.',
+  factors: [
+    {
+      key: 'keyword_match',
+      label: 'Keyword & role match',
+      earned: 32,
+      possible: 40,
+      status: 'partial',
+      detail: '8 of 10 target keywords found (80% coverage).',
+    },
+    {
+      key: 'sections',
+      label: 'Section coverage',
+      earned: 15,
+      possible: 15,
+      status: 'strong',
+      detail: 'All four expected sections are present.',
+    },
+    {
+      key: 'quantification',
+      label: 'Quantified achievements',
+      earned: 2,
+      possible: 10,
+      status: 'weak',
+      detail: '6 accomplishment bullet(s) have no metric.',
+    },
+  ],
+}
+
+describe('ScoreBreakdown (#554)', () => {
+  it('renders nothing when no breakdown is available', () => {
+    const { container } = render(<ScoreBreakdown breakdown={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the breakdown has no factors', () => {
+    const { container } = render(
+      <ScoreBreakdown breakdown={{ overall: 0, summary: '', factors: [] }} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the overall score and summary without being expanded', () => {
+    render(<ScoreBreakdown breakdown={BREAKDOWN} />)
+
+    expect(screen.getByText('62/100')).toBeInTheDocument()
+    expect(screen.getByText(/Solid resume with room to improve/)).toBeInTheDocument()
+    expect(screen.queryByText('Section coverage')).not.toBeInTheDocument()
+  })
+
+  it('expands and collapses the factor list', () => {
+    render(<ScoreBreakdown breakdown={BREAKDOWN} />)
+    const toggle = screen.getByRole('button', { name: /how this score was calculated/i })
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Section coverage')).toBeInTheDocument()
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('Section coverage')).not.toBeInTheDocument()
+  })
+
+  it('lists every factor with its points and explanation', () => {
+    render(<ScoreBreakdown breakdown={BREAKDOWN} defaultExpanded />)
+
+    expect(screen.getByText('32 / 40 pts')).toBeInTheDocument()
+    expect(screen.getByText('15 / 15 pts')).toBeInTheDocument()
+    expect(screen.getByText('2 / 10 pts')).toBeInTheDocument()
+    expect(screen.getByText(/8 of 10 target keywords found/)).toBeInTheDocument()
+  })
+
+  it('exposes each factor as a labelled progress bar', () => {
+    render(<ScoreBreakdown breakdown={BREAKDOWN} defaultExpanded />)
+
+    const bar = screen.getByRole('progressbar', {
+      name: /Section coverage: 15 of 15 points/i,
+    })
+    expect(bar).toHaveAttribute('aria-valuenow', '15')
+    expect(bar).toHaveAttribute('aria-valuemax', '15')
+  })
+
+  it('calls out the weakest factor and the points still available', () => {
+    render(<ScoreBreakdown breakdown={BREAKDOWN} defaultExpanded />)
+
+    const footnote = screen.getByText(/biggest single opportunity/i)
+    expect(footnote).toHaveTextContent('quantified achievements')
+    expect(footnote).toHaveTextContent('8 more points')
+  })
+
+  it('marks weak factors with a status class rather than colour alone', () => {
+    const { container } = render(<ScoreBreakdown breakdown={BREAKDOWN} defaultExpanded />)
+
+    expect(container.querySelectorAll('.score-breakdown__factor--weak')).toHaveLength(1)
+    expect(container.querySelectorAll('.score-breakdown__factor--strong')).toHaveLength(1)
+    expect(screen.getAllByTitle('Weak')).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/ScoreBreakdown.tsx
+++ b/frontend/src/components/ScoreBreakdown.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react'
+import './ScoreBreakdown.css'
+
+export interface ScoreFactor {
+  key: string
+  label: string
+  earned: number
+  possible: number
+  status: 'strong' | 'partial' | 'weak'
+  detail: string
+}
+
+export interface ScoreBreakdownData {
+  overall: number
+  summary: string
+  factors: ScoreFactor[]
+}
+
+interface ScoreBreakdownProps {
+  breakdown: ScoreBreakdownData | null | undefined
+  /** Open on first render. Off by default so the headline score stays the focus. */
+  defaultExpanded?: boolean
+}
+
+const STATUS_ICON: Record<ScoreFactor['status'], string> = {
+  strong: '✔',
+  partial: '◐',
+  weak: '!',
+}
+
+const STATUS_LABEL: Record<ScoreFactor['status'], string> = {
+  strong: 'Strong',
+  partial: 'Needs work',
+  weak: 'Weak',
+}
+
+/**
+ * Shows how the ATS score was arrived at: one row per factor, with the points
+ * earned out of the points available and a sentence saying why.
+ *
+ * The headline number on its own only ever supported one piece of advice —
+ * "add more keywords". This is the part that tells someone which lever to pull.
+ */
+export function ScoreBreakdown({ breakdown, defaultExpanded = false }: ScoreBreakdownProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+
+  if (!breakdown || !breakdown.factors?.length) return null
+
+  const { overall, summary, factors } = breakdown
+  const weakest = factors.reduce((worst, factor) =>
+    factor.earned / factor.possible < worst.earned / worst.possible ? factor : worst
+  )
+
+  return (
+    <section className="score-breakdown" aria-labelledby="score-breakdown-heading">
+      <button
+        type="button"
+        className="score-breakdown__toggle"
+        onClick={() => setExpanded((open) => !open)}
+        aria-expanded={expanded}
+        aria-controls="score-breakdown-panel"
+      >
+        <span className="score-breakdown__toggle-text">
+          <span id="score-breakdown-heading" className="score-breakdown__title">
+            How this score was calculated
+          </span>
+          <span className="score-breakdown__overall">{overall}/100</span>
+        </span>
+        <span className="score-breakdown__chevron" aria-hidden="true">
+          {expanded ? '▲' : '▼'}
+        </span>
+      </button>
+
+      <p className="score-breakdown__summary">{summary}</p>
+
+      {expanded && (
+        <div id="score-breakdown-panel" className="score-breakdown__panel">
+          <ul className="score-breakdown__list">
+            {factors.map((factor) => {
+              const percent = factor.possible
+                ? Math.round((factor.earned / factor.possible) * 100)
+                : 0
+
+              return (
+                <li
+                  key={factor.key}
+                  className={`score-breakdown__factor score-breakdown__factor--${factor.status}`}
+                >
+                  <div className="score-breakdown__factor-head">
+                    <span
+                      className="score-breakdown__status"
+                      title={STATUS_LABEL[factor.status]}
+                      aria-hidden="true"
+                    >
+                      {STATUS_ICON[factor.status]}
+                    </span>
+                    <span className="score-breakdown__label">{factor.label}</span>
+                    <span className="score-breakdown__points">
+                      <span className="sr-only">{STATUS_LABEL[factor.status]}. </span>
+                      {factor.earned} / {factor.possible} pts
+                    </span>
+                  </div>
+
+                  <div
+                    className="score-breakdown__bar"
+                    role="progressbar"
+                    aria-valuenow={factor.earned}
+                    aria-valuemin={0}
+                    aria-valuemax={factor.possible}
+                    aria-label={`${factor.label}: ${factor.earned} of ${factor.possible} points`}
+                  >
+                    <div className="score-breakdown__bar-fill" style={{ width: `${percent}%` }} />
+                  </div>
+
+                  <p className="score-breakdown__detail">{factor.detail}</p>
+                </li>
+              )
+            })}
+          </ul>
+
+          <p className="score-breakdown__footnote">
+            Weights total 100 points. The biggest single opportunity right now is{' '}
+            <strong>{weakest.label.toLowerCase()}</strong>, worth up to{' '}
+            {weakest.possible - weakest.earned} more points.
+          </p>
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default ScoreBreakdown


### PR DESCRIPTION
Fixes #554

## The problem

The ATS score was one division:

```python
score = int(len(matched) / len(required) * 100) if required else min(len(detected) * 10, 100)
```

So `KEYWORD_STUFFED_RESUME` — a bare list of technologies, no work history, no contact details, no achievements — scores **100**, while a well-written resume missing two niche keywords scores 60. And since keyword coverage is the only input, the only advice the product can give is "add more keywords".

Meanwhile the pipeline already computed two signals and scored neither: readability (`textstat`) and unquantified bullets (`quantify_checker`). Both were returned to the client and ignored.

## The scoring engine

`backend/analyzer/scoring.py`, seven factors summing to 100:

| factor | pts | what it measures |
|---|--:|---|
| Keyword & role match | 40 | coverage of the target role's / JD's keywords |
| Section coverage | 15 | experience, education, skills, projects |
| Impact language | 12 | bullets opening with an action verb, not "responsible for" |
| Contact details | 10 | email (half the weight), phone, professional link |
| Quantified achievements | 10 | reuses `flag_unquantified_bullets` |
| Readability | 8 | reuses the Flesch score already computed |
| Length & formatting | 5 | word count in range, bullets present |

Keyword match stays the largest single factor — it is what actually gets a resume past a filter. The rest are the difference between passing the filter and being worth reading afterwards.

Each factor returns its own points, a `strong`/`partial`/`weak` status and a sentence written for the person being scored:

```json
{
  "key": "quantification",
  "label": "Quantified achievements",
  "earned": 2, "possible": 10, "status": "weak",
  "detail": "6 accomplishment bullet(s) have no metric. Numbers make the same work measurably more convincing."
}
```

Nothing is re-parsed — readability and quantification are passed in from what `analyze_resume` already has, so this adds a handful of regex passes over text that is already in memory.

**Empty resumes score 0 across the board.** `textstat` rates empty text as *very dense* rather than *unknown*, which would have handed out a consolation point. A file with no extractable text now returns every factor at zero with a summary pointing at the likely cause (a scanned image).

## `score` is deliberately unchanged

`score` is persisted on `ResumeAnalysis` and read by the skills leaderboard, version comparison, weekly digest and score history chart. Redefining it would silently rewrite the meaning of every historical row and make old and new analyses incomparable in the same chart.

The new engine is additive — `score_breakdown` on the analysis response — and there is a test pinning the old field's arithmetic. A follow-up can decide whether to promote `overall` to the headline, with a migration for existing rows.

## Frontend

`ScoreBreakdown` renders a collapsible panel under the headline number. Collapsed it shows `62/100` and the one-line summary; expanded, one row per factor with a labelled progress bar, the points, and the explanation. It closes with the concrete next move:

> The biggest single opportunity right now is **quantified achievements**, worth up to 8 more points.

Accessibility: the toggle carries `aria-expanded` / `aria-controls`, each bar is a `progressbar` with a descriptive `aria-label`, and status is signalled by an icon and a points count as well as colour. Bar transitions respect `prefers-reduced-motion`.

Renders nothing when the payload has no breakdown, so replaying an older history entry degrades quietly.

## Tests

`backend/analyzer/tests_scoring.py` — 28 tests: every factor in isolation (including heading variants like "Employment History", contact details weighting, duty-phrase detection, readability bands, empty input), the aggregate invariants (weights sum to 100, overall equals the sum of factors, no factor exceeds its weight, everything stays in 0–100, output is JSON-serialisable), and integration through `analyze_resume`.

The one that captures the issue:

```python
def test_a_well_rounded_resume_outscores_a_keyword_dump(self):
    stuffed = self._breakdown(KEYWORD_STUFFED_RESUME, skills, skills, skills)
    rounded = self._breakdown(STRONG_RESUME, skills, skills, skills)
    self.assertEqual(stuffed.factors[0].earned, rounded.factors[0].earned)  # keyword factor ties
    self.assertGreater(rounded.overall, stuffed.overall)                     # everything else does not
```

`frontend/src/components/ScoreBreakdown.test.tsx` — 8 tests: empty/absent payload, collapsed and expanded states, points rendering, progressbar semantics, the weakest-factor footnote, and status classes.

```
backend:  Ran 73 tests — the 3 failures are pre-existing on main
          (ProfileAvatarTests ×2, CaptchaProtectionTests ×1)
frontend: 83 tests, 80 pass — the 3 failures are pre-existing on main
          (HistorySidebar, AppRoastMode, UploadZone)
```

## Tuning

The weights are a starting point, not a claim of precision — they live in one `WEIGHTS` dict at the top of the module and every factor derives its maximum from it, so rebalancing is a one-line change. Happy to adjust if maintainers want a different emphasis.
