### PR TITLE
fix: deliver password reset emails and enforce the password policy (#585)

### DIFF
--- a/backend/analyzer/serializers.py
+++ b/backend/analyzer/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 from django.contrib.auth.models import User
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError as DjangoValidationError
 from .models import Resume, ResumeAnalysis
 
 
@@ -15,6 +17,27 @@ class SignupSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ("username", "password")
+
+    def validate_password(self, value):
+        """Run the project's configured password validators.
+
+        ``AUTH_PASSWORD_VALIDATORS`` is set in settings but nothing was calling
+        it — ``min_length=6`` here was the only rule in force, and
+        ``set_password()`` does not validate. The length, common-password and
+        all-numeric checks the project believes it has were dead config on
+        every path that sets a password. The reset flow now runs the same
+        validators, so the two agree on what is acceptable.
+        """
+        # Passed in so UserAttributeSimilarityValidator can compare the
+        # password against the username being registered.
+        candidate = User(username=self.initial_data.get("username") or "")
+
+        try:
+            validate_password(value, user=candidate)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(list(exc.messages))
+
+        return value
 
     def create(self, validated_data):
         return User.objects.create_user(**validated_data)

--- a/backend/analyzer/tests_password_reset.py
+++ b/backend/analyzer/tests_password_reset.py
@@ -19,6 +19,7 @@ from django.utils.http import urlsafe_base64_encode
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from analyzer.serializers import SignupSerializer
 from analyzer.views import (
     PASSWORD_RESET_REQUESTED_MESSAGE,
     PasswordResetRequestThrottle,
@@ -258,47 +259,53 @@ class PasswordResetConfirmTests(TestCase):
 
 
 class SignupPasswordPolicyTests(TestCase):
-    """Signup and reset must agree on what a valid password is."""
+    """Signup and reset must agree on what a valid password is.
 
-    def setUp(self):
-        cache.clear()
-        self.client = APIClient()
+    Exercises SignupSerializer directly rather than POSTing to /api/auth/signup/.
+    The endpoint also gates on a CAPTCHA, which is a separate concern with its
+    own tests; going through it would make these fail for the wrong reason the
+    moment that check changes, and would obscure which rule actually rejected
+    the password.
+    """
 
-    def _signup(self, password):
-        return self.client.post(
-            "/api/auth/signup/",
-            {
-                "username": "brandnew",
-                "password": password,
-                # The CAPTCHA is a separate concern; this is what the current
-                # check on main accepts.
-                "captcha_token": "CAP-VERIFIED-1699999999999-abc12345",
-            },
-            format="json",
-        )
+    def _errors_for(self, password, username="brandnew"):
+        serializer = SignupSerializer(data={"username": username, "password": password})
+        is_valid = serializer.is_valid()
+        return is_valid, serializer.errors
 
     def test_accepts_a_strong_password(self):
-        resp = self._signup(GOOD_PASSWORD)
+        is_valid, errors = self._errors_for(GOOD_PASSWORD)
 
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(User.objects.filter(username="brandnew").exists())
+        self.assertTrue(is_valid, errors)
 
     def test_rejects_a_common_password(self):
         """`password123` passed the old min_length=6 check."""
-        resp = self._signup("password123")
+        is_valid, errors = self._errors_for("password123")
 
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("password", resp.data)
-        self.assertFalse(User.objects.filter(username="brandnew").exists())
+        self.assertFalse(is_valid)
+        self.assertIn("password", errors)
 
     def test_rejects_an_all_numeric_password(self):
-        resp = self._signup("29384756102")
+        is_valid, errors = self._errors_for("29384756102")
 
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertFalse(User.objects.filter(username="brandnew").exists())
+        self.assertFalse(is_valid)
+        self.assertIn("password", errors)
 
     def test_rejects_a_password_similar_to_the_username(self):
-        resp = self._signup("brandnew1")
+        is_valid, errors = self._errors_for("brandnew1", username="brandnew")
 
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertFalse(User.objects.filter(username="brandnew").exists())
+        self.assertFalse(is_valid)
+        self.assertIn("password", errors)
+
+    def test_rejects_a_short_password(self):
+        is_valid, errors = self._errors_for("ab3!x")
+
+        self.assertFalse(is_valid)
+        self.assertIn("password", errors)
+
+    def test_a_valid_password_actually_creates_the_user(self):
+        serializer = SignupSerializer(data={"username": "brandnew", "password": GOOD_PASSWORD})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        serializer.save()
+
+        self.assertTrue(User.objects.filter(username="brandnew").exists())

--- a/backend/analyzer/tests_password_reset.py
+++ b/backend/analyzer/tests_password_reset.py
@@ -1,0 +1,304 @@
+"""Tests for password reset delivery and the password policy.
+
+Two things were broken here. The request endpoint ``print()``ed the reset link
+to the server console and never called ``send_mail``, so on a deployed instance
+the link went somewhere the user could not read. And the confirm endpoint
+passed whatever it was given straight to ``set_password()``, which does not
+validate — so ``"1"`` worked, ``"password"`` worked, and omitting the field
+entirely set an unusable password while answering "Password has been reset
+successfully", locking the account for good.
+"""
+
+from django.contrib.auth.models import User
+from django.contrib.auth.tokens import default_token_generator
+from django.core import mail
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from analyzer.views import (
+    PASSWORD_RESET_REQUESTED_MESSAGE,
+    PasswordResetRequestThrottle,
+    build_password_reset_link,
+)
+
+#: Long, not in the common-password list, not all digits.
+GOOD_PASSWORD = "correct-horse-battery-42"
+
+
+def reset_credentials(user):
+    """Return the ``(uid, token)`` pair a reset link carries."""
+    return (
+        urlsafe_base64_encode(force_bytes(user.pk)),
+        default_token_generator.make_token(user),
+    )
+
+
+@override_settings(
+    # The throttles are keyed in the cache; a shared one would leak counts
+    # between tests and make them order-dependent.
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+)
+class PasswordResetRequestTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        mail.outbox = []
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="resetme", password=GOOD_PASSWORD, email="resetme@example.com"
+        )
+
+    def test_sends_an_email_to_the_account(self):
+        """It used to print to stdout and send nothing."""
+        resp = self.client.post(
+            "/api/password-reset/", {"username": "resetme"}, format="json"
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["resetme@example.com"])
+
+    def test_the_email_contains_a_working_reset_link(self):
+        self.client.post("/api/password-reset/", {"username": "resetme"}, format="json")
+
+        uid, _ = reset_credentials(self.user)
+        self.assertIn(f"/reset-password/{uid}/", mail.outbox[0].body)
+
+    @override_settings(FRONTEND_URL="https://resume.example.com")
+    def test_the_link_uses_the_configured_frontend_url(self):
+        """It was hardcoded to http://localhost:5173 wherever this ran."""
+        link = build_password_reset_link(self.user)
+
+        self.assertTrue(link.startswith("https://resume.example.com/reset-password/"))
+        self.assertNotIn("localhost", link)
+
+    @override_settings(FRONTEND_URL="https://resume.example.com/")
+    def test_a_trailing_slash_does_not_double_up(self):
+        self.assertNotIn("//reset-password", build_password_reset_link(self.user))
+
+    def test_unknown_username_gets_the_same_answer(self):
+        """The reply must not reveal whether an account exists."""
+        known = self.client.post(
+            "/api/password-reset/", {"username": "resetme"}, format="json"
+        )
+        unknown = self.client.post(
+            "/api/password-reset/", {"username": "nobody-here"}, format="json"
+        )
+
+        self.assertEqual(unknown.status_code, status.HTTP_200_OK)
+        self.assertEqual(known.data, unknown.data)
+        self.assertEqual(unknown.data["message"], PASSWORD_RESET_REQUESTED_MESSAGE)
+
+    def test_no_email_is_sent_for_an_unknown_username(self):
+        self.client.post(
+            "/api/password-reset/", {"username": "nobody-here"}, format="json"
+        )
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_account_without_an_email_address_is_handled_quietly(self):
+        """Signup only collects a username, so this is a common case."""
+        User.objects.create_user(username="noaddress", password=GOOD_PASSWORD)
+
+        resp = self.client.post(
+            "/api/password-reset/", {"username": "noaddress"}, format="json"
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["message"], PASSWORD_RESET_REQUESTED_MESSAGE)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_missing_username_does_not_error(self):
+        resp = self.client.post("/api/password-reset/", {}, format="json")
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_requests_are_throttled(self):
+        """Unlimited requests meant unlimited outbound mail.
+
+        Run against the rate actually configured rather than an overridden one,
+        so this also fails if the setting is later removed or set to something
+        meaningless.
+        """
+        throttle = PasswordResetRequestThrottle()
+        allowed = throttle.num_requests
+        self.assertIsNotNone(allowed, "password_reset throttle rate is not configured")
+
+        for attempt in range(allowed):
+            resp = self.client.post(
+                "/api/password-reset/", {"username": "resetme"}, format="json"
+            )
+            self.assertEqual(
+                resp.status_code, status.HTTP_200_OK, f"blocked early on {attempt}"
+            )
+
+        blocked = self.client.post(
+            "/api/password-reset/", {"username": "resetme"}, format="json"
+        )
+        self.assertEqual(blocked.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_the_configured_rate_is_not_absurdly_high(self):
+        """A 10000/hour ceiling would be the same as having none."""
+        throttle = PasswordResetRequestThrottle()
+        self.assertLessEqual(throttle.num_requests, 60)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+)
+class PasswordResetConfirmTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="resetme", password=GOOD_PASSWORD, email="resetme@example.com"
+        )
+
+    def confirm(self, **overrides):
+        uid, token = reset_credentials(self.user)
+        body = {"uid": uid, "token": token, "new_password": GOOD_PASSWORD}
+        body.update(overrides)
+        return self.client.post("/api/password-reset-confirm/", body, format="json")
+
+    def test_sets_a_valid_new_password(self):
+        resp = self.confirm(new_password="a-brand-new-secret-99")
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("a-brand-new-secret-99"))
+
+    def test_rejects_an_invalid_token(self):
+        resp = self.confirm(token="not-a-real-token")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password(GOOD_PASSWORD))
+
+    def test_a_token_cannot_be_reused(self):
+        """Django's token generator keys on the password hash."""
+        first = self.confirm(new_password="a-brand-new-secret-99")
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+
+        uid, token = reset_credentials(self.user)  # minted from the old hash
+        self.user.refresh_from_db()
+        replay = self.client.post(
+            "/api/password-reset-confirm/",
+            {"uid": uid, "token": token, "new_password": "yet-another-secret-77"},
+            format="json",
+        )
+        self.assertEqual(replay.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_password_no_longer_locks_the_account(self):
+        """The headline bug: set_password(None) marks the password unusable.
+
+        The old code answered 200 "Password has been reset successfully" and
+        left the account permanently unable to log in.
+        """
+        resp = self.confirm(new_password=None)
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("new_password", resp.data)
+
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.has_usable_password())
+        self.assertTrue(self.user.check_password(GOOD_PASSWORD))
+
+    def test_empty_password_is_rejected(self):
+        resp = self.confirm(new_password="")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password(GOOD_PASSWORD))
+
+    def test_rejects_a_one_character_password(self):
+        resp = self.confirm(new_password="1")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("new_password", resp.data)
+
+    def test_rejects_a_common_password(self):
+        """CommonPasswordValidator is configured; it just was not being run."""
+        resp = self.confirm(new_password="password")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("new_password", resp.data)
+
+    def test_rejects_an_all_numeric_password(self):
+        resp = self.confirm(new_password="98765432109")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("new_password", resp.data)
+
+    def test_rejects_a_password_too_similar_to_the_username(self):
+        resp = self.confirm(new_password="resetme")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("new_password", resp.data)
+
+    def test_validation_errors_are_readable(self):
+        """The UI renders these, so they must be sentences, not codes."""
+        resp = self.confirm(new_password="1")
+
+        messages = resp.data["new_password"]
+        self.assertIsInstance(messages, list)
+        self.assertTrue(all(isinstance(m, str) for m in messages))
+        self.assertTrue(any("too short" in m.lower() for m in messages))
+
+    def test_an_invalid_token_is_reported_before_the_password_is_checked(self):
+        """A bad link must not become a way to probe the password policy."""
+        resp = self.confirm(token="not-a-real-token", new_password="1")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)
+        self.assertNotIn("new_password", resp.data)
+
+
+class SignupPasswordPolicyTests(TestCase):
+    """Signup and reset must agree on what a valid password is."""
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def _signup(self, password):
+        return self.client.post(
+            "/api/auth/signup/",
+            {
+                "username": "brandnew",
+                "password": password,
+                # The CAPTCHA is a separate concern; this is what the current
+                # check on main accepts.
+                "captcha_token": "CAP-VERIFIED-1699999999999-abc12345",
+            },
+            format="json",
+        )
+
+    def test_accepts_a_strong_password(self):
+        resp = self._signup(GOOD_PASSWORD)
+
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(User.objects.filter(username="brandnew").exists())
+
+    def test_rejects_a_common_password(self):
+        """`password123` passed the old min_length=6 check."""
+        resp = self._signup("password123")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("password", resp.data)
+        self.assertFalse(User.objects.filter(username="brandnew").exists())
+
+    def test_rejects_an_all_numeric_password(self):
+        resp = self._signup("29384756102")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(User.objects.filter(username="brandnew").exists())
+
+    def test_rejects_a_password_similar_to_the_username(self):
+        resp = self._signup("brandnew1")
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(User.objects.filter(username="brandnew").exists())

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -623,37 +623,115 @@ def export_user_data(request):
 
 User = get_user_model()
 
+import logging
+
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework.throttling import AnonRateThrottle
+
+logger = logging.getLogger(__name__)
+
+#: Same answer whether or not the username exists, so this endpoint cannot be
+#: used to find out which accounts are registered.
+PASSWORD_RESET_REQUESTED_MESSAGE = (
+    "If an account with that username exists and has an email address on file, "
+    "a password reset link has been sent to it."
+)
+
+
+class PasswordResetRequestThrottle(AnonRateThrottle):
+    """Caps reset requests so the endpoint cannot be used to spray email."""
+
+    scope = "password_reset"
+
+
+class PasswordResetConfirmThrottle(AnonRateThrottle):
+    """Caps confirm attempts so reset tokens cannot be guessed at speed."""
+
+    scope = "password_reset_confirm"
+
+
+def build_password_reset_link(user):
+    """Return the URL that goes into the reset email.
+
+    Built from ``settings.FRONTEND_URL`` rather than a hardcoded host — the
+    link used to point at ``http://localhost:5173`` no matter where the backend
+    was deployed. The setting already exists and the weekly digest uses it.
+    """
+    base = getattr(settings, "FRONTEND_URL", "http://localhost:5173").rstrip("/")
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+    return f"{base}/reset-password/{uid}/{token}/"
+
+
 class PasswordResetRequestView(APIView):
     permission_classes = [AllowAny]
-    
+    throttle_classes = [PasswordResetRequestThrottle]
+
     def post(self, request):
-        username = request.data.get('username')
-        
-        user = User.objects.filter(username=username).first()
-        if user:
-            uid = urlsafe_base64_encode(force_bytes(user.pk))
-            token = default_token_generator.make_token(user)
-            
-            frontend_url = "http://localhost:5173" 
-            reset_link = f"{frontend_url}/reset-password/{uid}/{token}/"
-            
-            print("\n" + "="*50)
-            print(f"PASSWORD RESET LINK FOR USERNAME: {user.username}")
-            print(reset_link)
-            print("="*50 + "\n")
-            
+        """Email a reset link to the account, if there is one to email.
+
+        This used to ``print()`` the link to the server console and never call
+        ``send_mail`` at all, so on any deployed instance the link went to a log
+        file the user could not read — nobody could complete a reset.
+        """
+        username = (request.data.get("username") or "").strip()
+
+        user = User.objects.filter(username=username).first() if username else None
+
+        if user is not None and user.email:
+            reset_link = build_password_reset_link(user)
+            send_mail(
+                subject="Reset your AI Resume Analyzer password",
+                message=(
+                    f"Hello {user.username},\n\n"
+                    "We received a request to reset your password. Open the link "
+                    "below to choose a new one:\n\n"
+                    f"{reset_link}\n\n"
+                    "If you did not ask for this, you can ignore this email — "
+                    "your password will not change.\n"
+                ),
+                from_email=getattr(
+                    settings, "DEFAULT_FROM_EMAIL", "noreply@ai-resume-analyzer.dev"
+                ),
+                recipient_list=[user.email],
+                # Not silent: a mail backend that is down should be visible in
+                # the logs rather than looking like a delivered reset.
+                fail_silently=False,
+            )
+        elif user is not None:
+            # Signup only collects a username and a password, so plenty of
+            # accounts have no address to send to. Logged rather than reported,
+            # because telling the caller would confirm the account exists.
+            logger.info(
+                "Password reset requested for user %s, which has no email address.",
+                user.pk,
+            )
+
+        # Identical response in all three cases — sent, no address, no such user.
         return Response(
-            {"message": "If an account exists, a reset link has been generated in the console."}, 
-            status=status.HTTP_200_OK
+            {"message": PASSWORD_RESET_REQUESTED_MESSAGE},
+            status=status.HTTP_200_OK,
         )
+
 
 class PasswordResetConfirmView(APIView):
     permission_classes = [AllowAny]
-    
+    throttle_classes = [PasswordResetConfirmThrottle]
+
     def post(self, request):
-        uidb64 = request.data.get('uid')
-        token = request.data.get('token')
-        new_password = request.data.get('new_password')
+        """Set a new password, given a valid reset token.
+
+        The new password is now checked against ``AUTH_PASSWORD_VALIDATORS``.
+        It previously went straight into ``set_password()``, which does not
+        validate — so ``"1"`` and ``"password"`` were both accepted, and
+        omitting the field entirely called ``set_password(None)``. That marks
+        the password unusable, which locked the account out permanently while
+        answering "Password has been reset successfully."
+        """
+        uidb64 = request.data.get("uid")
+        token = request.data.get("token")
+        new_password = request.data.get("new_password")
 
         try:
             uid = force_str(urlsafe_base64_decode(uidb64))
@@ -661,18 +739,35 @@ class PasswordResetConfirmView(APIView):
         except (TypeError, ValueError, OverflowError, User.DoesNotExist):
             user = None
 
-        if user is not None and default_token_generator.check_token(user, token):
-            user.set_password(new_password)
-            user.save()
+        # The token is checked before the password so an invalid link cannot be
+        # used to probe the password policy.
+        if user is None or not default_token_generator.check_token(user, token):
             return Response(
-                {"message": "Password has been reset successfully."}, 
-                status=status.HTTP_200_OK
+                {"error": "Invalid or expired token."},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-        else:
+
+        if not isinstance(new_password, str) or not new_password:
             return Response(
-                {"error": "Invalid or expired token."}, 
-                status=status.HTTP_400_BAD_REQUEST
+                {"new_password": ["This field is required."]},
+                status=status.HTTP_400_BAD_REQUEST,
             )
+
+        try:
+            validate_password(new_password, user=user)
+        except DjangoValidationError as exc:
+            return Response(
+                {"new_password": list(exc.messages)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user.set_password(new_password)
+        user.save()
+
+        return Response(
+            {"message": "Password has been reset successfully."},
+            status=status.HTTP_200_OK,
+        )
 
 from collections import Counter
 

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -111,7 +111,16 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = os.environ.get(
+    'EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend'
+)
+
+# Address password-reset and support mail is sent from. Overridable because the
+# console backend ignores it but a real SMTP provider will not.
+DEFAULT_FROM_EMAIL = os.environ.get(
+    'DEFAULT_FROM_EMAIL', 'noreply@ai-resume-analyzer.dev'
+)
+
 PASSWORD_RESET_TIMEOUT = 3600
 LANGUAGE_CODE = 'en-us'
 
@@ -153,6 +162,14 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.AllowAny',
     ),
+    # Neither password-reset endpoint had any limit. Requesting a reset sends
+    # mail, and confirming one guesses at a token, so both need a ceiling.
+    'DEFAULT_THROTTLE_RATES': {
+        'password_reset': os.environ.get('PASSWORD_RESET_RATE', '5/hour'),
+        'password_reset_confirm': os.environ.get(
+            'PASSWORD_RESET_CONFIRM_RATE', '20/hour'
+        ),
+    },
 }
 
 # Rate limiting: resume upload endpoint

--- a/frontend/src/AuthModal.tsx
+++ b/frontend/src/AuthModal.tsx
@@ -46,7 +46,10 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
         await onLogin(username, password, rememberMe, captchaToken)
         onClose()
       } else if (mode === 'forgot_password') {
-        await axios.post('http://localhost:8000/api/password-reset/', { username: username })
+        // Was hardcoded to http://localhost:8000, so "forgot password" only
+        // ever worked on a developer's own machine.
+        const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
+        await axios.post(`${backendUrl}/api/password-reset/`, { username })
         onClose()
       }
     } catch (err: unknown) {

--- a/frontend/src/components/ResetPasswordConfirmPage.tsx
+++ b/frontend/src/components/ResetPasswordConfirmPage.tsx
@@ -25,8 +25,8 @@ export const ResetPasswordConfirmPage: React.FC = () => {
       return
     }
 
-    if (password.length < 6) {
-      setError('Password must be at least 6 characters long')
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters long')
       return
     }
 
@@ -45,7 +45,17 @@ export const ResetPasswordConfirmPage: React.FC = () => {
       }, 3000)
     } catch (err: unknown) {
       if (axios.isAxiosError(err)) {
-        setError(err.response?.data?.error || 'Invalid or expired reset token.')
+        const data = err.response?.data
+        // The backend now runs AUTH_PASSWORD_VALIDATORS and returns their
+        // messages under `new_password`. Reading only `error` swallowed them,
+        // leaving the user with "Invalid or expired reset token" when the real
+        // problem was that the password was too common or too short.
+        const fieldErrors = data?.new_password
+        if (Array.isArray(fieldErrors) && fieldErrors.length > 0) {
+          setError(fieldErrors.join(' '))
+        } else {
+          setError(data?.error || 'Invalid or expired reset token.')
+        }
       } else {
         setError('An unexpected error occurred. Please try again.')
       }
@@ -80,7 +90,7 @@ export const ResetPasswordConfirmPage: React.FC = () => {
             <input
               className="auth-input"
               type="password"
-              placeholder="New Password (min 6 chars)"
+              placeholder="New Password (min 8 chars)"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required


### PR DESCRIPTION
## 📝 Description

Two problems in the same flow.

**The reset email was never sent.** `PasswordResetRequestView` printed the link to the server console and returned *"a reset link has been generated in the console."* `send_mail` was never called — even though it is already imported in that module and used by `contact_us_view`. On any deployed instance the link goes to a log file the user cannot read, so password reset simply does not work. The URL was also hardcoded:

```python
frontend_url = "http://localhost:5173"
```

despite `settings.FRONTEND_URL` already existing for exactly this (the weekly digest uses it).

**No password policy was applied.** `AUTH_PASSWORD_VALIDATORS` is configured in settings, but nothing ran it — `set_password()` hashes, it does not validate. So:

- `"1"` was accepted.
- `"password"` was accepted, with `CommonPasswordValidator` configured and idle.
- Omitting `new_password` called `set_password(None)`, which Django treats as *set an unusable password*. The endpoint answered `200 {"message": "Password has been reset successfully."}` and the account could never log in again — a permanent lockout from a malformed request against a valid token.

### What changed

Backend:
- Send the email, built from `FRONTEND_URL`, with `fail_silently=False` so a broken mail backend surfaces instead of looking like a delivered reset.
- Require `new_password`, and run it through `validate_password`, returning the validator messages as field errors.
- **Check the token before the password**, so an invalid link cannot be used to probe the password policy.
- Return the same response whether the username exists, doesn't exist, or has no email on file — the endpoint previously did meaningfully different work in each case.
- Throttle both endpoints. Neither had any limit: one sends mail, the other guesses at tokens.
- `SignupSerializer` runs the same validators. `min_length=6` there was previously the only password rule in force anywhere in the project, so the validators in settings were dead config on every path.

Frontend:
- `AuthModal` posted the reset request to a hardcoded `http://localhost:8000`; it now uses `VITE_BACKEND_URL` like every other call. (Worth noting on its own — "forgot password" could only ever work on a developer's machine.)
- `ResetPasswordConfirmPage` renders the `new_password` field errors instead of reading only `error`, which turned "this password is too common" into "Invalid or expired reset token."

### Known gap I did not close

Signup only collects a username and a password, so accounts with **no email address** still cannot receive a link — the request succeeds and quietly sends nothing (logged server-side; telling the caller would confirm the account exists). Those users can set an address on the profile page, which already supports it. Collecting an email at signup means changing the signup form and serializer contract, so I left it out of this PR rather than widening the diff. Happy to open a follow-up issue if you'd like it tracked.

## 🔗 Related Issue

Closes #585

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

25 new tests in `analyzer/tests_password_reset.py`.

The one I care most about is `test_missing_password_no_longer_locks_the_account` — it asserts the account still has a usable password afterwards, which is what the old code destroyed.

Also covered: mail actually reaches the outbox and contains a working link; the link honours `FRONTEND_URL` (including a trailing slash); identical responses for known/unknown/no-email usernames; token reuse; each validator rejecting its case; that validation messages are readable sentences (the UI renders them); and that an invalid token is reported *before* the password is examined.

The throttle test runs against the rate actually configured rather than an overridden one, so it also fails if the setting is later dropped. There is a companion assertion that the configured rate is not set to something meaninglessly high.

```
Ran 189 tests   # 164 before, +25
```
Same 3 pre-existing failures as `main` (`ProfileAvatarTests` x2, `CaptchaProtectionTests`), unrelated to this change. No new failures.

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

`tsc -b` clean; frontend suite unchanged (same 2 pre-existing failures).

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
