### PR TITLE
feat: resume-to-resume diff viewer (#543)

### DIFF
--- a/backend/analyzer/tests.py
+++ b/backend/analyzer/tests.py
@@ -239,6 +239,76 @@ class CompareVersionsEngineTests(TestCase):
         self.assertEqual(result["added_skills"], [])
         self.assertEqual(result["removed_skills"], [])
 
+    def test_substantially_different_resumes_do_not_crash(self):
+        """A completely restructured resume must diff without raising.
+
+        The diff engine is the last thing a user sees in the UI, so it has to
+        survive resumes that share almost no lines — different section order,
+        different length, mostly disjoint content.
+        """
+        older = _make_analysis(
+            self.user,
+            resume_text="\n".join(
+                [
+                    "JOHN DOE",
+                    "Senior Backend Developer | New York, NY",
+                    "",
+                    "SUMMARY",
+                    "Eight years building distributed services with Python and Go.",
+                    "",
+                    "EXPERIENCE",
+                    "Senior Engineer - Acme Corp (2019 - Present)",
+                    "Led migration of a monolith to microservices.",
+                    "Cut p95 latency by 40% across the payments API.",
+                    "",
+                    "SKILLS",
+                    "Python, Go, PostgreSQL, Redis, Kubernetes, Docker, gRPC",
+                    "",
+                    "EDUCATION",
+                    "B.S. Computer Science, State University",
+                ]
+            ),
+        )
+        newer = _make_analysis(
+            self.user,
+            resume_text="\n".join(
+                [
+                    "JANE SMITH",
+                    "Frontend Engineer",
+                    "jane@example.com | Seattle, WA",
+                    "",
+                    "TECHNICAL SKILLS",
+                    "TypeScript, React, Next.js, Tailwind, GraphQL, Cypress, Jest",
+                    "",
+                    "PROJECTS",
+                    "Realtime dashboard - rebuilt a legacy UI with React.",
+                    "Design system - authored 40+ shared components.",
+                    "Performance - improved Largest Contentful Paint by 35%.",
+                    "",
+                    "WORK HISTORY",
+                    "Senior Frontend Engineer - Initech (2021 - Present)",
+                    "Owned the checkout experience used by 2M monthly users.",
+                    "",
+                    "OPEN SOURCE",
+                    "Maintainer of a popular React state library.",
+                    "Speaker at CityJS and React Summit.",
+                ]
+            ),
+        )
+
+        result = compare_versions(older, newer).as_dict()
+
+        # No crash; diff entries are only ever of the two highlightable types.
+        self.assertTrue(isinstance(result["text_diff"], list))
+        self.assertGreater(len(result["text_diff"]), 0)
+        self.assertTrue(all(d["type"] in ("added", "removed") for d in result["text_diff"]))
+        # The payload is capped so a huge rewrite cannot balloon the response.
+        self.assertLessEqual(len(result["text_diff"]), 200)
+        # A full rewrite is reflected in the insights summary.
+        self.assertTrue(
+            any("Content changes" in insight for insight in result["insights"])
+        )
+
 
 class CompareVersionsAPITests(TestCase):
     def setUp(self):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
 } from './utils/fileValidation'
 import { useAnalysisHistory, type AnalysisEntry } from './hooks/useAnalysisHistory'
 import { HistorySidebar } from './HistorySidebar'
+import { CompareVersions } from './components/CompareVersions/CompareVersions'
 import { useAuth } from './hooks/useAuth'
 import { api } from './api/client'
 import { AuthModal } from './AuthModal'
@@ -152,6 +153,8 @@ function App() {
   const [historyOpen, setHistoryOpen] = useState(false)
   const [historyNextUrl, setHistoryNextUrl] = useState<string | null>(null)
   const [activeFileName, setActiveFileName] = useState('')
+  // Modal that diffs two saved uploads against each other.
+  const [showCompare, setShowCompare] = useState(false)
 
   const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
 
@@ -480,9 +483,17 @@ function App() {
         unreadCount={unreadCount}
         lastViewedTimestamp={lastViewedTimestamp}
         onMarkAllAsViewed={markAllAsViewed}
+        onCompare={() => setShowCompare(true)}
         hasMoreOnServer={historyNextUrl !== null}
         onLoadMoreFromServer={loadMoreDbHistory}
       />
+      {showCompare && (
+        <CompareVersions
+          entries={entries}
+          token={user?.token}
+          onClose={() => setShowCompare(false)}
+        />
+      )}
       <div className="container mt-5">
         <div className="main-card text-center">
           {/* Theme toggle */}

--- a/frontend/src/components/CompareVersions/CompareVersions.test.tsx
+++ b/frontend/src/components/CompareVersions/CompareVersions.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CompareVersions } from './CompareVersions'
+import type { AnalysisEntry } from '../../hooks/useAnalysisHistory'
+import type { VersionComparison } from '../../hooks/useCompareVersions'
+
+vi.mock('../../hooks/useCompareVersions', () => ({
+  useCompareVersions: vi.fn(),
+}))
+
+vi.mock('../../utils/exportComparisonPdf', () => ({
+  exportComparisonPdf: vi.fn(),
+}))
+
+import { useCompareVersions } from '../../hooks/useCompareVersions'
+
+const mockEntries: AnalysisEntry[] = [
+  {
+    id: '1',
+    timestamp: 1000,
+    score: 85,
+    skills: ['React'],
+    suggestions: [],
+    matchedSkills: ['React'],
+    missingSkills: ['Vue'],
+    targetRole: 'Frontend Developer',
+    fileName: 'resume-v1.pdf',
+  },
+  {
+    id: '2',
+    timestamp: 2000,
+    score: 92,
+    skills: ['React', 'TypeScript'],
+    suggestions: [],
+    matchedSkills: ['React', 'TypeScript'],
+    missingSkills: [],
+    targetRole: 'Frontend Developer',
+    fileName: 'resume-v2.pdf',
+  },
+]
+
+const mockedUseCompareVersions = vi.mocked(useCompareVersions)
+
+beforeEach(() => {
+  mockedUseCompareVersions.mockReturnValue({
+    comparison: null,
+    loading: false,
+    error: null,
+    compare: vi.fn(),
+    reset: vi.fn(),
+  })
+})
+
+describe('CompareVersions diff viewer (#543)', () => {
+  it('lets the user pick two saved uploads to diff', () => {
+    render(<CompareVersions entries={mockEntries} token="test-token" onClose={() => {}} />)
+
+    const older = screen.getByLabelText('Older version')
+    const newer = screen.getByLabelText('Newer version')
+
+    expect(older).toBeInTheDocument()
+    expect(newer).toBeInTheDocument()
+    expect(screen.getAllByRole('option')).toHaveLength(4)
+    expect(screen.getByRole('button', { name: /compare/i })).toBeInTheDocument()
+  })
+
+  it('shows a sign-in prompt when there is no token', () => {
+    render(<CompareVersions entries={mockEntries} token={undefined} onClose={() => {}} />)
+
+    expect(screen.getByText('Sign in to compare your saved resume versions.')).toBeInTheDocument()
+  })
+
+  it('highlights added and removed diff lines clearly', () => {
+    const comparison: VersionComparison = {
+      older_id: 1,
+      newer_id: 2,
+      older_label: 'resume-v1.pdf — Jan 01, 2026 10:00',
+      newer_label: 'resume-v2.pdf — Jan 02, 2026 10:00',
+      older_score: 85,
+      newer_score: 92,
+      score_delta: 7,
+      added_skills: ['typescript'],
+      removed_skills: ['vue'],
+      newly_matched_skills: ['typescript'],
+      newly_missing_skills: [],
+      still_missing_skills: [],
+      text_diff: [
+        { type: 'removed', text: 'Familiar with Vue components' },
+        { type: 'added', text: 'Built UIs with TypeScript and React' },
+      ],
+      insights: ['Your ATS score improved by 7 points.'],
+    }
+
+    mockedUseCompareVersions.mockReturnValue({
+      comparison,
+      loading: false,
+      error: null,
+      compare: vi.fn(),
+      reset: vi.fn(),
+    })
+
+    render(<CompareVersions entries={mockEntries} token="test-token" onClose={() => {}} />)
+
+    const removedLine = screen.getByText('- Familiar with Vue components')
+    const addedLine = screen.getByText('+ Built UIs with TypeScript and React')
+
+    expect(removedLine).toHaveClass('compare-diff-line--removed')
+    expect(addedLine).toHaveClass('compare-diff-line--added')
+  })
+})


### PR DESCRIPTION
Closes #543

Wires the resume-to-resume diff viewer into the app. The comparison engine and `CompareVersions` modal already existed on `main` but were never reachable — the history sidebar's Compare button was rendered only when an `onCompare` callback was supplied, and nothing supplied it.

## Changes
- **`frontend/src/App.tsx`** — opens the `CompareVersions` modal from the history sidebar's **Compare** button, letting users select two saved uploads and see a line-by-line diff (`+` added / `-` removed highlights), score delta, skill changes, and insights.
- **`frontend/src/components/CompareVersions/CompareVersions.test.tsx`** (new) — covers: both version pickers render, sign-in prompt without a token, and added/removed diff lines carry distinct highlight classes.
- **`backend/analyzer/tests.py`** — `test_substantially_different_resumes_do_not_crash` verifies fully restructured resumes diff without raising, emit only `added`/`removed` entries, and stay within the 200-line payload cap.

## Acceptance criteria
- [x] Users can select two past uploads to diff
- [x] Diff view highlights additions/removals/changes clearly
- [x] Handles resumes with substantial structural differences without crashing

## Verification
- `tsc -b` passes; eslint clean on all touched files (pre-existing App.tsx formatting errors unchanged from `main`).
- Frontend: `npm test` → 134 passing (baseline 131), only the 2 pre-existing failures on `main` remain.
- The new backend test is included but **cannot be executed in this branch**: `main` has a pre-existing `analyzer.views ↔ analyzer.tasks` circular import (from the webhook feature) that crashes the backend at import time — unrelated to this change.