### PR TITLE
Route the avatar endpoint, fix the share URL, and add a route contract test

### DIFF
--- a/backend/analyzer/tests_api_routes.py
+++ b/backend/analyzer/tests_api_routes.py
@@ -1,0 +1,263 @@
+"""A contract test over the API paths the frontend actually requests.
+
+Two shipped features were calling URLs Django does not serve. `profile_avatar_view`
+was written, imported into ``urls.py`` and then never given a ``path()``, so every
+avatar upload 404'd; and ``SharedResultView`` asked for ``/api/analyzer/shared/<id>/``
+when the route is ``/api/shared/<id>/``, so every share link rendered "Result Not
+Found". Both failure modes look exactly like an ordinary server error from the
+UI, which is why neither was reported as a routing problem.
+
+Individual view tests cannot catch this. They exercise the view — often by
+calling it directly, or by hitting a path the same test file made up — and stay
+green whether or not the URL a browser would use resolves to anything.
+
+So this file asserts the opposite direction: for each path the frontend is known
+to request, *something* resolves. It deliberately checks routing only, not
+behaviour. Every entry carries the frontend file that calls it, so a route that
+is deleted on purpose fails here with a pointer to what still depends on it.
+
+When you add an endpoint the frontend calls, add it to ROUTES below.
+"""
+
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from django.urls import Resolver404, resolve
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from analyzer.models import UserProfile
+
+#: (path, the frontend source that requests it)
+#:
+#: Paths with parameters use a representative value; the resolver only cares
+#: that the pattern matches.
+ROUTES = [
+    ("/api/upload/", "App.tsx"),
+    ("/api/status/abc-123/", "App.tsx"),
+    ("/api/history/", "App.tsx, hooks/useAnalysisHistory.ts"),
+    ("/api/history/1/", "HistorySidebar.tsx"),
+    ("/api/history/clear/", "HistorySidebar.tsx"),
+    ("/api/compare/", "hooks/useCompareVersions.ts"),
+    ("/api/compare-uploads/", "components/CompareVersions/CompareUploads.tsx"),
+    ("/api/compare-bulk-jds/", "components/CompareVersions/CompareBulkJds.tsx"),
+    ("/api/suggestion-feedback/", "App.tsx"),
+    ("/api/analyze-jd/", "components/JdVisualizerPanel.tsx"),
+    ("/api/skills-leaderboard/", "components/SkillsLeaderboard.tsx"),
+    ("/api/mock-interview/", "components/InterviewQuestionsPanel.tsx"),
+    ("/api/contact/", "pages/ContactPage.tsx"),
+    ("/api/unsubscribe/", "pages/UnsubscribePage.tsx"),
+    ("/api/account/export/", "hooks/useAuth.ts"),
+    ("/api/admin/stats/", "components/AdminDashboard.tsx"),
+    ("/api/profile/", "components/ProfilePage.tsx"),
+    # Regressions this file was written for.
+    ("/api/profile/avatar/", "components/ProfileModal.tsx"),
+    (
+        "/api/shared/2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33/",
+        "SharedResultView.tsx",
+    ),
+    ("/api/auth/signup/", "hooks/useAuth.ts"),
+    ("/api/auth/login/", "hooks/useAuth.ts"),
+    ("/api/auth/refresh/", "api/client.ts"),
+    ("/api/password-reset/", "AuthModal.tsx"),
+    ("/api/password-reset-confirm/", "components/ResetPasswordConfirmPage.tsx"),
+]
+
+
+class FrontendRouteContractTests(TestCase):
+    def test_every_path_the_frontend_calls_resolves(self):
+        unresolved = []
+
+        for path, caller in ROUTES:
+            with self.subTest(path=path):
+                try:
+                    resolve(path)
+                except Resolver404:
+                    unresolved.append(f"{path}  (requested by {caller})")
+
+        self.assertEqual(
+            unresolved,
+            [],
+            "These paths are requested by the frontend but resolve to nothing:\n  "
+            + "\n  ".join(unresolved),
+        )
+
+    def test_the_avatar_endpoint_is_routed(self):
+        """The specific gap: a view that existed, was imported, and was never published."""
+        self.assertEqual(resolve("/api/profile/avatar/").url_name, "profile_avatar")
+
+    def test_the_share_endpoint_is_not_under_an_analyzer_prefix(self):
+        """`analyzer.urls` is included under `api/`, so `api/analyzer/` is not a thing.
+
+        Pinned as a negative assertion because the wrong path is a plausible
+        guess — the app is called `analyzer`, so `/api/analyzer/...` reads as if
+        it ought to work.
+        """
+        share_id = "2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33"
+        self.assertIsNotNone(resolve(f"/api/shared/{share_id}/"))
+        with self.assertRaises(Resolver404):
+            resolve(f"/api/analyzer/shared/{share_id}/")
+
+    def test_a_view_imported_into_urls_is_also_routed(self):
+        """Catch the next `profile_avatar_view` automatically.
+
+        Importing a view into ``urls.py`` and not routing it is a silent
+        mistake: the module still imports, the checks still pass, and the only
+        symptom is a 404 in production. Reading the names ``urls.py`` imports
+        and comparing them against the callbacks it registers turns that into a
+        test failure.
+        """
+        import ast
+        import inspect
+
+        from analyzer import urls as urls_module
+
+        source = inspect.getsource(urls_module)
+        tree = ast.parse(source)
+
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
+                ("views", ".views", "analyzer.views")
+            ):
+                imported.update(alias.asname or alias.name for alias in node.names)
+
+        # `path(..., some_view)` and `path(..., SomeView.as_view())`.
+        routed = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "path":
+                for arg in node.args[1:2]:
+                    if isinstance(arg, ast.Name):
+                        routed.add(arg.id)
+                    elif isinstance(arg, ast.Call) and isinstance(
+                        arg.func, ast.Attribute
+                    ):
+                        target = arg.func.value
+                        if isinstance(target, ast.Name):
+                            routed.add(target.id)
+
+        unrouted = sorted(imported - routed)
+        self.assertEqual(
+            unrouted,
+            [],
+            "These views are imported into analyzer/urls.py but never routed, "
+            f"so nothing can reach them: {unrouted}",
+        )
+
+
+@override_settings(MEDIA_ROOT="/tmp/ai-resume-analyzer-test-media")
+class ProfileAvatarEndpointTests(TestCase):
+    """The avatar endpoint's behaviour, now that it is reachable.
+
+    `force_authenticate` rather than a real login, so these stay about the
+    avatar endpoint and do not also depend on the CAPTCHA flow.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="avatarowner", password="password123"
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def _png(self, name="avatar.png", size=32):
+        # A real PNG signature, so this keeps working if content validation is
+        # tightened later.
+        content = b"\x89PNG\r\n\x1a\n" + b"\x00" * size
+        return SimpleUploadedFile(name, content, content_type="image/png")
+
+    def test_upload_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        resp = self.client.post("/api/profile/avatar/", {"avatar": self._png()})
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_upload_returns_a_url_and_persists_it(self):
+        resp = self.client.post("/api/profile/avatar/", {"avatar": self._png()})
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(resp.data["avatar_url"])
+
+        profile = UserProfile.objects.get(user=self.user)
+        self.assertTrue(profile.avatar)
+
+    def test_upload_without_a_file_is_a_400(self):
+        resp = self.client.post("/api/profile/avatar/", {})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)
+
+    def test_a_disallowed_extension_is_rejected(self):
+        bad = SimpleUploadedFile("avatar.txt", b"not an image", content_type="text/plain")
+        resp = self.client.post("/api/profile/avatar/", {"avatar": bad})
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)
+
+    def test_an_oversized_image_is_rejected(self):
+        huge = SimpleUploadedFile(
+            "avatar.png", b"\x89PNG\r\n\x1a\n" + b"x" * (2 * 1024 * 1024),
+            content_type="image/png",
+        )
+        resp = self.client.post("/api/profile/avatar/", {"avatar": huge})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_removes_the_avatar(self):
+        self.client.post("/api/profile/avatar/", {"avatar": self._png()})
+
+        resp = self.client.delete("/api/profile/avatar/")
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        profile = UserProfile.objects.get(user=self.user)
+        self.assertFalse(profile.avatar)
+
+    def test_delete_with_no_avatar_set_is_not_an_error(self):
+        resp = self.client.delete("/api/profile/avatar/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_one_user_cannot_touch_another_users_avatar(self):
+        """There is no id in the path, so this is really a check that the view
+        keys off request.user rather than anything the caller supplies."""
+        other = User.objects.create_user(username="someoneelse", password="password123")
+        UserProfile.objects.get_or_create(user=other)
+
+        self.client.post("/api/profile/avatar/", {"avatar": self._png()})
+
+        self.assertFalse(UserProfile.objects.get(user=other).avatar)
+        self.assertTrue(UserProfile.objects.get(user=self.user).avatar)
+
+
+class SharedResultEndpointTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="sharer", password="password123")
+
+    def _analysis(self):
+        from analyzer.models import ResumeAnalysis
+
+        return ResumeAnalysis.objects.create(
+            user=self.user,
+            file_name="resume.pdf",
+            score=72,
+            skills_found=["python"],
+            suggestions=[],
+            matched_skills=["python"],
+            missing_skills=["docker"],
+            target_role="Backend Developer",
+        )
+
+    def test_a_share_link_resolves_and_returns_the_analysis(self):
+        analysis = self._analysis()
+        resp = self.client.get(f"/api/shared/{analysis.share_id}/")
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["score"], 72)
+
+    def test_a_share_link_needs_no_authentication(self):
+        analysis = self._analysis()
+        self.client.force_authenticate(user=None)
+
+        resp = self.client.get(f"/api/shared/{analysis.share_id}/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_an_unknown_share_id_is_a_404(self):
+        resp = self.client.get("/api/shared/2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33/")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -37,6 +37,9 @@ urlpatterns = [
     path("analyze-jd/", analyze_jd_view),
     path("compare-bulk-jds/", compare_bulk_jds_view),
     path("profile/", user_profile_view),
+    # `profile_avatar_view` was imported here but never given a path, so the
+    # avatar upload the profile modal has always called returned 404. See #632.
+    path("profile/avatar/", profile_avatar_view, name="profile_avatar"),
     path("contact/", contact_us_view),
     path("skills-leaderboard/", skills_leaderboard_view),
     path("unsubscribe/", unsubscribe_digest_view),

--- a/frontend/src/SharedResultView.test.tsx
+++ b/frontend/src/SharedResultView.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import axios from 'axios'
+
+import { SharedResultView } from './SharedResultView'
+
+vi.mock('axios', () => {
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+    interceptors: { request: { use: vi.fn() }, response: { use: vi.fn() } },
+  }
+  const mockAxios = {
+    get: vi.fn(),
+    post: vi.fn(),
+    isAxiosError: vi.fn(),
+    create: vi.fn(() => instance),
+  }
+  return { default: mockAxios, ...mockAxios, AxiosHeaders: { from: (h: unknown) => h } }
+})
+
+const SHARE_ID = '2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33'
+
+const SHARED_RESULT = {
+  score: 72,
+  file_name: 'resume.pdf',
+  skills_found: ['python', 'django'],
+  suggestions: ['Add projects or experience with Docker'],
+}
+
+function renderAt(shareId = SHARE_ID) {
+  return render(
+    <MemoryRouter initialEntries={[`/shared/${shareId}`]}>
+      <Routes>
+        <Route path="/shared/:shareId" element={<SharedResultView />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('SharedResultView (#632)', () => {
+  afterEach(() => {
+    vi.mocked(axios.get).mockReset()
+  })
+
+  it('requests the share endpoint the backend actually serves', async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: SHARED_RESULT })
+
+    renderAt()
+
+    await waitFor(() => expect(axios.get).toHaveBeenCalled())
+
+    const requested = vi.mocked(axios.get).mock.calls[0][0] as string
+
+    // The route is `path("shared/<uuid:share_id>/")` inside `analyzer.urls`,
+    // which is included under `api/` — not `api/analyzer/`. This asked for
+    // `/api/analyzer/shared/<id>/`, so it 404'd every time.
+    expect(requested).toContain(`/api/shared/${SHARE_ID}/`)
+    expect(requested).not.toContain('/api/analyzer/')
+  })
+
+  it('renders the shared analysis once it loads', async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: SHARED_RESULT })
+
+    renderAt()
+
+    expect(await screen.findByText('resume.pdf')).toBeInTheDocument()
+  })
+
+  it('shows the not-found state when the share does not exist', async () => {
+    vi.mocked(axios.get).mockRejectedValue({
+      response: { data: { detail: 'Not found.' } },
+    })
+
+    renderAt()
+
+    expect(await screen.findByText('Result Not Found')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/SharedResultView.tsx
+++ b/frontend/src/SharedResultView.tsx
@@ -21,7 +21,11 @@ export const SharedResultView: React.FC = () => {
   useEffect(() => {
     const fetchSharedData = async () => {
       try {
-        const res = await axios.get(`${BACKEND}/api/analyzer/shared/${shareId}/`)
+        // `analyzer.urls` is included under `api/`, not `api/analyzer/`, so the
+        // endpoint is `/api/shared/<uuid>/`. The extra prefix made every share
+        // link 404 and render "Result Not Found" — indistinguishable from a
+        // share that genuinely did not exist. See #632.
+        const res = await axios.get(`${BACKEND}/api/shared/${shareId}/`)
         setData(res.data)
       } catch (err: unknown) {
         const axiosErr = err as { response?: { data?: { detail?: string } } }


### PR DESCRIPTION
Fixes #632

Two shipped features call API URLs Django does not serve. Both 404 in every environment.

## 1. The avatar endpoint was never published

`analyzer/urls.py` imports `profile_avatar_view` and then never uses it:

```python
from .views import (
    ...
    profile_avatar_view,   # imported
    ...
)

urlpatterns = [
    ...
    path("profile/", user_profile_view),   # and that's it
```

`ProfileModal.tsx` has always called it:

```ts
await axios.post(`${backendUrl}/api/profile/avatar/`, formData, { ... })   // 404
await axios.delete(`${backendUrl}/api/profile/avatar/`, { ... })           // 404
```

The modal catches the error and shows "Failed to upload profile picture", which reads as a server problem rather than a missing route — which is presumably why this has sat here. Everything else around the feature is wired up: `UserProfileSerializer` exposes `avatar_url`, the login response returns it, the navbar renders it. One `path()` line was missing.

## 2. The share URL has a prefix that does not exist

```python
path("shared/<uuid:share_id>/", get_shared_result)     # -> /api/shared/<uuid>/
```

```ts
const res = await axios.get(`${BACKEND}/api/analyzer/shared/${shareId}/`)   // SharedResultView.tsx:24
```

`analyzer.urls` is included under `api/`, not `api/analyzer/`. Every share link rendered "Result Not Found" — which is *also* what a share that genuinely does not exist renders, so the feature looked like it worked and simply never found anything. It is an easy mistake to make, since the app is called `analyzer` and `/api/analyzer/...` reads as if it ought to be right.

## The check that would have caught both

Neither of these is catchable by an ordinary view test. Those call the view directly, or hit a path the test file itself made up, and stay green whether or not the URL a browser would use resolves to anything — `ProfileAvatarTests` has existed all along and covers the avatar endpoint.

`backend/analyzer/tests_api_routes.py` asserts the opposite direction: **for each path the frontend is known to request, something resolves.** Routing only, no behaviour. Each entry carries the frontend file that calls it, so deleting a route on purpose fails with a pointer to what still depends on it:

```
These paths are requested by the frontend but resolve to nothing:
  /api/profile/avatar/  (requested by components/ProfileModal.tsx)
```

That list still has to be maintained by hand, so there is a second guard that does not: it parses `urls.py` and fails if a view is imported there but never routed. That is the exact shape of the avatar bug, and it catches the next one without anyone remembering to add anything.

```
These views are imported into analyzer/urls.py but never routed,
so nothing can reach them: ['profile_avatar_view']
```

I verified both by deleting the route again — they fail, and they say what and where.

Routing assertions use `resolve(path).url_name` rather than `func.__name__`: `@api_view` renames every view to `"view"`, so the name comparison would pass for any routed DRF view at all.

## Also

- The avatar endpoint's actual behaviour, now that it is reachable — auth required, upload returns and persists a URL, missing file / bad extension / oversized rejected, delete works and is not an error when nothing is set, and the view keys off `request.user`. These use `force_authenticate` deliberately, so they stay about the avatar endpoint rather than also depending on the CAPTCHA flow.
- `SharedResultView.test.tsx` asserts the requested URL contains `/api/shared/<id>/` and **not** `/api/analyzer/`, plus the loaded and not-found states.

```
backend   Ran 15 tests (tests_api_routes)   OK
frontend  SharedResultView.test.tsx  3 passed
```

## Notes for whoever merges

`analyzer/urls.py` is also touched by #636 (webhook routes). I checked: different lines, and git merges them cleanly in either order.

`ProfileAvatarTests.test_upload_and_delete_avatar` in `tests.py` is guarded by #635 with `require_route("/api/profile/avatar/")`. Routing the endpoint here is exactly the precondition that guard checks, so the test starts running by itself once both are in — no marker to delete, in either merge order. `tests.py` is untouched on this branch so the two changes cannot collide, and the new coverage lives in its own file.

I verified this rather than assuming it: merged all five open PRs in three different orders plus several partial combinations. No textual conflicts, suite green in every one, and the skip count drops from 2 to 0 as #636 and this one land.
