### PR TITLE
chore: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: Muskankr


### PR DESCRIPTION
## Summary

This PR adds the GitHub Sponsors funding configuration requested in Issue #596.

### Changes Made

- Added `.github/FUNDING.yml` at the required GitHub-recognized path.
- Configured GitHub Sponsors using the project's `Muskankr` Sponsors account.
- Avoided placeholder or unrelated funding links.
- Kept the change strictly limited to Issue #596.

## Testing

- [x] Verified `.github/FUNDING.yml` exists at the correct path.
- [x] Verified the configuration contains `github: Muskankr`.
- [x] Verified there are no placeholder funding URLs.
- [x] Confirmed no unrelated files were modified.
- [ ] Confirmed the Sponsor button is visible on the repository page after GitHub processes the configuration.

## Checklist

- [x] `.github/FUNDING.yml` added.
- [x] GitHub Sponsors configuration added.
- [x] No placeholder funding links.
- [x] No unrelated changes.
- [x] Change is limited to Issue #596.

## Related Issue

Closes #596