### PR TITLE
Add Webhook model for user-specific webhooks

### DIFF
--- a/backend/analyzer/models.py
+++ b/backend/analyzer/models.py
@@ -44,6 +44,20 @@ class UserProfile(models.Model):
         return f"{self.user.username}'s Profile"
 
 
+# ==========================================
+# NEW WEBHOOK MODEL ADDED HERE
+# ==========================================
+class Webhook(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="webhooks")
+    url = models.URLField(max_length=500)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.user.username} - {self.url}"
+# ==========================================
+
+
 class SuggestionFeedback(models.Model):
     """A user's up/down vote on one suggestion from one of their analyses.
 

--- a/backend/analyzer/tasks.py
+++ b/backend/analyzer/tasks.py
@@ -1,9 +1,15 @@
 from celery import shared_task
+from django.contrib.auth import get_user_model
 from .services import analyze_resume
+from .views import trigger_webhooks_for_user
+
+User = get_user_model()
 
 @shared_task
 def analyze_resume_task(file_path, target_role, file_name, user_id=None, job_description=None, cover_letter_path=None, cover_letter_name=None):
-    return analyze_resume(
+    
+    # 1. Run the AI analysis and capture the result
+    analysis_result = analyze_resume(
         file_path=file_path,
         target_role=target_role,
         file_name=file_name,
@@ -12,3 +18,14 @@ def analyze_resume_task(file_path, target_role, file_name, user_id=None, job_des
         cover_letter_path=cover_letter_path,
         cover_letter_name=cover_letter_name
     )
+
+    # 2. If this was triggered by a logged-in user, fire their webhooks
+    if user_id:
+        try:
+            user = User.objects.get(id=user_id)
+            trigger_webhooks_for_user(user, analysis_result)
+        except Exception as e:
+            print(f"Failed to trigger webhooks for user {user_id}: {e}")
+
+    # 3. Return the result so the Celery task completes successfully
+    return analysis_result

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -23,7 +23,8 @@ from django.core.mail import send_mail
 from rest_framework.throttling import SimpleRateThrottle
 
 from .comparison import compare_versions
-from .models import ResumeAnalysis, UserProfile
+# ADDED Webhook TO MODELS IMPORT
+from .models import ResumeAnalysis, UserProfile, Webhook
 from .serializers import (
     SignupSerializer,
     ResumeAnalysisSerializer,
@@ -39,6 +40,12 @@ from django.shortcuts import get_object_or_404
 import json
 from django.http import HttpResponse
 from django.utils import timezone
+
+# ADDED IMPORTS FOR WEBHOOK DISPATCHING
+import requests
+import threading
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 
 
 class UploadRateThrottle(SimpleRateThrottle):
@@ -1137,3 +1144,56 @@ def mock_interview_view(request):
         "feedback": feedback,
         "is_ai_generated": True
     }, status=status.HTTP_200_OK)
+
+
+# ==========================================
+# WEBHOOK MANAGEMENT & DISPATCHER
+# ==========================================
+
+def fire_webhook(url, payload):
+    """Fires webhook with 3 retries and exponential backoff for 5xx errors."""
+    session = requests.Session()
+    retry_strategy = Retry(total=3, backoff_factor=0.5, status_forcelist=[429, 500, 502, 503, 504])
+    session.mount("http://", HTTPAdapter(max_retries=retry_strategy))
+    session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
+    try:
+        session.post(url, json=payload, timeout=10)
+    except Exception as e:
+        print(f"Webhook failed for {url}: {e}")
+
+def trigger_webhooks_for_user(user, analysis_data):
+    """Finds active webhooks for a user and fires them in a background thread."""
+    if not user:
+        return
+    webhooks = Webhook.objects.filter(user=user, is_active=True)
+    if not webhooks.exists():
+        return
+        
+    payload = {"event": "resume_analysis.completed", "data": analysis_data}
+    for webhook in webhooks:
+        threading.Thread(target=fire_webhook, args=(webhook.url, payload)).start()
+
+@api_view(['GET', 'POST'])
+@permission_classes([IsAuthenticated])
+def manage_webhooks(request):
+    if request.method == 'GET':
+        webhooks = Webhook.objects.filter(user=request.user).values('id', 'url', 'is_active')
+        return Response(list(webhooks))
+        
+    elif request.method == 'POST':
+        url = request.data.get('url')
+        if not url:
+            return Response({"error": "URL is required"}, status=status.HTTP_400_BAD_REQUEST)
+            
+        webhook = Webhook.objects.create(user=request.user, url=url)
+        return Response({"id": webhook.id, "url": webhook.url}, status=status.HTTP_201_CREATED)
+
+@api_view(['DELETE'])
+@permission_classes([IsAuthenticated])
+def delete_webhook(request, pk):
+    try:
+        webhook = Webhook.objects.get(pk=pk, user=request.user)
+        webhook.delete()
+        return Response({"message": "Deleted successfully"}, status=status.HTTP_204_NO_CONTENT)
+    except Webhook.DoesNotExist:
+        return Response({"error": "Not found"}, status=status.HTTP_404_NOT_FOUND)

--- a/backend/analyzer/webhook_utils.py
+++ b/backend/analyzer/webhook_utils.py
@@ -1,0 +1,28 @@
+import requests
+import threading
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
+from .models import Webhook
+
+def fire_webhook(url, payload):
+    """Fires webhook with 3 retries and exponential backoff for 5xx errors."""
+    session = requests.Session()
+    retry_strategy = Retry(total=3, backoff_factor=0.5, status_forcelist=[429, 500, 502, 503, 504])
+    session.mount("http://", HTTPAdapter(max_retries=retry_strategy))
+    session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
+    try:
+        session.post(url, json=payload, timeout=10)
+    except Exception as e:
+        print(f"Webhook failed for {url}: {e}")
+
+def trigger_webhooks_for_user(user, analysis_data):
+    """Finds active webhooks for a user and fires them in a background thread."""
+    if not user:
+        return
+    webhooks = Webhook.objects.filter(user=user, is_active=True)
+    if not webhooks.exists():
+        return
+        
+    payload = {"event": "resume_analysis.completed", "data": analysis_data}
+    for webhook in webhooks:
+        threading.Thread(target=fire_webhook, args=(webhook.url, payload)).start()


### PR DESCRIPTION
Description
This pull request introduces webhook functionality to allow users to connect their accounts with external automation tools like Zapier, Make, or custom endpoints. It resolves the request to send real-time JSON payloads when a resume analysis completes.

Changes Included:
Database Models (backend/analyzer/models.py): Added the Webhook model with a foreign key to the User model to store user-registered endpoints securely.

Backend API (backend/analyzer/views.py & urls.py): Implemented Django REST Framework CRUD endpoints (GET, POST, DELETE at /api/webhooks/) to manage user webhooks.

Event Dispatcher (backend/analyzer/views.py): Created the fire_webhook and trigger_webhooks_for_user functions. The dispatcher uses a requests.Session with a urllib3 Retry adapter to provide exponential backoff (max 3 retries) on 5xx errors and timeouts, running on a separate thread to prevent blocking the main API response.

Frontend Component (frontend/src/components/WebhookSettings.tsx): Added a React UI component that allows users to seamlessly add, view, and remove their integration URLs from their settings dashboard.

Issue Reference
Resolves #549

