### PR TITLE
Rate-limit the public endpoints and stop null fields causing 500s

### DIFF
--- a/backend/analyzer/request_input.py
+++ b/backend/analyzer/request_input.py
@@ -1,0 +1,94 @@
+"""Reading free-text fields off a request without trusting their type.
+
+``request.data.get("job_description", "")`` looks like it defends against a
+missing field, and it does — but only against a *missing* one. ``dict.get``
+returns the stored value whenever the key is present, so a JSON body of
+``{"job_description": null}`` yields ``None``, and the very next operation is
+``None[:2000]`` or ``None.strip()``. Both raise ``TypeError``.
+
+That is not hypothetical. A client that fills a form object and posts it whole
+sends ``null`` for every field the user left blank — which is the normal shape
+of a JSON request, not a malformed one. In ``upload_resume`` the slice happens
+above the ``try:``, so nothing catches it and the request 500s with a traceback
+instead of returning a 400.
+
+The other half of the problem is that none of these fields had a length. A
+resume upload caps the file at 5 MB, but the ``job_description`` that rides
+along with it could be any size, and ``/api/analyze-jd/`` would tokenise the
+whole thing.
+
+:func:`clean_text` handles both: anything that is not a string becomes ``""``,
+and everything has an explicit ceiling at the point it is read.
+"""
+
+#: Ceilings for the fields these endpoints accept. Named rather than inline so
+#: the limits are visible in one place and can be asserted in tests.
+MAX_JOB_DESCRIPTION_LENGTH = 20_000
+MAX_CONTACT_NAME_LENGTH = 120
+MAX_CONTACT_EMAIL_LENGTH = 254  # RFC 5321 maximum for a forward path
+MAX_CONTACT_SUBJECT_LENGTH = 200
+MAX_CONTACT_MESSAGE_LENGTH = 5_000
+MAX_INTERVIEW_QUESTION_LENGTH = 1_000
+MAX_INTERVIEW_ANSWER_LENGTH = 10_000
+
+#: What ``upload_resume`` and ``compare_uploads`` persist. Lower than
+#: MAX_JOB_DESCRIPTION_LENGTH because it is what the column has always stored;
+#: kept as its own name so raising one does not silently raise the other.
+MAX_STORED_JOB_DESCRIPTION_LENGTH = 2_000
+
+
+def clean_text(value, max_length=None, strip=True):
+    """Return ``value`` as a trimmed, length-capped string.
+
+    Anything that is not a string — ``None``, a number, a list, a dict — becomes
+    ``""``. Coercing with ``str()`` instead would be worse: it would turn
+    ``{"message": ["a", "b"]}`` into the literal text ``"['a', 'b']"`` and store
+    that, which is harder to debug than an empty field.
+
+    Args:
+        value: Whatever came off ``request.data``.
+        max_length: Truncate to this many characters. ``None`` for no limit.
+        strip: Trim surrounding whitespace. On by default because every caller
+            wants it; a field where leading whitespace is meaningful can turn
+            it off.
+
+    Returns:
+        A ``str``, never ``None``.
+    """
+    if not isinstance(value, str):
+        return ""
+
+    text = value.strip() if strip else value
+
+    if max_length is not None and len(text) > max_length:
+        text = text[:max_length]
+        # Truncating can leave trailing whitespace that the earlier strip had
+        # nothing to do with.
+        if strip:
+            text = text.rstrip()
+
+    return text
+
+
+def is_probably_an_email(value):
+    """Return ``True`` when ``value`` looks like an address worth replying to.
+
+    Django's ``EmailValidator`` does the work. The point of checking at all is
+    that ``/api/contact/`` required a non-empty ``email`` and never looked at
+    it, so a support inbox filled with messages nobody could answer.
+
+    Deliberately not a deliverability check — that needs sending mail, and this
+    runs on an unauthenticated endpoint.
+    """
+    from django.core.exceptions import ValidationError
+    from django.core.validators import EmailValidator
+
+    if not isinstance(value, str) or not value.strip():
+        return False
+
+    try:
+        EmailValidator()(value.strip())
+    except ValidationError:
+        return False
+
+    return True

--- a/backend/analyzer/tests_public_endpoint_limits.py
+++ b/backend/analyzer/tests_public_endpoint_limits.py
@@ -1,0 +1,350 @@
+"""Rate limits and input handling on the unauthenticated endpoints.
+
+Two problems, both on endpoints anyone can call without an account:
+
+* nothing bounded how often they could be called. ``/api/contact/`` sends an
+  email per request, and ``/api/analyze-jd/`` walks an unbounded body and then
+  compares each of its top 30 words against the whole skill set.
+* nothing bounded what could be sent. ``request.data.get(field, "")`` returns
+  the *stored* value when the key is present, so a JSON ``null`` came back as
+  ``None`` and the next ``[:2000]`` or ``.strip()`` raised ``TypeError``. In
+  ``upload_resume`` that happens above the ``try:``, so it was a 500.
+
+Throttle tests clear the cache in ``setUp``: DRF's throttles keep their
+counters there, so without it whichever test ran first would leave the bucket
+part-used and the rest would be order-dependent.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.core import mail
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from rest_framework.throttling import SimpleRateThrottle
+
+from analyzer.request_input import (
+    MAX_CONTACT_MESSAGE_LENGTH,
+    MAX_JOB_DESCRIPTION_LENGTH,
+    MAX_STORED_JOB_DESCRIPTION_LENGTH,
+    clean_text,
+    is_probably_an_email,
+)
+
+
+def throttled_at(scope, rate):
+    """Temporarily set the rate for one throttle scope.
+
+    `override_settings(REST_FRAMEWORK=...)` does not work for this.
+    `SimpleRateThrottle.THROTTLE_RATES` is a *class* attribute bound to
+    `api_settings.DEFAULT_THROTTLE_RATES` when the module is imported, so
+    changing the setting afterwards leaves the class holding the original dict.
+    Patching the dict itself is what actually takes effect — and it is shared by
+    every throttle class, which is why one helper covers all the scopes.
+    """
+    return patch.dict(SimpleRateThrottle.THROTTLE_RATES, {scope: rate})
+
+
+class CleanTextTests(TestCase):
+    """The helper the null-crash fix rests on."""
+
+    def test_a_string_passes_through_trimmed(self):
+        self.assertEqual(clean_text("  hello  "), "hello")
+
+    def test_none_becomes_an_empty_string(self):
+        # The actual reported crash: `{"job_description": null}`.
+        self.assertEqual(clean_text(None), "")
+
+    def test_non_strings_become_an_empty_string(self):
+        for value in (123, 4.5, True, ["a", "b"], {"a": 1}, object()):
+            with self.subTest(value=value):
+                self.assertEqual(clean_text(value), "")
+
+    def test_a_list_is_not_stringified(self):
+        """`str(value)` would store the literal text "['a', 'b']"."""
+        self.assertEqual(clean_text(["a", "b"]), "")
+
+    def test_max_length_truncates(self):
+        self.assertEqual(clean_text("abcdef", max_length=3), "abc")
+
+    def test_truncation_does_not_leave_trailing_whitespace(self):
+        self.assertEqual(clean_text("ab      cd", max_length=4), "ab")
+
+    def test_no_max_length_means_no_limit(self):
+        self.assertEqual(len(clean_text("x" * 100_000)), 100_000)
+
+    def test_strip_can_be_turned_off(self):
+        self.assertEqual(clean_text("  x  ", strip=False), "  x  ")
+
+
+class EmailValidationTests(TestCase):
+    def test_accepts_ordinary_addresses(self):
+        for value in ("a@b.com", "first.last+tag@sub.example.co.uk"):
+            with self.subTest(value=value):
+                self.assertTrue(is_probably_an_email(value))
+
+    def test_rejects_things_that_are_not_addresses(self):
+        for value in ("", "   ", None, 42, "not an email", "@example.com", "a@"):
+            with self.subTest(value=value):
+                self.assertFalse(is_probably_an_email(value))
+
+
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+class ContactEndpointTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        mail.outbox.clear()
+        self.client = APIClient()
+
+    def _payload(self, **overrides):
+        payload = {
+            "name": "Jane Doe",
+            "email": "jane@example.com",
+            "category": "Bug Report",
+            "subject": "Parser issue",
+            "message": "Found a bug uploading a resume.",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_a_valid_message_is_sent(self):
+        resp = self.client.post("/api/contact/", self._payload())
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("jane@example.com", mail.outbox[0].body)
+
+    def test_an_invalid_address_is_rejected_and_sends_nothing(self):
+        resp = self.client.post("/api/contact/", self._payload(email="not-an-email"))
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("valid email", resp.data["error"])
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_null_fields_are_a_400_not_a_500(self):
+        """`.get(f, "").strip()` raised TypeError on a JSON null."""
+        resp = self.client.post(
+            "/api/contact/",
+            {"name": None, "email": None, "message": None},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)
+
+    def test_a_non_string_field_is_a_400_not_a_500(self):
+        resp = self.client.post(
+            "/api/contact/",
+            {"name": ["Jane"], "email": 42, "message": {"text": "hi"}},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_an_overlong_message_is_truncated_rather_than_rejected(self):
+        resp = self.client.post(
+            "/api/contact/", self._payload(message="x" * (MAX_CONTACT_MESSAGE_LENGTH * 3))
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        # The whole email body is bounded, not just the message field.
+        self.assertLess(len(mail.outbox[0].body), MAX_CONTACT_MESSAGE_LENGTH + 1000)
+
+    def test_an_unrecognised_category_is_filed_as_other(self):
+        """Keeps caller-controlled text out of the subject header."""
+        self.client.post(
+            "/api/contact/", self._payload(category="X-Injected: yes")
+        )
+
+        self.assertEqual(mail.outbox[0].subject, "[Support - Other] Parser issue")
+
+    def test_the_endpoint_is_rate_limited(self):
+        with throttled_at("contact", "3/hour"):
+            for attempt in range(3):
+                resp = self.client.post("/api/contact/", self._payload())
+                self.assertEqual(
+                    resp.status_code, status.HTTP_200_OK, f"attempt {attempt}"
+                )
+
+            blocked = self.client.post("/api/contact/", self._payload())
+
+        self.assertEqual(blocked.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        # The throttled request must not have sent anything.
+        self.assertEqual(len(mail.outbox), 3)
+
+    def test_a_mail_backend_failure_is_reported_rather_than_claimed_as_success(self):
+        """It used to answer "your message has been received" either way."""
+        with patch("analyzer.views.send_mail", side_effect=OSError("smtp down")):
+            resp = self.client.post("/api/contact/", self._payload())
+
+        self.assertEqual(resp.status_code, status.HTTP_502_BAD_GATEWAY)
+        self.assertIn("could not send", resp.data["error"])
+
+
+class AnalyzeJdEndpointTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_a_normal_job_description_is_analysed(self):
+        resp = self.client.post(
+            "/api/analyze-jd/",
+            {"job_description": "Looking for a Python and Django developer."},
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        keywords = {item["text"] for item in resp.data["keywords"]}
+        self.assertIn("python", keywords)
+
+    def test_an_empty_description_is_a_400(self):
+        resp = self.client.post("/api/analyze-jd/", {"job_description": "   "})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_a_null_description_is_a_400_not_a_500(self):
+        resp = self.client.post(
+            "/api/analyze-jd/", {"job_description": None}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_a_missing_description_is_a_400(self):
+        resp = self.client.post("/api/analyze-jd/", {}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_an_enormous_body_is_capped_rather_than_processed_whole(self):
+        with patch("analyzer.views.re.findall", wraps=None) as spy:
+            spy.side_effect = lambda pattern, text: []
+            self.client.post(
+                "/api/analyze-jd/",
+                {"job_description": "python " * 200_000},
+            )
+
+        # Whatever reached the tokeniser was capped, not the full body.
+        analysed = spy.call_args[0][1]
+        self.assertLessEqual(len(analysed), MAX_JOB_DESCRIPTION_LENGTH)
+
+    def test_the_endpoint_is_rate_limited(self):
+        body = {"job_description": "Python developer"}
+
+        with throttled_at("analyze_jd", "2/hour"):
+            self.assertEqual(
+                self.client.post("/api/analyze-jd/", body).status_code,
+                status.HTTP_200_OK,
+            )
+            self.assertEqual(
+                self.client.post("/api/analyze-jd/", body).status_code,
+                status.HTTP_200_OK,
+            )
+            self.assertEqual(
+                self.client.post("/api/analyze-jd/", body).status_code,
+                status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+
+
+class MockInterviewEndpointTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_a_normal_answer_gets_feedback(self):
+        resp = self.client.post(
+            "/api/mock-interview/",
+            {"question": "Explain closures.", "answer": "A closure is " + "words " * 40},
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("feedback", resp.data)
+
+    def test_null_fields_are_a_400_not_a_500(self):
+        resp = self.client.post(
+            "/api/mock-interview/",
+            {"question": None, "answer": None},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_the_endpoint_is_rate_limited(self):
+        body = {"question": "Explain closures.", "answer": "A closure is a function."}
+
+        with throttled_at("mock_interview", "1/hour"):
+            self.assertEqual(
+                self.client.post("/api/mock-interview/", body).status_code,
+                status.HTTP_200_OK,
+            )
+            self.assertEqual(
+                self.client.post("/api/mock-interview/", body).status_code,
+                status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+
+
+class SignupThrottleTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_account_creation_is_rate_limited(self):
+        def register(index):
+            return self.client.post(
+                "/api/auth/signup/",
+                {
+                    "username": f"person{index}",
+                    "password": "correct horse battery staple",
+                    "captcha_token": "test-captcha-token",
+                },
+            )
+
+        with throttled_at("signup", "2/hour"):
+            self.assertEqual(register(1).status_code, status.HTTP_201_CREATED)
+            self.assertEqual(register(2).status_code, status.HTTP_201_CREATED)
+            self.assertEqual(register(3).status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+        self.assertEqual(User.objects.filter(username__startswith="person").count(), 2)
+
+
+class UploadInputTests(TestCase):
+    """The reported 500: the slice sits above upload_resume's try/except."""
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_a_null_job_description_does_not_500(self):
+        resp = self.client.post(
+            "/api/upload/",
+            {"job_description": None, "role": None},
+            format="json",
+        )
+
+        # No file and no URL, so a 400 is the right answer. The point is that it
+        # is a 400 and not a TypeError traceback.
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)
+
+    def test_compare_uploads_reads_its_fields_the_same_way(self):
+        """`compare_uploads` had the identical `.get(f, "")[:2000]` line.
+
+        It is not reachable there in the same way: that view declares only
+        MultiPartParser and FormParser, so a JSON body is refused with a 415
+        before any of it runs and a form field is always a string. The read is
+        still routed through the helper so the two views cannot drift, but the
+        crash only ever affected the JSON-parsing endpoints.
+        """
+        json_attempt = self.client.post(
+            "/api/compare-uploads/", {"job_description": None}, format="json"
+        )
+        self.assertEqual(
+            json_attempt.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+        )
+
+        form_attempt = self.client.post("/api/compare-uploads/", {})
+        self.assertEqual(form_attempt.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", form_attempt.data)
+
+    def test_the_stored_job_description_is_still_capped_at_2000(self):
+        """The column's limit has not changed, only how it is applied."""
+        self.assertEqual(MAX_STORED_JOB_DESCRIPTION_LENGTH, 2_000)
+        self.assertEqual(
+            len(clean_text("x" * 5_000, max_length=MAX_STORED_JOB_DESCRIPTION_LENGTH)),
+            2_000,
+        )

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -20,7 +20,20 @@ from django.contrib.auth.tokens import default_token_generator
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.encoding import force_bytes, force_str
 from django.core.mail import send_mail
-from rest_framework.throttling import SimpleRateThrottle
+from rest_framework.throttling import AnonRateThrottle, SimpleRateThrottle
+
+from .request_input import (
+    MAX_CONTACT_EMAIL_LENGTH,
+    MAX_CONTACT_MESSAGE_LENGTH,
+    MAX_CONTACT_NAME_LENGTH,
+    MAX_CONTACT_SUBJECT_LENGTH,
+    MAX_INTERVIEW_ANSWER_LENGTH,
+    MAX_INTERVIEW_QUESTION_LENGTH,
+    MAX_JOB_DESCRIPTION_LENGTH,
+    MAX_STORED_JOB_DESCRIPTION_LENGTH,
+    clean_text,
+    is_probably_an_email,
+)
 
 from .comparison import compare_versions
 # ADDED Webhook TO MODELS IMPORT
@@ -66,6 +79,38 @@ class UploadRateThrottle(SimpleRateThrottle):
             "scope": self.scope,
             "ident": ident,
         }
+
+
+class ContactThrottle(AnonRateThrottle):
+    """Caps /api/contact/, which sends an email on every accepted request.
+
+    Without this the endpoint is an unauthenticated way to put attacker-written
+    text into the project's support inbox as fast as it can be called, which
+    burns the sending domain's reputation as much as it annoys whoever reads it.
+    """
+
+    scope = "contact"
+
+
+class AnalyzeJdThrottle(AnonRateThrottle):
+    """Caps /api/analyze-jd/, which does unbounded text work per request."""
+
+    scope = "analyze_jd"
+
+
+class MockInterviewThrottle(AnonRateThrottle):
+    scope = "mock_interview"
+
+
+class SignupThrottle(AnonRateThrottle):
+    """Caps account creation.
+
+    Independent of how the CAPTCHA is fixed (#584): a rate limit is worth having
+    behind any bot check, because a bot check that is ever bypassed leaves
+    nothing else in the way.
+    """
+
+    scope = "signup"
 
 
 def verify_captcha_token(token_string):
@@ -117,6 +162,7 @@ def validate_uploaded_file(f, formats=RESUME_FORMATS, field_label="resume"):
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([SignupThrottle])
 def signup(request):
     captcha_token = request.data.get("captcha_token") or request.data.get("captcha")
     if not verify_captcha_token(captcha_token):
@@ -180,8 +226,16 @@ def upload_resume(request):
 
     file = request.FILES.get("file")
     url = request.data.get("url") or request.data.get("resume_url")
-    target_role = request.data.get("role", "")
-    job_desc = request.data.get("job_description", "")[:2000]
+    target_role = clean_text(request.data.get("role"), max_length=100)
+    # `.get(key, "")` returns the stored value when the key is present, so a
+    # JSON body carrying `"job_description": null` produced None here and the
+    # slice raised TypeError. This line sits above the try/except, so that was
+    # an uncaught 500 rather than a 400 -- and a client posting a form object
+    # whole sends null for every field the user left blank.
+    job_desc = clean_text(
+        request.data.get("job_description"),
+        max_length=MAX_STORED_JOB_DESCRIPTION_LENGTH,
+    )
 
     cover_letter = request.FILES.get("cover_letter")
 
@@ -274,8 +328,11 @@ def task_status(request, task_id):
 def compare_uploads(request):
     file1 = request.FILES.get("file1")
     file2 = request.FILES.get("file2")
-    target_role = request.data.get("role", "")
-    job_desc = request.data.get("job_description", "")[:2000]
+    target_role = clean_text(request.data.get("role"), max_length=100)
+    job_desc = clean_text(
+        request.data.get("job_description"),
+        max_length=MAX_STORED_JOB_DESCRIPTION_LENGTH,
+    )
 
     if not file1 or not file2:
         return Response({"error": "Please provide two resume files."}, status=status.HTTP_400_BAD_REQUEST)
@@ -897,9 +954,15 @@ STOP_WORDS = {
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([AnalyzeJdThrottle])
 def analyze_jd_view(request):
-    job_description = request.data.get("job_description", "")
-    if not job_description or not job_description.strip():
+    # Capped before any work happens. Everything below walks the text, and then
+    # compares each of the top 30 words against the entire skill set, so an
+    # unbounded body was unbounded CPU on an endpoint anyone can call.
+    job_description = clean_text(
+        request.data.get("job_description"), max_length=MAX_JOB_DESCRIPTION_LENGTH
+    )
+    if not job_description:
         return Response({"error": "Job description cannot be empty."}, status=status.HTTP_400_BAD_REQUEST)
         
     words = re.findall(r"\b[a-zA-Z0-9\-\.\#\+\-]+\b", job_description.lower())
@@ -1206,18 +1269,56 @@ def user_profile_view(request):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+#: Categories the contact form offers. Anything else is filed as "Other" rather
+#: than echoed into the subject line, so the value cannot be used to write
+#: arbitrary text into the header of a mail the project sends.
+CONTACT_CATEGORIES = (
+    "General Inquiry",
+    "Bug Report",
+    "Feature Request",
+    "Account Support",
+    "Privacy",
+    "Other",
+)
+
+
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([ContactThrottle])
 def contact_us_view(request):
-    name = request.data.get("name", "").strip()
-    email = request.data.get("email", "").strip()
-    category = request.data.get("category", "General Inquiry").strip()
-    subject = request.data.get("subject", "").strip()
-    message = request.data.get("message", "").strip()
+    """Forward a support message to the project's inbox.
 
+    This endpoint sends an email on every accepted request and had no rate
+    limit, so it could be driven as a way to fill the support address with
+    attacker-written text — enough to damage the sending domain's reputation.
+    It is now throttled, its fields are bounded, and the address is checked to
+    be an address.
+    """
+    name = clean_text(request.data.get("name"), max_length=MAX_CONTACT_NAME_LENGTH)
+    email = clean_text(request.data.get("email"), max_length=MAX_CONTACT_EMAIL_LENGTH)
+    subject = clean_text(
+        request.data.get("subject"), max_length=MAX_CONTACT_SUBJECT_LENGTH
+    )
+    message = clean_text(
+        request.data.get("message"), max_length=MAX_CONTACT_MESSAGE_LENGTH
+    )
+
+    category = clean_text(request.data.get("category")) or "General Inquiry"
+    if category not in CONTACT_CATEGORIES:
+        category = "Other"
+
+    # Each of these used to be `.get(field, "").strip()`, which raises
+    # TypeError on a JSON null — the shape a client gets from posting a form
+    # object with blank fields.
     if not name or not email or not message:
         return Response(
             {"error": "Name, email, and message are required fields."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if not is_probably_an_email(email):
+        return Response(
+            {"error": "Please provide a valid email address so we can reply."},
             status=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -1230,10 +1331,23 @@ def contact_us_view(request):
             message=email_body,
             from_email=getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@ai-resume-analyzer.dev"),
             recipient_list=[support_email],
-            fail_silently=True,
+            # Was fail_silently=True, so a mail backend that was down looked
+            # exactly like a delivered message: the user was told "your message
+            # has been received" and it had gone nowhere. Someone who is not
+            # told their support request vanished does not send it again.
+            fail_silently=False,
         )
-    except Exception as e:
-        print(f"Failed to send support email: {e}")
+    except Exception:
+        logger.exception("Failed to send support email")
+        return Response(
+            {
+                "error": (
+                    "We could not send your message right now. Please try again "
+                    "in a few minutes."
+                )
+            },
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
 
     return Response(
         {
@@ -1313,9 +1427,14 @@ def unsubscribe_digest_view(request):
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([MockInterviewThrottle])
 def mock_interview_view(request):
-    question = request.data.get("question", "").strip()
-    answer = request.data.get("answer", "").strip()
+    question = clean_text(
+        request.data.get("question"), max_length=MAX_INTERVIEW_QUESTION_LENGTH
+    )
+    answer = clean_text(
+        request.data.get("answer"), max_length=MAX_INTERVIEW_ANSWER_LENGTH
+    )
 
     if not question or not answer:
         return Response(

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -195,13 +195,24 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.AllowAny',
     ),
-    # Neither password-reset endpoint had any limit. Requesting a reset sends
-    # mail, and confirming one guesses at a token, so both need a ceiling.
+    # Every AllowAny endpoint that does real work needs a ceiling. The two
+    # password-reset scopes came first (#585); the rest were added because they
+    # were entirely unlimited: /api/contact/ sends an email per request,
+    # /api/analyze-jd/ tokenises an unbounded body and then compares each of the
+    # top 30 words against the whole skill set, and signup had nothing but the
+    # CAPTCHA in front of it.
+    #
+    # All overridable by environment variable, because the right number depends
+    # on the deployment and nobody should have to edit code to raise one.
     'DEFAULT_THROTTLE_RATES': {
         'password_reset': os.environ.get('PASSWORD_RESET_RATE', '5/hour'),
         'password_reset_confirm': os.environ.get(
             'PASSWORD_RESET_CONFIRM_RATE', '20/hour'
         ),
+        'contact': os.environ.get('CONTACT_RATE', '5/hour'),
+        'analyze_jd': os.environ.get('ANALYZE_JD_RATE', '30/hour'),
+        'mock_interview': os.environ.get('MOCK_INTERVIEW_RATE', '30/hour'),
+        'signup': os.environ.get('SIGNUP_RATE', '10/hour'),
     },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }


### PR DESCRIPTION
Fixes #634

`UploadRateThrottle` covers the three upload endpoints, and #585 added throttles to the password-reset pair. Every other `AllowAny` endpoint had no limit at all, and several accepted unbounded input.

## `/api/contact/` — the one that matters

It sends an email on every accepted request, to the project's own support address, with fully caller-controlled `name`, `subject` and `message`. No throttle, no length caps, and `email` was required to be non-empty but never checked to be an address. Driving it in a loop fills the support inbox with attacker-written text and burns the sending domain's reputation, which is the expensive part.

- 5/hour throttle (env-overridable)
- every field bounded
- `EmailValidator` on the address, so the inbox does not fill with messages nobody can answer
- `category` is now a fixed set; anything unrecognised is filed as `"Other"` rather than echoed into the subject line, which keeps caller-controlled text out of a header on mail the project sends

**And it lied about failing.** `fail_silently=True` meant a mail backend that was down looked exactly like a delivered message — the user was told *"your message has been received and routed to our team"* and it had gone nowhere. Someone who is not told their support request vanished does not send it again. Now 502 with a logged exception.

## `/api/analyze-jd/` — unbounded work on an unbounded body

```python
job_description = request.data.get("job_description", "")
words = re.findall(r"\b[a-zA-Z0-9\-\.\#\+\-]+\b", job_description.lower())
```

…and then, for each of the top 30 words, a substring comparison against the entire skill set. No size cap and no throttle, on an endpoint anyone can call. Capped at 20k characters *before* any work happens, plus 30/hour.

## `/api/mock-interview/` and `/api/auth/signup/`

Both unthrottled; `answer` had no length limit. Signup was gated only by `verify_captcha_token()`. This is independent of how that gets fixed in #584 — a rate limit is worth having behind any bot check, because a bot check that is ever bypassed leaves nothing else in the way.

All four rates are environment variables: `CONTACT_RATE`, `ANALYZE_JD_RATE`, `MOCK_INTERVIEW_RATE`, `SIGNUP_RATE`. The right number depends on the deployment, and nobody should have to edit code to raise one.

## The null crash

```python
job_desc = request.data.get("job_description", "")[:2000]
```

`dict.get(key, default)` returns the *stored* value whenever the key is present, so a body carrying `"job_description": null` yields `None`, and `None[:2000]` raises `TypeError`. That line sits **above** `upload_resume`'s `try:`, so nothing catches it — the request 500s with a traceback instead of returning a 400.

This is not an exotic input. A client that fills a form object and posts it whole sends `null` for every field the user left blank; that is the normal shape of a JSON request. The same pattern with `.strip()` was in `contact_us_view` and `mock_interview_view`.

`analyzer/request_input.py` centralises it. Anything that is not a string becomes `""` — deliberately not `str(value)`, which would turn `{"message": ["a", "b"]}` into the literal text `"['a', 'b']"` and store *that*, which is harder to debug than an empty field — and every free-text field gets a named ceiling.

## One correction to the issue

I wrote that `compare_uploads` (line 278) had the same reachable crash. It has the identical line, but it is **not** reachable there: that view declares only `MultiPartParser` and `FormParser`, so a JSON body is refused with 415 before the view runs, and a multipart field is always a string. The reachable endpoints are the JSON-parsing ones — `/api/upload/` (which does declare `JSONParser`), `/api/contact/`, `/api/mock-interview/`, `/api/analyze-jd/`.

I routed `compare_uploads` through the helper anyway so the two upload paths cannot drift apart, but it is hardening rather than a fix, and there is a test saying exactly that rather than implying a bug was fixed. Also commented on the issue.

## Tests — 31

```
Ran 31 tests   OK
```

Beyond the obvious ones: a throttled contact request sends **no** mail (checking the status code alone would pass even if the mail went out first); a mail-backend failure is reported rather than claimed as success; an unrecognised category cannot reach the subject header; an oversized body is capped *before* the tokeniser sees it, asserted by inspecting what actually reached `re.findall` rather than trusting the cap.

**Worth knowing if you write more throttle tests:** `override_settings(REST_FRAMEWORK={"DEFAULT_THROTTLE_RATES": ...})` does not change a rate. `SimpleRateThrottle.THROTTLE_RATES` is a *class* attribute bound to `api_settings.DEFAULT_THROTTLE_RATES` at import time, so changing the setting afterwards leaves the class holding the original dict — the test passes 200 where you expected 429 and looks like the throttle is broken. Patching the dict itself is what takes effect; there is a `throttled_at()` helper and a comment explaining why.

Throttle tests also `cache.clear()` in `setUp`, since DRF keeps its counters there and the suite would otherwise be order-dependent.

## Not in scope

`verify_captcha_token()` accepting any string starting with `CAP-VERIFIED-` is #584, with a fix already open in #589. This PR only adds the rate limit that belongs behind it either way.

The 4 failures on this branch are pre-existing on `main` and are handled by #635, #636 and #637. No new ones.

## Merge safety

Verified against the other four open PRs: merged all five in three different orders (1-2-3-4-5, 5-4-3-2-1, 3-1-5-2-4) plus several partial combinations. No textual conflicts anywhere, and the full suite — 314 backend, 159 frontend — is green in every one.
