### PR TITLE
fix: stop URL resume import reaching internal addresses (#583)

### DIFF
--- a/backend/analyzer/tests_url_safety.py
+++ b/backend/analyzer/tests_url_safety.py
@@ -1,0 +1,313 @@
+"""Tests for the outbound-fetch guard on user-supplied resume URLs.
+
+``/api/upload/`` used to hand any ``http(s)://`` URL straight to
+``requests.get``, so an anonymous caller could make the backend connect to the
+Celery broker on localhost, our own API, or the cloud metadata endpoint — and
+read the differing error messages to work out what was listening.
+
+These tests pin down three things: which addresses are refused, that a redirect
+cannot be used to walk from a public host to an internal one, and that a
+refusal never says *why* (the reason is what made the endpoint a scanner).
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from analyzer.url_fetcher import download_and_validate_url, fetch_with_redirect_guard
+from analyzer.url_safety import (
+    ALLOWED_PORTS,
+    GENERIC_REJECTION_MESSAGE,
+    MAX_REDIRECTS,
+    UnsafeURLError,
+    assert_url_is_safe,
+    is_public_address,
+)
+
+#: A routable address, used wherever a test needs the guard to say yes.
+PUBLIC_IP = "93.184.216.34"
+
+
+def resolver_returning(*addresses):
+    """Build a resolver that always answers with ``addresses``.
+
+    Injected so the address rules can be tested without depending on live DNS
+    (or on a particular hostname continuing to resolve the way it does today).
+    """
+    import ipaddress
+
+    def _resolve(hostname, port):
+        return [ipaddress.ip_address(a) for a in addresses]
+
+    return _resolve
+
+
+class PublicAddressTests(TestCase):
+    """The address classification itself."""
+
+    def test_rejects_loopback(self):
+        self.assertFalse(is_public_address("127.0.0.1"))
+        self.assertFalse(is_public_address("127.1.2.3"))
+        self.assertFalse(is_public_address("::1"))
+
+    def test_rejects_private_ranges(self):
+        for address in ("10.0.0.5", "192.168.1.1", "172.16.4.9", "fd00::1"):
+            with self.subTest(address=address):
+                self.assertFalse(is_public_address(address))
+
+    def test_rejects_link_local_metadata_address(self):
+        """169.254.169.254 is where cloud instance credentials live."""
+        self.assertFalse(is_public_address("169.254.169.254"))
+        self.assertFalse(is_public_address("fe80::1"))
+
+    def test_rejects_unspecified_and_multicast(self):
+        self.assertFalse(is_public_address("0.0.0.0"))
+        self.assertFalse(is_public_address("::"))
+        self.assertFalse(is_public_address("224.0.0.1"))
+
+    def test_rejects_ipv4_loopback_wearing_an_ipv6_hat(self):
+        """``::ffff:127.0.0.1`` is not reported as loopback by Python."""
+        self.assertFalse(is_public_address("::ffff:127.0.0.1"))
+        self.assertFalse(is_public_address("::ffff:169.254.169.254"))
+
+    def test_rejects_6to4_wrapped_private_address(self):
+        # 2002:: + 10.0.0.1 encoded as hex — a v6 address that routes to v4
+        # private space.
+        self.assertFalse(is_public_address("2002:0a00:0001::"))
+
+    def test_accepts_a_routable_address(self):
+        self.assertTrue(is_public_address(PUBLIC_IP))
+        self.assertTrue(is_public_address("2606:2800:220:1::"))
+
+    def test_garbage_is_not_public(self):
+        """Fails closed — an address we cannot parse is never allowed."""
+        self.assertFalse(is_public_address("not-an-ip"))
+        self.assertFalse(is_public_address(""))
+
+
+class AssertUrlIsSafeTests(TestCase):
+    """The whole-URL check: scheme, port, host."""
+
+    def test_allows_a_public_https_url(self):
+        parsed = assert_url_is_safe(
+            "https://files.example.com/cv.pdf", resolver=resolver_returning(PUBLIC_IP)
+        )
+        self.assertEqual(parsed.hostname, "files.example.com")
+
+    def test_rejects_non_http_schemes(self):
+        for url in (
+            "ftp://example.com/cv.pdf",
+            "file:///etc/passwd",
+            "gopher://example.com:6379/_SET%20x%20y",
+        ):
+            with self.subTest(url=url):
+                with self.assertRaises(UnsafeURLError):
+                    assert_url_is_safe(url, resolver=resolver_returning(PUBLIC_IP))
+
+    def test_rejects_internal_service_ports(self):
+        """Restricting the port is what keeps the fetcher away from Redis etc."""
+        for port in (22, 3306, 5432, 6379, 8000, 9200):
+            with self.subTest(port=port):
+                with self.assertRaises(UnsafeURLError):
+                    assert_url_is_safe(
+                        f"http://files.example.com:{port}/cv.pdf",
+                        resolver=resolver_returning(PUBLIC_IP),
+                    )
+
+    def test_allows_explicit_web_ports(self):
+        for port in sorted(ALLOWED_PORTS):
+            with self.subTest(port=port):
+                assert_url_is_safe(
+                    f"http://files.example.com:{port}/cv.pdf",
+                    resolver=resolver_returning(PUBLIC_IP),
+                )
+
+    def test_rejects_literal_internal_addresses(self):
+        for url in (
+            "http://127.0.0.1/cv.pdf",
+            "http://127.0.0.1:80/cv.pdf",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1/cv.pdf",
+            "http://[::1]/cv.pdf",
+            "http://0.0.0.0/cv.pdf",
+        ):
+            with self.subTest(url=url):
+                with self.assertRaises(UnsafeURLError):
+                    assert_url_is_safe(url)
+
+    def test_rejects_a_hostname_that_resolves_internally(self):
+        """The classic bypass: a public name with a 127.0.0.1 A record."""
+        with self.assertRaises(UnsafeURLError):
+            assert_url_is_safe(
+                "http://evil.example.com/cv.pdf",
+                resolver=resolver_returning("127.0.0.1"),
+            )
+
+    def test_rejects_when_any_resolved_address_is_internal(self):
+        """One public record must not launder the internal one alongside it."""
+        with self.assertRaises(UnsafeURLError):
+            assert_url_is_safe(
+                "http://mixed.example.com/cv.pdf",
+                resolver=resolver_returning(PUBLIC_IP, "169.254.169.254"),
+            )
+
+    def test_rejects_url_without_a_host(self):
+        with self.assertRaises(UnsafeURLError):
+            assert_url_is_safe("http:///cv.pdf")
+
+    def test_rejects_empty_input(self):
+        for value in ("", None, 42):
+            with self.subTest(value=value):
+                with self.assertRaises(UnsafeURLError):
+                    assert_url_is_safe(value)
+
+    def test_reason_is_recorded_but_not_the_user_message(self):
+        """The detail exists for logs; the message handed out stays generic."""
+        with self.assertRaises(UnsafeURLError) as ctx:
+            assert_url_is_safe("http://127.0.0.1/cv.pdf")
+
+        self.assertIn("loopback", ctx.exception.reason)
+        self.assertEqual(str(ctx.exception), GENERIC_REJECTION_MESSAGE)
+
+
+class FakeResponse:
+    """Minimal stand-in for a streaming ``requests`` response."""
+
+    def __init__(self, status_code=200, headers=None, body=b"%PDF-1.4 fake"):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._body = body
+        self.closed = False
+
+    @property
+    def is_redirect(self):
+        return self.status_code in (301, 302, 303, 307, 308) and "Location" in self.headers
+
+    @property
+    def is_permanent_redirect(self):
+        return self.status_code in (301, 308)
+
+    def iter_content(self, chunk_size=8192):
+        for start in range(0, len(self._body), chunk_size):
+            yield self._body[start : start + chunk_size]
+
+    def close(self):
+        self.closed = True
+
+
+class RedirectGuardTests(TestCase):
+    """A redirect must not be a way around the address check."""
+
+    def test_follows_a_redirect_between_public_hosts(self):
+        responses = [
+            FakeResponse(302, {"Location": f"http://{PUBLIC_IP}/final.pdf"}),
+            FakeResponse(200),
+        ]
+
+        with patch("analyzer.url_fetcher.requests.get", side_effect=responses) as mock_get:
+            result = fetch_with_redirect_guard(f"http://{PUBLIC_IP}/start.pdf", headers={})
+
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(mock_get.call_count, 2)
+        # Redirects must be walked by us, not by requests.
+        self.assertFalse(mock_get.call_args_list[0].kwargs["allow_redirects"])
+
+    def test_blocks_a_redirect_into_the_metadata_service(self):
+        """Public host on hop 1, 169.254.169.254 on hop 2."""
+        responses = [
+            FakeResponse(302, {"Location": "http://169.254.169.254/latest/meta-data/"}),
+            FakeResponse(200, body=b"secret-credentials"),
+        ]
+
+        with patch("analyzer.url_fetcher.requests.get", side_effect=responses) as mock_get:
+            with self.assertRaises(UnsafeURLError):
+                fetch_with_redirect_guard(f"http://{PUBLIC_IP}/start.pdf", headers={})
+
+        # The second request must never have been made.
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_blocks_a_redirect_to_loopback(self):
+        responses = [FakeResponse(302, {"Location": "http://127.0.0.1:6379/"})]
+
+        with patch("analyzer.url_fetcher.requests.get", side_effect=responses):
+            with self.assertRaises(UnsafeURLError):
+                fetch_with_redirect_guard(f"http://{PUBLIC_IP}/start.pdf", headers={})
+
+    def test_resolves_a_relative_redirect_against_the_current_url(self):
+        responses = [
+            FakeResponse(302, {"Location": "/elsewhere.pdf"}),
+            FakeResponse(200),
+        ]
+
+        with patch("analyzer.url_fetcher.requests.get", side_effect=responses) as mock_get:
+            fetch_with_redirect_guard(f"http://{PUBLIC_IP}/start.pdf", headers={})
+
+        self.assertEqual(
+            mock_get.call_args_list[1].args[0], f"http://{PUBLIC_IP}/elsewhere.pdf"
+        )
+
+    def test_gives_up_on_a_redirect_loop(self):
+        looping = [
+            FakeResponse(302, {"Location": f"http://{PUBLIC_IP}/loop"})
+            for _ in range(MAX_REDIRECTS + 2)
+        ]
+
+        with patch("analyzer.url_fetcher.requests.get", side_effect=looping):
+            with self.assertRaises(UnsafeURLError):
+                fetch_with_redirect_guard(f"http://{PUBLIC_IP}/loop", headers={})
+
+    def test_redirect_without_a_location_is_rejected(self):
+        with patch("analyzer.url_fetcher.requests.get", return_value=FakeResponse(302)):
+            # No Location header, so is_redirect is False and it is treated as a
+            # plain response rather than followed into nowhere.
+            result = fetch_with_redirect_guard(f"http://{PUBLIC_IP}/x.pdf", headers={})
+        self.assertEqual(result.status_code, 302)
+
+
+class DownloadEntryPointTests(TestCase):
+    """End-to-end behaviour of the function the views actually call."""
+
+    def test_internal_url_is_refused_with_the_generic_message(self):
+        with patch("analyzer.url_fetcher.requests.get") as mock_get:
+            with self.assertRaises(ValueError) as ctx:
+                download_and_validate_url("http://127.0.0.1:6379/")
+
+        self.assertEqual(str(ctx.exception), GENERIC_REJECTION_MESSAGE)
+        # Nothing was fetched — the guard ran before any connection.
+        mock_get.assert_not_called()
+
+    def test_metadata_endpoint_is_refused(self):
+        with patch("analyzer.url_fetcher.requests.get") as mock_get:
+            with self.assertRaises(ValueError):
+                download_and_validate_url(
+                    "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+                )
+
+        mock_get.assert_not_called()
+
+    def test_error_message_does_not_reveal_what_was_reachable(self):
+        """A 404 and a refused connection must read identically."""
+        with patch(
+            "analyzer.url_fetcher.requests.get", return_value=FakeResponse(404)
+        ):
+            with self.assertRaises(ValueError) as not_found:
+                download_and_validate_url(f"http://{PUBLIC_IP}/missing.pdf")
+
+        import requests as requests_lib
+
+        with patch(
+            "analyzer.url_fetcher.requests.get",
+            side_effect=requests_lib.exceptions.ConnectionError("port 6379 refused"),
+        ):
+            with self.assertRaises(ValueError) as refused:
+                download_and_validate_url(f"http://{PUBLIC_IP}/missing.pdf")
+
+        self.assertEqual(str(not_found.exception), str(refused.exception))
+        self.assertNotIn("6379", str(refused.exception))
+
+    def test_non_http_scheme_still_reports_the_scheme_problem(self):
+        """Kept specific: it is user error, and says nothing about our network."""
+        with self.assertRaises(ValueError) as ctx:
+            download_and_validate_url("ftp://example.com/file.pdf")
+
+        self.assertIn("valid URL starting with http", str(ctx.exception))

--- a/backend/analyzer/url_fetcher.py
+++ b/backend/analyzer/url_fetcher.py
@@ -3,6 +3,14 @@ import re
 import uuid
 import requests
 from django.conf import settings
+from urllib.parse import urljoin
+
+from .url_safety import (
+    GENERIC_REJECTION_MESSAGE,
+    MAX_REDIRECTS,
+    UnsafeURLError,
+    assert_url_is_safe,
+)
 
 
 def convert_to_direct_download_url(url: str) -> tuple[str, str]:
@@ -38,11 +46,58 @@ def convert_to_direct_download_url(url: str) -> tuple[str, str]:
     return url, filename
 
 
+def fetch_with_redirect_guard(url: str, headers: dict, timeout: int = 15):
+    """Fetch ``url``, re-checking safety on every redirect hop.
+
+    ``requests`` follows redirects itself by default, which would make the
+    check on the submitted URL meaningless — a link on a host the attacker
+    controls can answer ``302 Location: http://169.254.169.254/`` and the
+    client would follow it without ever asking us. So redirects are turned off
+    and the chain is walked here, running :func:`assert_url_is_safe` before
+    each request.
+
+    Returns the final streaming response.
+    """
+    current = url
+
+    for _ in range(MAX_REDIRECTS + 1):
+        assert_url_is_safe(current)
+
+        response = requests.get(
+            current,
+            stream=True,
+            timeout=timeout,
+            headers=headers,
+            allow_redirects=False,
+        )
+
+        if not response.is_redirect and not response.is_permanent_redirect:
+            return response
+
+        location = response.headers.get("Location")
+        # The body of a redirect is of no interest, and leaving it unread keeps
+        # the connection out of the pool.
+        response.close()
+
+        if not location:
+            raise UnsafeURLError(reason="redirect without a Location header")
+
+        # Relative redirects are legal, so resolve against the URL we just
+        # asked for rather than assuming an absolute target.
+        current = urljoin(current, location)
+
+    raise UnsafeURLError(reason=f"more than {MAX_REDIRECTS} redirects")
+
+
 def download_and_validate_url(url: str, max_size_mb: int = 10) -> tuple[str, str]:
     """
     Downloads a resume from a URL, validates accessibility, size, and format.
     Returns (saved_file_path, file_name).
     Raises ValueError with user-friendly error message on failure.
+
+    The URL is checked before every request, including each redirect hop, so it
+    cannot be aimed at loopback, private or link-local addresses. See
+    :mod:`analyzer.url_safety` for what is rejected and why.
     """
     if not url or not url.strip().startswith(("http://", "https://")):
         raise ValueError("Please provide a valid URL starting with http:// or https://")
@@ -58,18 +113,26 @@ def download_and_validate_url(url: str, max_size_mb: int = 10) -> tuple[str, str
     }
 
     try:
-        response = requests.get(direct_url, stream=True, timeout=15, headers=headers)
+        response = fetch_with_redirect_guard(direct_url, headers=headers, timeout=15)
+    except UnsafeURLError:
+        # Deliberately not re-raised with its reason attached: the reason says
+        # what is reachable from the server, which is exactly what we do not
+        # want to tell an anonymous caller.
+        raise ValueError(GENERIC_REJECTION_MESSAGE)
     except requests.exceptions.Timeout:
         raise ValueError("The request timed out while trying to fetch the file. Please check the URL and try again.")
-    except requests.exceptions.RequestException as e:
-        raise ValueError(f"Failed to connect to the provided URL: {str(e)}")
+    except requests.exceptions.RequestException:
+        # The exception text carries the host and port that failed, which turns
+        # a connection error into a scan result. Kept generic for the same
+        # reason as above.
+        raise ValueError(GENERIC_REJECTION_MESSAGE)
 
-    if response.status_code in (401, 403):
-        raise ValueError("The provided link is private or inaccessible. Please ensure share permissions are set to 'Anyone with the link can view'.")
-    elif response.status_code == 404:
-        raise ValueError("File not found at the provided URL (404). Please check the link and try again.")
-    elif response.status_code != 200:
-        raise ValueError(f"Could not download file from URL (HTTP Status {response.status_code}).")
+    if response.status_code != 200:
+        # Every non-200 gets one answer. Distinguishing 401/403 from 404 from
+        # "connection refused" is what let this endpoint be used to map which
+        # internal services exist.
+        response.close()
+        raise ValueError(GENERIC_REJECTION_MESSAGE)
 
     # Check Content-Length if available
     content_length = response.headers.get("Content-Length")

--- a/backend/analyzer/url_safety.py
+++ b/backend/analyzer/url_safety.py
@@ -1,0 +1,225 @@
+"""Safety checks for outbound fetches of user-supplied URLs.
+
+``/api/upload/`` and ``/api/compare-bulk-jds/`` both let a caller hand us a link
+instead of a file, and both are ``AllowAny``. That makes the backend an HTTP
+client that strangers get to aim. Without a check on where it may point, the
+obvious targets are the ones only reachable from inside:
+
+* ``127.0.0.1:6379`` — the Celery broker, which ``settings.CELERY_BROKER_URL``
+  puts on localhost.
+* ``127.0.0.1:8000`` — our own API, called from a source address it trusts.
+* ``169.254.169.254`` — the instance metadata service on every major cloud,
+  which hands out instance credentials to anything that asks.
+
+This module answers one question — *may we fetch this URL?* — and is written to
+be boring about it: an address is allowed only when it is a public one, on a
+port the web actually uses, over a scheme we understand.
+
+Redirects are the part that is easy to get wrong. Validating the submitted URL
+and then letting the HTTP client follow a ``302`` is not a control at all: the
+attacker submits a URL on a host they own and redirects it wherever they like.
+:func:`assert_url_is_safe` therefore has to be re-run on every hop, which is why
+:mod:`analyzer.url_fetcher` walks the chain itself with redirects disabled
+rather than handing the job to ``requests``.
+
+Known limitation, deliberately not solved here: a host whose DNS record changes
+between our lookup and the one ``requests`` does when it opens the socket can
+still slip past (DNS rebinding). Closing that means pinning the validated
+address into the connection, which means either a custom transport adapter or
+losing certificate validation. That is a bigger change than this fix, and the
+rebinding window is a much narrower path than the wide-open one being closed —
+so it is recorded here rather than papered over.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+#: The only two schemes the fetcher understands. ``file://``, ``gopher://`` and
+#: friends are classic SSRF pivots and have no business here.
+ALLOWED_SCHEMES = ("http", "https")
+
+#: Ports a public document link plausibly lives on. Restricting this is what
+#: stops the fetcher being aimed at Redis (6379), Postgres (5432), an internal
+#: admin panel on 8000, and so on.
+ALLOWED_PORTS = frozenset({80, 443})
+
+#: How many hops the redirect chain may take before we stop following it.
+MAX_REDIRECTS = 5
+
+#: One message for every rejection. The old code returned a different error for
+#: 401/403, for 404 and for everything else, which turned the endpoint into a
+#: usable port scanner — the error text told you what was listening. Callers
+#: get this single string instead, so a refusal reveals nothing about what is
+#: or is not reachable from the server.
+GENERIC_REJECTION_MESSAGE = (
+    "That link could not be fetched. Please provide a public link to your "
+    "resume that anyone can open — for example a Google Drive or Dropbox "
+    "share link set to 'Anyone with the link can view'."
+)
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL may not be fetched.
+
+    Subclasses ``ValueError`` because both callers in ``views.py`` already turn
+    a ``ValueError`` from the fetcher into a 400 with the message attached.
+    """
+
+    def __init__(self, message=GENERIC_REJECTION_MESSAGE, reason=""):
+        super().__init__(message)
+        #: Why it was actually rejected. Never sent to the caller — it exists so
+        #: an operator reading logs, or a test, can tell the cases apart.
+        self.reason = reason or message
+
+
+def _describe(ip):
+    """Return the reason ``ip`` is not routable on the public internet, or ``None``.
+
+    Checked in specificity order purely so the logged reason is the useful one;
+    several of these overlap (loopback is also reserved, for instance).
+    """
+    if ip.is_unspecified:
+        # 0.0.0.0 / :: — on many stacks a connection here lands on localhost.
+        return "unspecified address"
+    if ip.is_loopback:
+        return "loopback address"
+    if ip.is_link_local:
+        # Covers 169.254.0.0/16, and so the cloud metadata endpoint.
+        return "link-local address"
+    if ip.is_multicast:
+        return "multicast address"
+    if ip.is_private:
+        # RFC 1918 for v4, plus unique-local fc00::/7 for v6.
+        return "private address"
+    if ip.is_reserved:
+        return "reserved address"
+    return None
+
+
+def _unwrap(ip):
+    """Return the address a v6 wrapper is really pointing at.
+
+    ``::ffff:127.0.0.1`` and ``2002:7f00:1::`` are IPv4 loopback wearing a v6
+    hat. Python reports neither as ``is_loopback``, so without unwrapping them
+    they would sail through :func:`_describe`.
+    """
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        return mapped
+
+    sixtofour = getattr(ip, "sixtofour", None)
+    if sixtofour is not None:
+        return sixtofour
+
+    teredo = getattr(ip, "teredo", None)
+    if teredo:
+        # (server, client) — the client half is the interesting one.
+        return teredo[1]
+
+    return ip
+
+
+def is_public_address(raw_ip):
+    """Return ``True`` when ``raw_ip`` is a public, routable address.
+
+    Accepts a string or an ``ipaddress`` object. Anything unparseable is
+    treated as not public — failing closed is the only safe direction here.
+    """
+    try:
+        ip = ipaddress.ip_address(raw_ip) if isinstance(raw_ip, str) else raw_ip
+    except ValueError:
+        return False
+
+    return _describe(_unwrap(ip)) is None
+
+
+def resolve_host(hostname, port):
+    """Return every IP ``hostname`` resolves to.
+
+    All of them are checked, not just the first. A name with several A records
+    — or one that resolves differently on each lookup — would otherwise only
+    have to get one public address in front of the check to pass it.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, UnicodeError, ValueError):
+        raise UnsafeURLError(reason=f"could not resolve host {hostname!r}")
+
+    addresses = []
+    for info in infos:
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        try:
+            addresses.append(ipaddress.ip_address(sockaddr[0]))
+        except ValueError:
+            continue
+
+    if not addresses:
+        raise UnsafeURLError(reason=f"host {hostname!r} resolved to no usable address")
+
+    return addresses
+
+
+def assert_url_is_safe(url, resolver=resolve_host):
+    """Raise :class:`UnsafeURLError` unless ``url`` is safe to fetch.
+
+    Returns the parsed URL on success, so callers that already need the parts
+    do not have to parse it twice.
+
+    ``resolver`` is injectable so tests can exercise the address rules without
+    depending on live DNS.
+    """
+    if not url or not isinstance(url, str):
+        raise UnsafeURLError(reason="empty url")
+
+    try:
+        parsed = urlparse(url.strip())
+    except ValueError:
+        raise UnsafeURLError(reason="url could not be parsed")
+
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        raise UnsafeURLError(reason=f"scheme {parsed.scheme!r} is not allowed")
+
+    try:
+        hostname = parsed.hostname
+    except ValueError:
+        # urlparse defers some malformed-host errors to attribute access.
+        raise UnsafeURLError(reason="url has an invalid host")
+
+    if not hostname:
+        raise UnsafeURLError(reason="url has no host")
+
+    try:
+        port = parsed.port
+    except ValueError:
+        raise UnsafeURLError(reason="url has an invalid port")
+
+    if port is None:
+        port = 443 if parsed.scheme.lower() == "https" else 80
+
+    if port not in ALLOWED_PORTS:
+        raise UnsafeURLError(reason=f"port {port} is not allowed")
+
+    # A literal IP in the URL skips DNS entirely, so check it directly rather
+    # than round-tripping it through the resolver.
+    try:
+        literal = ipaddress.ip_address(hostname)
+    except ValueError:
+        literal = None
+
+    if literal is not None:
+        blocked = _describe(_unwrap(literal))
+        if blocked:
+            raise UnsafeURLError(reason=f"{hostname} is a {blocked}")
+        return parsed
+
+    for address in resolver(hostname, port):
+        blocked = _describe(_unwrap(address))
+        if blocked:
+            raise UnsafeURLError(
+                reason=f"{hostname} resolves to {address}, a {blocked}"
+            )
+
+    return parsed


### PR DESCRIPTION
## 📝 Description

`download_and_validate_url()` accepted any URL that started with `http://` or `https://` and passed it to `requests.get()`. Both endpoints that reach it (`/api/upload/` and `/api/compare-bulk-jds/`) are `AllowAny`, so an anonymous caller could make the backend connect to anything reachable from the server — the Redis broker `settings.py` puts on localhost, our own API on port 8000, or `169.254.169.254` for cloud instance credentials.

This adds `analyzer/url_safety.py` and routes the fetcher through it.

**What is now allowed:** an `http`/`https` URL, on port 80 or 443, whose host is a public routable address.

**What changed, and why each part is needed:**

- **Address classification.** Loopback, private, link-local, reserved, multicast and unspecified addresses are refused. IPv4 addresses wrapped in IPv6 are unwrapped first — `::ffff:127.0.0.1`, 6to4 and Teredo are all IPv4 internals in a v6 costume, and Python reports none of them as `is_loopback` on their own.
- **Every resolved address is checked, not just the first.** Otherwise a hostname with one public A record alongside an internal one gets through.
- **Port allowlist.** This is what keeps the fetcher off Redis, Postgres and internal admin ports even when the host itself looks fine.
- **Redirects are walked here, not by `requests`.** This was the part that made the naive fix useless: `requests.get()` follows redirects by default, so validating the submitted URL proves nothing when the attacker owns the first hop and answers `302 Location: http://169.254.169.254/`. The fetcher now sets `allow_redirects=False` and re-runs the full check before each hop, capped at 5.
- **One generic rejection message.** The old code returned different text for 401/403, for 404, and for connection errors, which turned the endpoint into a port scanner — the error told you what was listening. All refusals now read the same. The specific reason is kept on the exception for logs.

The size-limit and scheme-error messages stay specific: they are user error and say nothing about our network.

### Known limitation, called out deliberately

DNS rebinding — a record that changes between our lookup and the socket `requests` opens — is still possible. Closing it means pinning the validated IP into the connection, which costs either a custom transport adapter or TLS certificate validation. That is a larger change than this fix and I did not want to smuggle it in here, so it is documented in the module docstring rather than left implied. The wide-open path is closed; this narrow one is recorded.

## 🔗 Related Issue

Closes #583

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

28 new tests in `analyzer/tests_url_safety.py`:

- Each rejected address class, including the IPv6-wrapped IPv4 cases and a mixed public/internal resolution.
- Scheme and port rules, including the specific internal ports that motivated this.
- Redirect guard: public → metadata service is blocked and **the second request is never made**; relative redirects resolve correctly; redirect loops give up.
- A 404 and a refused connection produce byte-identical error messages, and the port does not appear in the text.

The resolver is injected in the tests, so none of this depends on live DNS.

```
Ran 192 tests   # 164 before, +28
```
Same 3 failures as on `main` before this branch (`ProfileAvatarTests` x2, `CaptchaProtectionTests.test_signup_fails_without_captcha_token`) — all pre-existing and unrelated. No new failures.

- [ ] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

Manual check — before this change, `curl -X POST .../api/upload/ -F 'url=http://127.0.0.1:6379/'` connected to Redis. Now it returns a 400 with the generic message and no connection is attempted.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
