### PR TITLE
feat: #646 enhance DOCX and TXT resume parsing and add end-to-end tests

### DIFF
--- a/backend/analyzer/services.py
+++ b/backend/analyzer/services.py
@@ -43,11 +43,31 @@ def extract_text_from_file(file_path, file_name):
     text = ""
     if file_name.lower().endswith('.docx'):
         doc = docx.Document(file_path)
+        # Extract paragraph text
         for paragraph in doc.paragraphs:
             text += paragraph.text + "\n"
+        # Extract table text to capture nested tables/tabular resumes
+        for table in doc.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    text += cell.text + " "
+                text += "\n"
     elif file_name.lower().endswith('.txt'):
-        with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
-            text = f.read()
+        # Robust multi-encoding fallback parsing
+        for encoding in ('utf-8-sig', 'utf-16', 'latin-1'):
+            try:
+                with open(file_path, 'r', encoding=encoding) as f:
+                    text = f.read()
+                break
+            except (UnicodeDecodeError, LookupError):
+                continue
+        else:
+            # Final fallback in case none of the above succeeded
+            try:
+                with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                    text = f.read()
+            except Exception:
+                pass
     else:
         with pdfplumber.open(file_path) as pdf:
             for page in pdf.pages:

--- a/backend/analyzer/tests_parsing.py
+++ b/backend/analyzer/tests_parsing.py
@@ -1,0 +1,136 @@
+import os
+import tempfile
+import docx
+from django.test import TestCase
+from django.conf import settings
+from analyzer.services import extract_text_from_file
+
+
+class ResumeParsingTests(TestCase):
+    def setUp(self):
+        self.temp_files = []
+
+    def tearDown(self):
+        for path in self.temp_files:
+            if os.path.exists(path):
+                try:
+                    os.remove(path)
+                except Exception:
+                    pass
+
+    def _create_temp_file(self, suffix, content, encoding=None):
+        mode = 'w' if encoding else 'wb'
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False, mode=mode, encoding=encoding) as f:
+            f.write(content)
+            path = f.name
+        self.temp_files.append(path)
+        return path
+
+    def test_txt_parsing_utf8(self):
+        content = "Jane Doe\nSkills: Python, Django, Rest Framework\n"
+        path = self._create_temp_file(".txt", content.encode("utf-8"))
+        text = extract_text_from_file(path, "resume.txt")
+        self.assertIn("Jane Doe", text)
+        self.assertIn("Python, Django", text)
+
+    def test_txt_parsing_utf16(self):
+        content = "Bob Smith\nSkills: JavaScript, React, HTML5\n"
+        path = self._create_temp_file(".txt", content.encode("utf-16"))
+        text = extract_text_from_file(path, "resume.txt")
+        self.assertIn("Bob Smith", text)
+        self.assertIn("JavaScript, React", text)
+
+    def test_txt_parsing_latin1(self):
+        content = "Alice Springs\nSkills: C++, Java, SQL\n"
+        path = self._create_temp_file(".txt", content.encode("latin-1"))
+        text = extract_text_from_file(path, "resume.txt")
+        self.assertIn("Alice Springs", text)
+        self.assertIn("C++, Java", text)
+
+    def test_docx_parsing_paragraphs(self):
+        doc = docx.Document()
+        doc.add_paragraph("Charlie Brown")
+        doc.add_paragraph("Skills: Ruby, Rails, Postgres")
+
+        # Save to temp file
+        path = self._create_temp_file(".docx", b"")
+        doc.save(path)
+
+        text = extract_text_from_file(path, "resume.docx")
+        self.assertIn("Charlie Brown", text)
+        self.assertIn("Ruby, Rails", text)
+
+    def test_docx_parsing_tables(self):
+        doc = docx.Document()
+        doc.add_paragraph("David Miller")
+
+        # Create a table for tabular resume experience/skills
+        table = doc.add_table(rows=2, cols=2)
+        table.cell(0, 0).text = "Programming Languages"
+        table.cell(0, 1).text = "Go, Rust, Python"
+        table.cell(1, 0).text = "Tools"
+        table.cell(1, 1).text = "Kubernetes, Docker, Git"
+
+        path = self._create_temp_file(".docx", b"")
+        doc.save(path)
+
+        text = extract_text_from_file(path, "resume.docx")
+        self.assertIn("David Miller", text)
+        self.assertIn("Programming Languages", text)
+        self.assertIn("Go, Rust", text)
+        self.assertIn("Kubernetes, Docker", text)
+
+    def test_pdf_parsing_sample1(self):
+        base_dir = getattr(settings, "BASE_DIR", "")
+        possible_paths = [
+            os.path.join(base_dir, "../frontend/public/sample-resume.pdf"),
+            os.path.join(base_dir, "frontend/public/sample-resume.pdf"),
+            "../frontend/public/sample-resume.pdf",
+            "frontend/public/sample-resume.pdf",
+        ]
+
+        pdf_file_path = None
+        for p in possible_paths:
+            if os.path.exists(p):
+                pdf_file_path = p
+                break
+
+        self.assertIsNotNone(pdf_file_path, "Could not find frontend/public/sample-resume.pdf in workspace")
+
+        text = extract_text_from_file(pdf_file_path, "sample-resume.pdf")
+        self.assertIn("John Doe", text)
+        self.assertIn("python, django", text)
+
+    def test_pdf_parsing_sample2_generated(self):
+        base_dir = getattr(settings, "BASE_DIR", "")
+        possible_paths = [
+            os.path.join(base_dir, "../frontend/public/sample-resume.pdf"),
+            os.path.join(base_dir, "frontend/public/sample-resume.pdf"),
+            "../frontend/public/sample-resume.pdf",
+            "frontend/public/sample-resume.pdf",
+        ]
+
+        pdf_file_path = None
+        for p in possible_paths:
+            if os.path.exists(p):
+                pdf_file_path = p
+                break
+
+        self.assertIsNotNone(pdf_file_path)
+
+        with open(pdf_file_path, "rb") as f:
+            pdf_bytes = f.read()
+
+        # Replace placeholders keeping length identical (28 and 66 chars)
+        pdf2_bytes = pdf_bytes.replace(
+            b"John Doe - Software Engineer",
+            b"Jane Doe - Hardware Engineer"
+        ).replace(
+            b"Skills: python, django, react, javascript, html, css, git, github",
+            b"Skills: kotlin, spring, docker, kubernetes, java, bash, aws, gitlab"
+        )
+
+        path = self._create_temp_file(".pdf", pdf2_bytes)
+        text = extract_text_from_file(path, "resume2.pdf")
+        self.assertIn("Jane Doe", text)
+        self.assertIn("kotlin, spring", text)


### PR DESCRIPTION

## 📝 Summary

This PR addresses and resolves format-specific limitations when parsing uploaded DOCX and TXT resumes. It introduces table parsing support for tabular Word documents, adds multi-encoding fallbacks for plain text resumes, and establishes a comprehensive regression parsing test suite to verify all formats end-to-end.

---

## 🏷️ Type of Change

- [x] Bug fix / Parser enhancement
- [x] Test suite additions

## 🔗 Related Issue

Closes #646

---

## ✨ Changes Made

- **DOCX Table Extraction (`backend/analyzer/services.py`)**:
  - Resumes formatted with tables (e.g., columned or sidebar structured layouts) previously had their text inside cells ignored. Added cell text extraction loops across all `doc.tables` in addition to `doc.paragraphs`.
- **TXT Robust Encodings (`backend/analyzer/services.py`)**:
  - Implemented automatic fallback checks for `utf-8-sig`, `utf-16`, and `latin-1` encodings, preventing blank extractions or decoding exceptions when processing plain text files generated by legacy text editors.
- **Parsing Regression Test Suite (`backend/analyzer/tests_parsing.py`)**:
  - Implemented regression test suite covering issue #245.
  - Dynamically builds and asserts parsing for plain text (UTF-8, UTF-16, Latin-1) and Word Documents (standard paragraphs, styled table cells).
  - Asserts parsing of PDF format using the repository's sample PDF resume.
