### PR TITLE
fix(auth): add proper autocomplete attributes to login and signup form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Fixed widespread low-opacity/faded text across stats, How It Works cards, upload zone, and footer (#242).
+- Added proper HTML autocomplete attributes (`username`, `email`, `new-password`, `current-password`) to auth and account form inputs for password manager compatibility (#531).
 - Minor UI and styling fixes across multiple frontend components.
 - Improved responsiveness and consistency across the application.
 - Various bug fixes related to resume analysis and UI rendering.

--- a/frontend/src/AuthModal.test.tsx
+++ b/frontend/src/AuthModal.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AuthModal } from './AuthModal'
+
+describe('AuthModal autocomplete attributes (#531)', () => {
+  it('renders login form inputs with correct autocomplete attributes', () => {
+    render(
+      <AuthModal
+        onSignup={vi.fn()}
+        onLogin={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    const usernameInput = screen.getByPlaceholderText('Username')
+    const passwordInput = screen.getByPlaceholderText(/Password/i)
+
+    expect(usernameInput).toHaveAttribute('autocomplete', 'username')
+    expect(usernameInput).toHaveAttribute('name', 'username')
+    expect(passwordInput).toHaveAttribute('autocomplete', 'current-password')
+    expect(passwordInput).toHaveAttribute('name', 'password')
+  })
+
+  it('renders signup form inputs with new-password autocomplete attribute', () => {
+    render(
+      <AuthModal
+        onSignup={vi.fn()}
+        onLogin={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    const switchBtn = screen.getByRole('button', { name: /Sign up/i })
+    fireEvent.click(switchBtn)
+
+    const usernameInput = screen.getByPlaceholderText('Username')
+    const passwordInput = screen.getByPlaceholderText(/Password/i)
+
+    expect(usernameInput).toHaveAttribute('autocomplete', 'username')
+    expect(passwordInput).toHaveAttribute('autocomplete', 'new-password')
+  })
+
+  it('renders forgot password form input with username autocomplete attribute', () => {
+    render(
+      <AuthModal
+        onSignup={vi.fn()}
+        onLogin={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    const forgotBtn = screen.getByRole('button', { name: /Forgot password\?/i })
+    fireEvent.click(forgotBtn)
+
+    const usernameInput = screen.getByPlaceholderText(/Enter your username/i)
+    expect(usernameInput).toHaveAttribute('autocomplete', 'username')
+    expect(usernameInput).toHaveAttribute('name', 'username')
+  })
+})

--- a/frontend/src/AuthModal.tsx
+++ b/frontend/src/AuthModal.tsx
@@ -83,6 +83,8 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
         <form onSubmit={submit}>
           {mode === 'forgot_password' && (
             <input
+              id="auth-forgot-username"
+              name="username"
               className="auth-input"
               type="text"
               placeholder="Enter your username"
@@ -90,25 +92,33 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
               onChange={(e) => setUsername(e.target.value)}
               required
               autoFocus
+              autoComplete="username"
             />
           )}
           {mode !== 'forgot_password' && (
             <>
               <input
+                id="auth-username"
+                name="username"
                 className="auth-input"
+                type="text"
                 placeholder="Username"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
                 required
                 autoFocus
+                autoComplete="username"
               />
               <input
+                id="auth-password"
+                name="password"
                 className="auth-input"
                 type="password"
                 placeholder="Password (min 6 chars)"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
+                autoComplete={mode === 'signup' ? 'new-password' : 'current-password'}
               />
             </>
           )}

--- a/frontend/src/components/ProfilePage.tsx
+++ b/frontend/src/components/ProfilePage.tsx
@@ -208,7 +208,9 @@ export const ProfilePage: React.FC = () => {
               <label htmlFor="profile-username" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Username</label>
               <input
                 id="profile-username"
+                name="username"
                 type="text"
+                autoComplete="username"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
                 disabled={!isEditing || saving}
@@ -230,7 +232,9 @@ export const ProfilePage: React.FC = () => {
               <label htmlFor="profile-email" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Email Address</label>
               <input
                 id="profile-email"
+                name="email"
                 type="email"
+                autoComplete="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 disabled={!isEditing || saving}

--- a/frontend/src/components/ResetPasswordConfirmPage.tsx
+++ b/frontend/src/components/ResetPasswordConfirmPage.tsx
@@ -88,6 +88,8 @@ export const ResetPasswordConfirmPage: React.FC = () => {
         ) : (
           <form onSubmit={handleSubmit}>
             <input
+              id="reset-new-password"
+              name="new-password"
               className="auth-input"
               type="password"
               placeholder="New Password (min 8 chars)"
@@ -95,15 +97,19 @@ export const ResetPasswordConfirmPage: React.FC = () => {
               onChange={(e) => setPassword(e.target.value)}
               required
               autoFocus
+              autoComplete="new-password"
             />
 
             <input
+              id="reset-confirm-password"
+              name="confirm-password"
               className="auth-input"
               type="password"
               placeholder="Confirm New Password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               required
+              autoComplete="new-password"
             />
 
             {error && <p className="auth-error">{error}</p>}


### PR DESCRIPTION
## 📝 Description

Adds proper HTML `autocomplete` attributes (`username`, `email`, `new-password`, `current-password`) and explicit `name` identifiers to all authentication and account management form inputs (`AuthModal`, `ResetPasswordConfirmPage`, and `ProfilePage`). This allows native browser password managers, 1Password, Bitwarden, and autofill agents to reliably recognize credentials, offer to save/update passwords, and pre-fill credentials without interfering with existing validation behavior.

## 🔗 Related Issue

Closes #531

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [x] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [x] Frontend tests pass (`AuthModal.test.tsx` testing `username`, `current-password`, `new-password`, and forgot password inputs)
- [x] Tested autofill attribute values across Login, Signup, Password Reset Confirm, and Profile forms
- [x] Verified password managers offer to save/fill credentials without regressions in validation

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have updated `CHANGELOG.md`
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
