### PR TITLE
Route every authenticated request through the refreshing API client

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -157,8 +157,6 @@ function App() {
   // Modal that diffs two saved uploads against each other.
   const [showCompare, setShowCompare] = useState(false)
 
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
-
   const fetchDbHistory = useCallback(
     async () => {
       try {
@@ -240,14 +238,20 @@ function App() {
       formData.append('file', fileToAnalyze)
       formData.append('role', targetRole)
 
-      const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
-      const headers = user ? { Authorization: `Bearer ${user.token}` } : {}
-      const res = await axios.post(`${backendUrl}/api/upload/`, formData, { headers })
+      // Through `api`, which attaches the current access token and, on a 401,
+      // refreshes once and retries. This used to build an Authorization header
+      // by hand from `user.token` — a value captured when the component
+      // rendered — so uploading anything more than 15 minutes after signing in
+      // failed with a 401 and an "Upload failed" alert. It also stayed stale
+      // even when something else had refreshed the token in the meantime.
+      // Anonymous uploads are unaffected: with no session the interceptor
+      // attaches nothing, exactly as before.
+      const res = await api.post('/api/upload/', formData)
       const taskId = res.data.task_id
 
       let result = null
       while (true) {
-        const statusRes = await axios.get(`${backendUrl}/api/status/${taskId}/`)
+        const statusRes = await api.get(`/api/status/${taskId}/`)
         if (statusRes.data.state === 'SUCCESS') {
           result = statusRes.data.result
           break
@@ -381,17 +385,13 @@ function App() {
         return next
       })
 
-      const config = { headers: { Authorization: `Bearer ${user.token}` } }
       const payload = { analysis_id: analysisId, suggestion_text: suggestion }
 
       try {
         if (vote === null) {
-          await axios.delete(`${backendUrl}/api/suggestion-feedback/`, {
-            ...config,
-            data: payload,
-          })
+          await api.delete('/api/suggestion-feedback/', { data: payload })
         } else {
-          await axios.post(`${backendUrl}/api/suggestion-feedback/`, { ...payload, vote }, config)
+          await api.post('/api/suggestion-feedback/', { ...payload, vote })
         }
       } catch {
         setSuggestionVotes((current) => {
@@ -402,7 +402,7 @@ function App() {
         })
       }
     },
-    [analysisId, backendUrl, suggestionVotes, user]
+    [analysisId, suggestionVotes, user]
   )
 
   // Restore votes already cast against this analysis, so returning to it does
@@ -411,10 +411,8 @@ function App() {
     if (!user || analysisId === null) return
 
     let cancelled = false
-    axios
-      .get(`${backendUrl}/api/suggestion-feedback/?analysis_id=${analysisId}`, {
-        headers: { Authorization: `Bearer ${user.token}` },
-      })
+    api
+      .get(`/api/suggestion-feedback/?analysis_id=${analysisId}`)
       .then((res) => {
         if (cancelled) return
         const stored: Record<string, VoteValue> = {}
@@ -430,7 +428,7 @@ function App() {
     return () => {
       cancelled = true
     }
-  }, [analysisId, backendUrl, user])
+  }, [analysisId, user])
 
   const copySuggestionsToClipboard = () => {
     if (suggestions.length === 0) return

--- a/frontend/src/api/authenticatedCalls.test.ts
+++ b/frontend/src/api/authenticatedCalls.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The refresh machinery from #586 only helps the calls that actually use it.
+ *
+ * It was built — `api/client.ts` attaches the current token and retries once
+ * after refreshing on a 401 — and then wired into exactly two calls. Everything
+ * else kept building `Authorization: Bearer ${user.token}` by hand from a value
+ * captured when the component rendered, so upload, voting, profile, avatar,
+ * admin stats and compare all started failing fifteen minutes after login while
+ * the navbar still showed the user as signed in.
+ *
+ * These tests are about that gap. The first group is a source-level assertion
+ * that no authenticated call has drifted back to bare axios, because that is
+ * the failure mode: not a broken function, a function that quietly stopped
+ * being routed through the thing that renews the session. The rest exercise the
+ * interceptor end to end against a mock adapter, so the "401 then refresh then
+ * retry" path is checked rather than assumed.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AxiosRequestConfig } from 'axios'
+
+/**
+ * One observed request. The Authorization value is copied out at the moment the
+ * request is made rather than kept as a reference to the config: the retry
+ * reuses the same config object and mutates its headers in place, so holding
+ * the object would make the first attempt appear to have carried the refreshed
+ * token all along.
+ */
+interface SeenRequest {
+  url?: string
+  authorization?: string
+}
+
+const STORAGE_KEY = 'auth_user'
+
+function signIn(token = 'access-1', refresh = 'refresh-1') {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ username: 'someone', token, refresh })
+  )
+}
+
+describe('authenticated calls go through the refreshing client', () => {
+  /**
+   * Files that make at least one call requiring a session, and the endpoints
+   * they own. Kept explicit so adding an authenticated call to a new file is a
+   * deliberate act that includes adding it here.
+   */
+  const AUTHENTICATED_SOURCES = [
+    'App.tsx',
+    'components/ProfilePage.tsx',
+    'components/ProfileModal.tsx',
+    'components/AdminDashboard.tsx',
+    'hooks/useCompareVersions.ts',
+  ]
+
+  /**
+   * Loaded eagerly: vitest's glob import is resolved at build time, so the
+   * pattern cannot be built from the array above.
+   */
+  const sources = import.meta.glob('../**/*.{ts,tsx}', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }) as Record<string, string>
+
+  function sourceFor(relativePath: string): string {
+    const key = Object.keys(sources).find((k) => k.endsWith(`/${relativePath}`))
+    if (!key) throw new Error(`Could not load source for ${relativePath}`)
+    return sources[key]
+  }
+
+  it.each(AUTHENTICATED_SOURCES)(
+    '%s does not hand-build an Authorization header',
+    (file) => {
+      // A hand-built header carries whatever token the component captured on
+      // render. Even when the interceptor refreshes and writes a new token to
+      // storage, a closure like this keeps sending the stale one.
+      expect(sourceFor(file)).not.toMatch(/Authorization:\s*`Bearer/)
+    }
+  )
+
+  it.each(AUTHENTICATED_SOURCES)('%s does not call bare axios verbs', (file) => {
+    // `axios.isAxiosError` is fine — it inspects an error, it does not make a
+    // request. `axios.get` / `.post` / `.put` / `.delete` bypass the
+    // interceptor entirely.
+    expect(sourceFor(file)).not.toMatch(/\baxios\.(get|post|put|delete|patch)\s*\(/)
+  })
+
+  it('the calls that must stay on bare axios still do', () => {
+    // Login and signup have no session to renew, and a 401 from them means bad
+    // credentials. Routing them through `api` would fire a pointless refresh on
+    // every wrong password.
+    const useAuth = sourceFor('hooks/useAuth.ts')
+    expect(useAuth).toMatch(/axios\.post\(`\$\{BACKEND\}\/api\/auth\/login\//)
+    expect(useAuth).toMatch(/axios\.post\(`\$\{BACKEND\}\/api\/auth\/signup\//)
+  })
+})
+
+describe('api client refresh behaviour', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.resetModules()
+  })
+
+  /**
+   * Drives the real interceptors with a stubbed adapter, so what is exercised
+   * is the client's own request/response chain.
+   *
+   * The adapter is installed on the axios default *before* `./client` is
+   * imported, deliberately. `client.ts` builds two instances at module load —
+   * `api` and the bare one the refresh call uses, which has to be separate or a
+   * failing refresh would recurse through the same interceptor. `axios.create()`
+   * snapshots the defaults at that moment, so an adapter assigned afterwards
+   * reaches `api` but never the refresh client, and the refresh would go to the
+   * real network.
+   */
+  async function withMockedTransport(
+    handler: (config: AxiosRequestConfig) => Promise<{ status: number; data: unknown }>
+  ) {
+    const seen: SeenRequest[] = []
+    const axios = (await import('axios')).default
+
+    axios.defaults.adapter = async (config) => {
+      seen.push({
+        url: config.url,
+        authorization: config.headers?.Authorization as string | undefined,
+      })
+      const { status, data } = await handler(config)
+      if (status >= 400) {
+        throw Object.assign(new Error(`Request failed with status ${status}`), {
+          isAxiosError: true,
+          config,
+          response: { status, data, config, headers: {}, statusText: '' },
+        })
+      }
+      return { status, data, statusText: 'OK', headers: {}, config }
+    }
+
+    const { api } = await import('./client')
+
+    return { api, seen }
+  }
+
+  it('attaches the token currently in storage, not one captured earlier', async () => {
+    signIn('access-1')
+    const { api, seen } = await withMockedTransport(async () => ({ status: 200, data: {} }))
+
+    await api.get('/api/profile/')
+
+    // Something else refreshes the session — another tab, or a concurrent call.
+    signIn('access-2')
+    await api.get('/api/profile/')
+
+    expect(seen[0].authorization).toBe('Bearer access-1')
+    expect(seen[1].authorization).toBe('Bearer access-2')
+  })
+
+  it('refreshes and retries once when an authenticated call 401s', async () => {
+    signIn('expired-token')
+
+    let refreshed = false
+    const { api, seen } = await withMockedTransport(async (config) => {
+      if (config.url?.includes('/api/auth/refresh/')) {
+        refreshed = true
+        return { status: 200, data: { access: 'fresh-token', refresh: 'refresh-2' } }
+      }
+      if (config.headers?.Authorization === 'Bearer expired-token') {
+        return { status: 401, data: { detail: 'Token is invalid or expired' } }
+      }
+      return { status: 200, data: { ok: true } }
+    })
+
+    const response = await api.post('/api/upload/', new FormData())
+
+    expect(response.data).toEqual({ ok: true })
+    expect(refreshed).toBe(true)
+
+    const uploads = seen.filter((c) => c.url?.includes('/api/upload/'))
+    expect(uploads).toHaveLength(2)
+    expect(uploads[0].authorization).toBe('Bearer expired-token')
+    expect(uploads[1].authorization).toBe('Bearer fresh-token')
+  })
+
+  it('does not retry an anonymous 401 — there is nothing to renew', async () => {
+    // No session in storage at all.
+    const { api, seen } = await withMockedTransport(async () => ({
+      status: 401,
+      data: { detail: 'Authentication credentials were not provided.' },
+    }))
+
+    await expect(api.get('/api/history/')).rejects.toMatchObject({
+      response: { status: 401 },
+    })
+
+    expect(seen.filter((c) => c.url?.includes('/api/auth/refresh/'))).toHaveLength(0)
+    expect(seen).toHaveLength(1)
+  })
+
+  it('gives up rather than looping when the retry also 401s', async () => {
+    signIn('expired-token')
+
+    const { api, seen } = await withMockedTransport(async (config) => {
+      if (config.url?.includes('/api/auth/refresh/')) {
+        return { status: 200, data: { access: 'also-bad' } }
+      }
+      return { status: 401, data: { detail: 'nope' } }
+    })
+
+    await expect(api.get('/api/compare/')).rejects.toMatchObject({
+      response: { status: 401 },
+    })
+
+    // Exactly two attempts at the original call: the first, and one retry.
+    expect(seen.filter((c) => c.url?.includes('/api/compare/'))).toHaveLength(2)
+  })
+})

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import axios from 'axios'
+import { api } from '../api/client'
 import type { AuthUser } from '../hooks/useAuth'
 
 interface AdminDashboardProps {
@@ -18,8 +18,6 @@ interface AdminStats {
   top_missing_skills: StatItem[]
 }
 
-const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
-
 const AdminDashboard: React.FC<AdminDashboardProps> = ({ user }) => {
   const [stats, setStats] = useState<AdminStats | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -30,9 +28,7 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({ user }) => {
 
     const fetchStats = async () => {
       try {
-        const res = await axios.get(`${BACKEND}/api/admin/stats/`, {
-          headers: { Authorization: `Bearer ${user.token}` },
-        })
+        const res = await api.get('/api/admin/stats/')
         setStats(res.data)
       } catch (err: unknown) {
         const axiosErr = err as { response?: { status?: number } }

--- a/frontend/src/components/ProfileModal.tsx
+++ b/frontend/src/components/ProfileModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react'
-import axios from 'axios'
+import { api } from '../api/client'
 import type { AuthUser } from '../hooks/useAuth'
 
 interface ProfileModalProps {
@@ -13,8 +13,6 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ user, onClose, onAva
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
-
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
 
   // Get initials for fallback
   const getInitials = () => {
@@ -48,12 +46,7 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ user, onClose, onAva
     formData.append('avatar', file)
 
     try {
-      const res = await axios.post(`${backendUrl}/api/profile/avatar/`, formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          Authorization: `Bearer ${user.token}`,
-        },
-      })
+      const res = await api.post('/api/profile/avatar/', formData)
       onAvatarUpdated(res.data.avatar_url)
       setSuccess('Profile picture updated successfully!')
     } catch (err: any) {
@@ -70,11 +63,7 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ user, onClose, onAva
     setSuccess(null)
 
     try {
-      await axios.delete(`${backendUrl}/api/profile/avatar/`, {
-        headers: {
-          Authorization: `Bearer ${user.token}`,
-        },
-      })
+      await api.delete('/api/profile/avatar/')
       onAvatarUpdated(null)
       setSuccess('Profile picture removed.')
     } catch (err: any) {

--- a/frontend/src/components/ProfilePage.test.tsx
+++ b/frontend/src/components/ProfilePage.test.tsx
@@ -2,19 +2,32 @@
 import '@testing-library/jest-dom/vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import axios from 'axios'
 import { ProfilePage } from './ProfilePage'
 
-vi.mock('axios')
+// ProfilePage now talks to the shared `api` instance rather than bare axios,
+// so that the access token is attached from storage and a 401 is retried after
+// a refresh (#633). Mocking the client directly keeps these tests about the
+// page rather than about axios' interceptor plumbing.
+vi.mock('../api/client', () => ({
+    api: {
+        get: vi.fn(),
+        put: vi.fn(),
+        post: vi.fn(),
+        delete: vi.fn(),
+    },
+    BACKEND_URL: 'http://127.0.0.1:8000',
+    onSessionExpired: vi.fn(() => () => {}),
+}))
 
 vi.mock('../hooks/useAuth', () => ({
     useAuth: vi.fn(),
 }))
 
+import { api } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 
-const mockedAxiosGet = vi.mocked(axios.get)
-const mockedAxiosPut = vi.mocked(axios.put)
+const mockedAxiosGet = vi.mocked(api.get)
+const mockedAxiosPut = vi.mocked(api.put)
 const mockedUseAuth = vi.mocked(useAuth)
 
 describe('ProfilePage', () => {
@@ -91,13 +104,11 @@ describe('ProfilePage', () => {
 
         expect(digestToggle).toBeChecked()
 
+        // No Authorization argument any more: the client's request
+        // interceptor attaches the current token, so the page does not build
+        // a header from a value captured on render.
         expect(mockedAxiosGet).toHaveBeenCalledWith(
-            expect.stringContaining('/api/profile/'),
-            {
-                headers: {
-                    Authorization: 'Bearer fake-token',
-                },
-            }
+            expect.stringContaining('/api/profile/')
         )
     })
 
@@ -196,11 +207,6 @@ describe('ProfilePage', () => {
                 username: 'updateduser',
                 email: 'updated@example.com',
                 weekly_digest_opt_in: true,
-            },
-            {
-                headers: {
-                    Authorization: 'Bearer fake-token',
-                },
             }
         )
 

--- a/frontend/src/components/ProfilePage.tsx
+++ b/frontend/src/components/ProfilePage.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react'
-import axios from 'axios'
+import { api } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
-
-const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
 
 export const ProfilePage: React.FC = () => {
   const { user, updateProfileSession, exportUserData } = useAuth()
@@ -28,11 +26,11 @@ export const ProfilePage: React.FC = () => {
       try {
         setLoading(true)
         setError(null)
-        const response = await axios.get(`${BACKEND}/api/profile/`, {
-          headers: {
-            Authorization: `Bearer ${user.token}`,
-          },
-        })
+        // Through `api` so an expired access token is refreshed and the
+        // request retried. Building the header from `user.token` by hand meant
+        // the profile page was blank with "Failed to load profile details"
+        // fifteen minutes after signing in.
+        const response = await api.get('/api/profile/')
         const data = response.data
         setUsername(data.username)
         setEmail(data.email || '')
@@ -100,15 +98,11 @@ export const ProfilePage: React.FC = () => {
       setError(null)
       setSuccessMsg(null)
 
-      const response = await axios.put(
-        `${BACKEND}/api/profile/`,
-        { username, email, weekly_digest_opt_in: weeklyDigestOptIn },
-        {
-          headers: {
-            Authorization: `Bearer ${user.token}`,
-          },
-        }
-      )
+      const response = await api.put('/api/profile/', {
+        username,
+        email,
+        weekly_digest_opt_in: weeklyDigestOptIn,
+      })
 
       const updated = response.data
       setUsername(updated.username)

--- a/frontend/src/hooks/useCompareVersions.ts
+++ b/frontend/src/hooks/useCompareVersions.ts
@@ -1,5 +1,7 @@
-import { useCallback, useState } from 'react'
 import axios from 'axios'
+import { useCallback, useState } from 'react'
+
+import { api } from '../api/client'
 
 export interface TextDiffLine {
   type: 'added' | 'removed'
@@ -23,8 +25,6 @@ export interface VersionComparison {
   insights: string[]
 }
 
-const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
-
 export function useCompareVersions(token: string | undefined) {
   const [comparison, setComparison] = useState<VersionComparison | null>(null)
   const [loading, setLoading] = useState(false)
@@ -39,8 +39,10 @@ export function useCompareVersions(token: string | undefined) {
       setLoading(true)
       setError(null)
       try {
-        const res = await axios.get<VersionComparison>(`${BACKEND}/api/compare/`, {
-          headers: { Authorization: `Bearer ${token}` },
+        // `token` is still a parameter because callers use it to tell whether
+        // there is a session at all; the header itself now comes from `api`,
+        // which reads the current token rather than one captured on render.
+        const res = await api.get<VersionComparison>('/api/compare/', {
           params: { older: olderId, newer: newerId },
         })
         setComparison(res.data)


### PR DESCRIPTION
Fixes #633

## The gap

#586 built the refresh machinery and it works — `api/client.ts` attaches the current token and, on a 401, refreshes once and retries; `api/tokenRefresh.ts` makes that single-flight so concurrent 401s do not each burn a rotating refresh token. It was then wired into exactly two calls:

- `App.tsx` → `api.get('/api/history/...')`
- `useAuth.ts` → `api.get('/api/account/export/')`

Everything else kept doing this:

```ts
const headers = user ? { Authorization: `Bearer ${user.token}` } : {}
const res = await axios.post(`${backendUrl}/api/upload/`, formData, { headers })
```

`ACCESS_TOKEN_LIFETIME` is 15 minutes. So fifteen minutes after signing in:

| Action | What happened |
|---|---|
| Analyze Resume | 401 → `alert('Upload failed: Request failed with status code 401')` |
| Vote on a suggestion | 401 → the catch rolls the vote back, so the button silently springs to neutral |
| Open the profile page | 401 → "Failed to load profile details" |
| Upload an avatar | 401 |
| Compare two versions | 401 |
| Admin dashboard | 401 → "An error occurred" |

Meanwhile the history sidebar kept refreshing fine and the navbar still showed the user as signed in — so the app looked logged in while most of it was not. Same symptom #586 set out to fix, still present everywhere the fix had not been applied.

## What changed

Moved onto `api`: `/api/upload/`, `/api/status/`, `/api/suggestion-feedback/` (App.tsx), `/api/profile/` (ProfilePage), `/api/profile/avatar/` (ProfileModal), `/api/admin/stats/` (AdminDashboard), `/api/compare/` (useCompareVersions).

**Deliberately left on bare axios:** login and signup. They have no session to renew and a 401 from them means bad credentials — routing them through `api` would fire a pointless refresh on every mistyped password. Same for the genuinely anonymous endpoints (`compare-uploads`, `compare-bulk-jds`, `analyze-jd`, `skills-leaderboard`, `shared`, `contact`, `unsubscribe`, the password-reset pair). There is a test pinning that login and signup stay put, so a future "tidy up the axios calls" pass does not sweep them in.

Anonymous uploads are unchanged: with no session the request interceptor attaches nothing, which is what the old `user ? {...} : {}` ternary did.

## The second bug this fixes

`user.token` was read *inside* `runAnalysis` and `submitSuggestionVote`. Even on the occasions the interceptor did refresh and write a new token to storage, those closures kept sending the value captured when the component rendered. The request interceptor reads storage per request, so there is nothing left to go stale — there is a test for exactly this, asserting two sequential calls pick up two different tokens.

## Tidy-up that came with it

`api` carries `baseURL`, so callers pass relative paths and the per-file `backendUrl` / `BACKEND` constants are gone. `App.tsx` had declared it twice — once at component scope and again inside `runAnalysis`, shadowing the first.

## Tests — 15 new

**Source-level guards.** The failure mode here is not a broken function; it is a function that quietly stops being routed through the thing that renews the session, which no behavioural test notices. So for each file that makes an authenticated call, two assertions: no hand-built `Authorization: \`Bearer` header, and no bare `axios.get/post/put/delete/patch`. (`axios.isAxiosError` is fine — it inspects an error, it does not make a request.)

**Behavioural.** The interceptor driven end to end against a stubbed adapter:

- the token attached is the one currently in storage, not one captured earlier
- a 401 triggers a refresh and the original request is retried with the new token — asserted as two attempts at `/api/upload/`, the first with the expired token and the second with the fresh one
- an anonymous 401 does **not** hit the refresh endpoint (nothing to renew)
- a retry that also 401s gives up rather than looping

Two things about the harness worth flagging for review, both of which caught me out while writing it:

1. The adapter is installed on the axios default *before* `./client` is imported. `client.ts` builds two instances at module load — `api` and the separate bare one the refresh uses (separate so a failing refresh cannot recurse through the same interceptor) — and `axios.create()` snapshots defaults at that moment. Assigning the adapter afterwards reaches `api` but not the refresh client, and the refresh would go to the real network.
2. Observed requests record the Authorization *value*, not the config object. The retry reuses the same config and mutates its headers in place, so holding the object makes the first attempt appear to have carried the refreshed token all along — which is a green test for a broken implementation.

`ProfilePage.test.tsx` now mocks `../api/client` instead of `axios`, and its assertions no longer expect a hand-built Authorization argument.

```
Test Files  27 passed
Tests      154 passed
```

The 2 remaining failures on this branch (`AppRoastMode`, `HistorySidebar`) are pre-existing on `main` and are fixed by #635.

## Note for whoever merges

There is an interaction with #635 that is worth spelling out, because it is **not** a textual conflict — git merges both cleanly and the test would fail anyway.

#635 repairs `AppRoastMode.test.tsx`, which mocks `axios`. This PR changes `App.tsx` to call `api.post`, which in that test resolves to the *instance* returned by the mock's `create()`, not the module-level `axios.post` the test configures. Configure one, call the other, and the request quietly resolves to the instance's default — back to spinning in the poll loop.

I hit exactly that while checking, and fixed it in #635 rather than here: its mock now shares one set of mock functions between the module and the instance, so it does not care which of the two `App` calls. That makes it correct before *and* after this PR, in either merge order, and this branch does not need to touch the file at all.

Verified by merging all five open PRs in three different orders plus several partial combinations — no conflicts, and 159/159 frontend tests pass in every one.
