### PR TITLE
perf: paginate and slim the analysis history endpoint (#555)

### DIFF
--- a/backend/analyzer/serializers.py
+++ b/backend/analyzer/serializers.py
@@ -47,11 +47,28 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
 
 
 class ResumeAnalysisSerializer(serializers.ModelSerializer):
+    """Full record, including the extracted text. Used for a single analysis."""
+
     class Meta:
         model = ResumeAnalysis
         fields = ("id", "share_id", "file_name", "score", "skills_found", "suggestions",
                   "matched_skills", "missing_skills", "target_role", "created_at", "resume_text",
                   "cover_letter_text", "cover_letter_feedback", "interview_questions")
+
+
+class ResumeAnalysisListSerializer(serializers.ModelSerializer):
+    """Slim record for history listings.
+
+    Drops ``resume_text``, ``cover_letter_text``, ``cover_letter_feedback`` and
+    ``interview_questions`` — several KB per row that the history sidebar
+    fetches and immediately discards. Fetch a single analysis from
+    ``/api/history/<id>/`` when the full text is actually needed.
+    """
+
+    class Meta:
+        model = ResumeAnalysis
+        fields = ("id", "share_id", "file_name", "score", "skills_found", "suggestions",
+                  "matched_skills", "missing_skills", "target_role", "created_at")
 
 
 class VersionComparisonSerializer(serializers.Serializer):

--- a/backend/analyzer/tests_history_api.py
+++ b/backend/analyzer/tests_history_api.py
@@ -1,0 +1,208 @@
+"""Tests for the analysis history endpoints.
+
+Covers the payload slimming, pagination, explicit ordering, the new detail
+endpoint, and the 204-with-a-body fix on clear.
+"""
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from analyzer.models import ResumeAnalysis
+from analyzer.views import HISTORY_DEFAULT_PAGE_SIZE, HISTORY_MAX_PAGE_SIZE
+
+LONG_RESUME_TEXT = "Python developer with Django experience. " * 200
+
+
+def make_analysis(user, index=0, **overrides):
+    defaults = dict(
+        file_name=f"resume-{index}.pdf",
+        score=50 + index,
+        skills_found=["python", "sql"],
+        suggestions=["Add projects or experience with React"],
+        matched_skills=["python"],
+        missing_skills=["react"],
+        target_role="Backend Developer",
+        resume_text=LONG_RESUME_TEXT,
+        cover_letter_text="Dear hiring team, I am excited to apply.",
+        cover_letter_feedback={"word_count": 8},
+        interview_questions=["Explain the GIL."],
+    )
+    defaults.update(overrides)
+    return ResumeAnalysis.objects.create(user=user, **defaults)
+
+
+class HistoryListTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="lister", password="password123")
+        self.client.force_authenticate(user=self.user)
+
+    def test_requires_authentication(self):
+        response = APIClient().get("/api/history/")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_returns_a_bare_array_when_no_pagination_is_requested(self):
+        make_analysis(self.user)
+        response = self.client.get("/api/history/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data, list)
+        self.assertEqual(len(response.data), 1)
+
+    def test_list_payload_omits_the_heavy_fields(self):
+        make_analysis(self.user)
+        row = self.client.get("/api/history/").data[0]
+
+        for heavy in ("resume_text", "cover_letter_text", "cover_letter_feedback", "interview_questions"):
+            with self.subTest(field=heavy):
+                self.assertNotIn(heavy, row)
+
+    def test_list_payload_keeps_what_the_sidebar_renders(self):
+        make_analysis(self.user)
+        row = self.client.get("/api/history/").data[0]
+
+        for field in (
+            "id", "share_id", "file_name", "score", "skills_found", "suggestions",
+            "matched_skills", "missing_skills", "target_role", "created_at",
+        ):
+            with self.subTest(field=field):
+                self.assertIn(field, row)
+
+    def test_only_returns_the_requesting_users_analyses(self):
+        make_analysis(self.user)
+        other = User.objects.create_user(username="someone-else", password="password123")
+        make_analysis(other, index=99)
+
+        response = self.client.get("/api/history/")
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["file_name"], "resume-0.pdf")
+
+    def test_newest_first(self):
+        for index in range(3):
+            make_analysis(self.user, index=index)
+
+        names = [row["file_name"] for row in self.client.get("/api/history/").data]
+        self.assertEqual(names, ["resume-2.pdf", "resume-1.pdf", "resume-0.pdf"])
+
+
+class HistoryPaginationTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="paginator", password="password123")
+        self.client.force_authenticate(user=self.user)
+        for index in range(25):
+            make_analysis(self.user, index=index)
+
+    def test_page_param_returns_an_envelope(self):
+        response = self.client.get("/api/history/?page=1")
+
+        self.assertEqual(set(response.data), {"count", "page", "page_size", "next", "previous", "results"})
+        self.assertEqual(response.data["count"], 25)
+        self.assertEqual(response.data["page_size"], HISTORY_DEFAULT_PAGE_SIZE)
+        self.assertEqual(len(response.data["results"]), HISTORY_DEFAULT_PAGE_SIZE)
+
+    def test_second_page_holds_the_remainder(self):
+        response = self.client.get("/api/history/?page=2")
+
+        self.assertEqual(len(response.data["results"]), 25 - HISTORY_DEFAULT_PAGE_SIZE)
+        self.assertIsNone(response.data["next"])
+        self.assertIn("page=1", response.data["previous"])
+
+    def test_pages_do_not_overlap_or_skip(self):
+        first = self.client.get("/api/history/?page=1&page_size=10").data["results"]
+        second = self.client.get("/api/history/?page=2&page_size=10").data["results"]
+        third = self.client.get("/api/history/?page=3&page_size=10").data["results"]
+
+        ids = [row["id"] for row in first + second + third]
+        self.assertEqual(len(ids), 25)
+        self.assertEqual(len(set(ids)), 25)
+
+    def test_page_size_is_capped(self):
+        response = self.client.get(f"/api/history/?page=1&page_size={HISTORY_MAX_PAGE_SIZE * 10}")
+        self.assertEqual(response.data["page_size"], HISTORY_MAX_PAGE_SIZE)
+
+    def test_page_size_alone_is_enough_to_paginate(self):
+        response = self.client.get("/api/history/?page_size=5")
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(len(response.data["results"]), 5)
+
+    def test_nonsense_params_fall_back_instead_of_erroring(self):
+        for query in ("?page=abc", "?page=0", "?page=-3", "?page=1&page_size=nope"):
+            with self.subTest(query=query):
+                response = self.client.get(f"/api/history/{query}")
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data["page"], 1)
+
+    def test_page_past_the_end_is_empty_rather_than_an_error(self):
+        response = self.client.get("/api/history/?page=99")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+        self.assertIsNone(response.data["next"])
+
+    def test_next_link_carries_the_requested_page_size(self):
+        response = self.client.get("/api/history/?page=1&page_size=10")
+        self.assertIn("page_size=10", response.data["next"])
+        self.assertIn("page=2", response.data["next"])
+
+
+class HistoryDetailTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="reader", password="password123")
+        self.client.force_authenticate(user=self.user)
+        self.analysis = make_analysis(self.user)
+
+    def test_detail_returns_the_full_text(self):
+        response = self.client.get(f"/api/history/{self.analysis.pk}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["resume_text"], LONG_RESUME_TEXT)
+        self.assertEqual(response.data["interview_questions"], ["Explain the GIL."])
+
+    def test_detail_does_not_expose_another_users_analysis(self):
+        other = User.objects.create_user(username="stranger", password="password123")
+        theirs = make_analysis(other, index=7)
+
+        response = self.client.get(f"/api/history/{theirs.pk}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_still_works_on_the_same_route(self):
+        response = self.client.delete(f"/api/history/{self.analysis.pk}/")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(ResumeAnalysis.objects.filter(pk=self.analysis.pk).exists())
+
+    def test_delete_does_not_touch_another_users_analysis(self):
+        other = User.objects.create_user(username="stranger", password="password123")
+        theirs = make_analysis(other, index=7)
+
+        response = self.client.delete(f"/api/history/{theirs.pk}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertTrue(ResumeAnalysis.objects.filter(pk=theirs.pk).exists())
+
+
+class ClearHistoryTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="clearer", password="password123")
+        self.client.force_authenticate(user=self.user)
+
+    def test_clear_removes_only_the_callers_rows(self):
+        make_analysis(self.user)
+        other = User.objects.create_user(username="bystander", password="password123")
+        make_analysis(other, index=3)
+
+        self.client.delete("/api/history/clear/")
+
+        self.assertFalse(ResumeAnalysis.objects.filter(user=self.user).exists())
+        self.assertTrue(ResumeAnalysis.objects.filter(user=other).exists())
+
+    def test_204_response_has_no_body(self):
+        """A 204 must not carry content; the old response sent a JSON message."""
+        response = self.client.delete("/api/history/clear/")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.content, b"")

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -10,7 +10,7 @@ from .views import (
     compare_uploads,
     signup,
     analysis_history,
-    delete_single_history,
+    history_detail,
     clear_user_history,
     compare_versions_view,
     suggestion_feedback,
@@ -46,7 +46,7 @@ urlpatterns = [
 
     path("history/", analysis_history),
     path("history/clear/", clear_user_history),
-    path("history/<int:pk>/", delete_single_history),
+    path("history/<int:pk>/", history_detail),
 
     path("compare/", compare_versions_view),
     path("suggestion-feedback/", suggestion_feedback),

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -294,35 +294,120 @@ def compare_uploads(request):
         return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
+from .serializers import ResumeAnalysisListSerializer
+
+#: Rows per page when the caller does not ask for a size.
+HISTORY_DEFAULT_PAGE_SIZE = 20
+
+#: Hard ceiling, so ``?page_size=100000`` cannot rebuild the old behaviour.
+HISTORY_MAX_PAGE_SIZE = 100
+
+
+def _positive_int(raw, default, maximum=None):
+    """Parse a query param as a positive int, falling back on anything odd."""
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if value < 1:
+        return default
+    if maximum is not None:
+        return min(value, maximum)
+    return value
+
+
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def analysis_history(request):
+    """List the requesting user's analyses, newest first.
 
-    analyses = ResumeAnalysis.objects.filter(
-        user=request.user
+    The list is slim by design: ``resume_text`` and the other long fields are
+    several KB per row, and the history sidebar discards them. Fetch a single
+    analysis from ``/api/history/<id>/`` when the full text is needed.
+
+    Pass ``?page=`` (optionally with ``?page_size=``) to page through the
+    results and get a ``{count, next, previous, results}`` envelope back.
+    Without those params the response stays a bare array, so an already
+    deployed frontend keeps working.
+    """
+    analyses = (
+        ResumeAnalysis.objects.filter(user=request.user)
+        # Explicit rather than relying on Meta.ordering, so a later .distinct()
+        # or .annotate() elsewhere cannot silently reshuffle the sidebar.
+        .order_by("-created_at", "-id")
+        .only(
+            "id", "share_id", "file_name", "score", "skills_found", "suggestions",
+            "matched_skills", "missing_skills", "target_role", "created_at",
+        )
     )
 
-    serializer = ResumeAnalysisSerializer(
-        analyses,
-        many=True,
+    page_param = request.query_params.get("page")
+    size_param = request.query_params.get("page_size")
+
+    if page_param is None and size_param is None:
+        serializer = ResumeAnalysisListSerializer(analyses, many=True)
+        return Response(serializer.data)
+
+    page_size = _positive_int(size_param, HISTORY_DEFAULT_PAGE_SIZE, HISTORY_MAX_PAGE_SIZE)
+    page_number = _positive_int(page_param, 1)
+
+    total = analyses.count()
+    start = (page_number - 1) * page_size
+    end = start + page_size
+    rows = analyses[start:end]
+
+    def page_url(number):
+        if number is None:
+            return None
+        query = request.query_params.copy()
+        query["page"] = number
+        query["page_size"] = page_size
+        return request.build_absolute_uri(f"{request.path}?{query.urlencode()}")
+
+    serializer = ResumeAnalysisListSerializer(rows, many=True)
+    return Response(
+        {
+            "count": total,
+            "page": page_number,
+            "page_size": page_size,
+            "next": page_url(page_number + 1) if end < total else None,
+            "previous": page_url(page_number - 1) if page_number > 1 and start <= total else None,
+            "results": serializer.data,
+        }
     )
 
-    return Response(serializer.data)
-@api_view(['DELETE'])
+
+@api_view(["GET", "DELETE"])
 @permission_classes([IsAuthenticated])
-def delete_single_history(request, pk):
+def history_detail(request, pk):
+    """Fetch or delete one of the requesting user's analyses.
+
+    ``GET`` returns the full record, including ``resume_text`` — the fields the
+    list endpoint leaves out.
+    """
     try:
         entry = ResumeAnalysis.objects.get(pk=pk, user=request.user)
-        entry.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
     except ResumeAnalysis.DoesNotExist:
         return Response(status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == "GET":
+        return Response(ResumeAnalysisSerializer(entry).data)
+
+    entry.delete()
+    return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+#: Kept so existing imports of the old name keep resolving.
+delete_single_history = history_detail
+
 
 @api_view(['DELETE'])
 @permission_classes([IsAuthenticated])
 def clear_user_history(request):
     ResumeAnalysis.objects.filter(user=request.user).delete()
-    return Response({"message": "All history cleared"}, status=status.HTTP_204_NO_CONTENT)
+    # 204 must not carry a body — the old response sent one, which some proxies
+    # and HTTP clients treat as a protocol error.
+    return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @api_view(['GET'])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,50 @@ function highlightSkills(text: string, skills: string[]): React.ReactNode[] {
   )
 }
 
+/** Rows per request from `/api/history/`. */
+const HISTORY_PAGE_SIZE = 20
+
+interface HistoryRow {
+  id: number
+  file_name: string
+  score: number
+  skills_found: string[]
+  suggestions: string[]
+  matched_skills: string[]
+  missing_skills: string[]
+  target_role: string
+  created_at: string
+}
+
+interface HistoryPage {
+  count: number
+  next: string | null
+  results: HistoryRow[]
+}
+
+/** `/api/history/` answers with a bare array, or an envelope when paginated. */
+function historyRowsOf(payload: HistoryRow[] | HistoryPage): HistoryRow[] {
+  return Array.isArray(payload) ? payload : (payload?.results ?? [])
+}
+
+function nextPageUrl(payload: HistoryRow[] | HistoryPage): string | null {
+  return Array.isArray(payload) ? null : (payload?.next ?? null)
+}
+
+function toAnalysisEntries(payload: HistoryRow[] | HistoryPage): AnalysisEntry[] {
+  return historyRowsOf(payload).map((item) => ({
+    id: String(item.id),
+    timestamp: new Date(item.created_at).getTime(),
+    score: item.score,
+    skills: item.skills_found,
+    suggestions: item.suggestions,
+    matchedSkills: item.matched_skills,
+    missingSkills: item.missing_skills,
+    targetRole: item.target_role,
+    fileName: item.file_name,
+  }))
+}
+
 function ResumePreview({ text, skills }: { text: string; skills: string[] }) {
   if (!text) return null
   return (
@@ -91,6 +135,7 @@ function App() {
   // History
   const { entries, deleteEntry, clearHistory, setEntries, unreadCount, lastViewedTimestamp, markAllAsViewed } = useAnalysisHistory()
   const [historyOpen, setHistoryOpen] = useState(false)
+  const [historyNextUrl, setHistoryNextUrl] = useState<string | null>(null)
   const [activeFileName, setActiveFileName] = useState('')
 
   const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
@@ -98,39 +143,38 @@ function App() {
   const fetchDbHistory = useCallback(
     async (token: string) => {
       try {
-        const res = await axios.get(`${backendUrl}/api/history/`, {
-          headers: { Authorization: `Bearer ${token}` },
-        })
-        const dbEntries: AnalysisEntry[] = res.data.map(
-          (item: {
-            id: number
-            file_name: string
-            score: number
-            skills_found: string[]
-            suggestions: string[]
-            matched_skills: string[]
-            missing_skills: string[]
-            target_role: string
-            created_at: string
-          }) => ({
-            id: String(item.id),
-            timestamp: new Date(item.created_at).getTime(),
-            score: item.score,
-            skills: item.skills_found,
-            suggestions: item.suggestions,
-            matchedSkills: item.matched_skills,
-            missingSkills: item.missing_skills,
-            targetRole: item.target_role,
-            fileName: item.file_name,
-          })
+        const res = await axios.get(
+          `${backendUrl}/api/history/?page=1&page_size=${HISTORY_PAGE_SIZE}`,
+          { headers: { Authorization: `Bearer ${token}` } }
         )
-        setEntries(dbEntries)
+        // The endpoint returns a bare array when asked for no particular page,
+        // and a {count, next, results} envelope otherwise. Handle both so this
+        // keeps working against a backend that has not been updated yet.
+        setEntries(toAnalysisEntries(res.data))
+        setHistoryNextUrl(nextPageUrl(res.data))
       } catch {
         /* silently ignore */
       }
     },
     [backendUrl, setEntries]
   )
+
+  const loadMoreDbHistory = useCallback(async () => {
+    if (!historyNextUrl || !user) return
+    try {
+      const res = await axios.get(historyNextUrl, {
+        headers: { Authorization: `Bearer ${user.token}` },
+      })
+      const older = toAnalysisEntries(res.data)
+      setEntries((previous) => {
+        const seen = new Set(previous.map((entry) => entry.id))
+        return [...previous, ...older.filter((entry) => !seen.has(entry.id))]
+      })
+      setHistoryNextUrl(nextPageUrl(res.data))
+    } catch {
+      /* silently ignore */
+    }
+  }, [historyNextUrl, setEntries, user])
 
   useEffect(() => {
     if (user) fetchDbHistory(user.token)
@@ -337,6 +381,8 @@ function App() {
         unreadCount={unreadCount}
         lastViewedTimestamp={lastViewedTimestamp}
         onMarkAllAsViewed={markAllAsViewed}
+        hasMoreOnServer={historyNextUrl !== null}
+        onLoadMoreFromServer={loadMoreDbHistory}
       />
       <div className="container mt-5">
         <div className="main-card text-center">

--- a/frontend/src/HistorySidebar.tsx
+++ b/frontend/src/HistorySidebar.tsx
@@ -19,6 +19,10 @@ interface HistorySidebarProps {
   isOpen: boolean
   onToggle: () => void
   onCompare?: () => void
+  /** True when the server has older analyses that have not been fetched yet. */
+  hasMoreOnServer?: boolean
+  /** Fetches the next page from the server; resolves once entries are appended. */
+  onLoadMoreFromServer?: () => Promise<void> | void
 }
 
 const SORT_MODE_STORAGE_KEY = "history_sort_mode";
@@ -35,6 +39,8 @@ export const HistorySidebar: React.FC<HistorySidebarProps> = ({
   isOpen,
   onToggle,
   onCompare,
+  hasMoreOnServer = false,
+  onLoadMoreFromServer,
 }) => {
   const [confirmClear, setConfirmClear] = useState(false);
   const [downloadingZip, setDownloadingZip] = useState(false);
@@ -102,12 +108,27 @@ export const HistorySidebar: React.FC<HistorySidebarProps> = ({
     onToggle()
   }
 
-  const handleLoadMore = () => {
+  const handleLoadMore = async () => {
+    // Reveal what has already been fetched first; only go back to the server
+    // once every locally held entry is on screen.
+    if (visibleCount < entries.length) {
+      setIsLoadingMore(true)
+      setTimeout(() => {
+        setVisibleCount((prev) => prev + PAGE_SIZE)
+        setIsLoadingMore(false)
+      }, 300)
+      return
+    }
+
+    if (!onLoadMoreFromServer) return
+
     setIsLoadingMore(true)
-    setTimeout(() => {
+    try {
+      await onLoadMoreFromServer()
       setVisibleCount((prev) => prev + PAGE_SIZE)
+    } finally {
       setIsLoadingMore(false)
-    }, 300)
+    }
   }
 
   const formatDate = (ts: number) => {
@@ -310,7 +331,7 @@ export const HistorySidebar: React.FC<HistorySidebarProps> = ({
                 )
               })}
             </ul>
-            {visibleCount < entries.length && (
+            {(visibleCount < entries.length || hasMoreOnServer) && (
               <div
                 className="history-load-more-container"
                 style={{ textAlign: 'center', margin: '1rem 0' }}

--- a/frontend/src/HistorySidebarPaging.test.tsx
+++ b/frontend/src/HistorySidebarPaging.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { HistorySidebar } from './HistorySidebar'
+import type { AnalysisEntry } from './hooks/useAnalysisHistory'
+
+function makeEntries(count: number): AnalysisEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: String(index + 1),
+    timestamp: 1000 + index,
+    score: 70,
+    skills: ['React'],
+    suggestions: [],
+    matchedSkills: ['React'],
+    missingSkills: [],
+    targetRole: 'Frontend Developer',
+    fileName: `resume-${index + 1}.pdf`,
+  }))
+}
+
+function renderSidebar(props: Partial<React.ComponentProps<typeof HistorySidebar>> = {}) {
+  return render(
+    <HistorySidebar
+      entries={makeEntries(3)}
+      isOpen
+      onToggle={() => {}}
+      onSelect={() => {}}
+      onDelete={() => {}}
+      onClear={() => {}}
+      {...props}
+    />
+  )
+}
+
+describe('HistorySidebar server paging (#555)', () => {
+  it('hides Load More when everything held locally is already shown', () => {
+    renderSidebar()
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
+  })
+
+  it('offers Load More when the server reports older analyses', () => {
+    renderSidebar({ hasMoreOnServer: true, onLoadMoreFromServer: vi.fn() })
+    expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument()
+  })
+
+  it('asks the server for the next page once local entries are exhausted', async () => {
+    const onLoadMoreFromServer = vi.fn().mockResolvedValue(undefined)
+    renderSidebar({ hasMoreOnServer: true, onLoadMoreFromServer })
+
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }))
+
+    await waitFor(() => expect(onLoadMoreFromServer).toHaveBeenCalledTimes(1))
+  })
+
+  it('reveals locally held entries before going back to the server', () => {
+    const onLoadMoreFromServer = vi.fn()
+    // 12 entries with a local page size of 10 — the first click is local.
+    renderSidebar({
+      entries: makeEntries(12),
+      hasMoreOnServer: true,
+      onLoadMoreFromServer,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }))
+
+    expect(onLoadMoreFromServer).not.toHaveBeenCalled()
+  })
+
+  it('does not break when no server-paging handler is supplied', () => {
+    renderSidebar({ hasMoreOnServer: true })
+
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }))
+
+    expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #555

## The problem

```python
analyses = ResumeAnalysis.objects.filter(user=request.user)
serializer = ResumeAnalysisSerializer(analyses, many=True)
return Response(serializer.data)
```

Every analysis a user has ever run, in one response, with `resume_text`, `cover_letter_text`, `cover_letter_feedback` and `interview_questions` on every row. A two-page resume is 4–6KB of extracted text, so 100 analyses is a ~600KB payload — rebuilt in memory and serialised on every sidebar open, every login, every page load that calls `fetchDbHistory`.

Almost all of which is thrown away. `App.tsx` reads nine fields and never touches `resume_text`.

## Changes

**Slim list payload.** `ResumeAnalysisListSerializer` carries exactly what the sidebar renders. On a row with a two-page resume that is roughly 5KB down to ~300 bytes.

**Opt-in pagination.**

```
GET /api/history/                        → bare array (unchanged shape)
GET /api/history/?page=1&page_size=20    → {count, page, page_size, next, previous, results}
```

Pagination is triggered by either param. `page_size` is capped at 100, so `?page_size=100000` cannot reconstruct the old behaviour. Bad input (`?page=abc`, `?page=0`, `?page=-3`) falls back to page 1 rather than 400-ing, and a page past the end returns an empty `results` instead of an error.

Keeping the bare array as the no-params default means an already-deployed frontend keeps working through the deploy gap, per the suggestion in the issue.

**New detail endpoint.** `GET /api/history/<id>/` returns the full record including `resume_text` — the fields the list drops. `DELETE` on that route is unchanged; the view now handles both methods, and `delete_single_history` stays bound to it so any external import still resolves.

**Explicit ordering.** The view relied on `Meta.ordering`. It now says `.order_by("-created_at", "-id")` at the query site, with a test asserting newest-first, so a later `.distinct()` or `.annotate()` cannot silently reshuffle the sidebar. The `-id` tiebreak matters for pagination: rows created in the same tick would otherwise be free to swap between pages.

**Column deferral.** `.only(...)` so the database does not read the text columns for a listing that will not serialise them.

## Also fixed here

`clear_user_history` returned a body with its 204:

```python
return Response({"message": "All history cleared"}, status=status.HTTP_204_NO_CONTENT)
```

A 204 must not carry content. Now it returns an empty 204, with a test asserting `response.content == b""`.

## Frontend

`fetchDbHistory` requests one page (`page=1&page_size=20`) and handles both response shapes, so it works against an old or new backend:

```ts
function historyRowsOf(payload: HistoryRow[] | HistoryPage): HistoryRow[] {
  return Array.isArray(payload) ? payload : (payload?.results ?? [])
}
```

`HistorySidebar` already paged locally 10 at a time. Its **Load More** button now reveals what is already held first, and only asks the server for the next page once local entries are exhausted — so the common case stays instant and no request is made until it is actually needed. Appended pages are de-duplicated by id, since a new analysis created between two page fetches would otherwise shift rows across the boundary.

The button appears when there is either more held locally *or* more on the server.

## Tests

`backend/analyzer/tests_history_api.py` — 20 tests:

- heavy fields absent from the list, present on the detail endpoint
- sidebar fields all still present
- other users' analyses excluded from list, detail and delete
- newest-first ordering
- envelope shape, page boundaries, no overlap and no skipped rows across three pages
- `page_size` cap, `page_size` alone paginating, malformed params, page past the end
- `next` link carrying the requested page size
- clear removes only the caller's rows, and its 204 has no body

`frontend/src/HistorySidebarPaging.test.tsx` — 5 tests covering local-then-server ordering, the button's visibility, and the no-handler case.

```
backend:  Ran 65 tests — the 3 failures are pre-existing on main
          (ProfileAvatarTests ×2, CaptchaProtectionTests ×1)
frontend: 80 tests, 77 pass — the 3 failures are pre-existing on main
          (HistorySidebar "Mark Read", AppRoastMode, UploadZone)
```

## Follow-up worth considering

Now that the list is slim, `/api/history/` could reasonably become paginated by default in a later release once the frontend change has shipped. I have left that out of this PR so nothing breaks mid-deploy.
