### PR TITLE
feat: #644 add structured login error messages with actionable next-steps

### DIFF
--- a/backend/analyzer/serializers.py
+++ b/backend/analyzer/serializers.py
@@ -58,6 +58,38 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                     {"captcha_token": ["CAPTCHA verification failed. Please complete the security challenge."]}
                 )
 
+        username = attrs.get("username")
+        password = attrs.get("password")
+
+        from django.contrib.auth import authenticate
+        from django.contrib.auth.models import User
+        from rest_framework.exceptions import AuthenticationFailed
+
+        user = User.objects.filter(username=username).first()
+        if not user:
+            # Generic message to prevent user enumeration
+            raise AuthenticationFailed("No active account found with the given credentials.")
+
+        if not user.is_active:
+            raise AuthenticationFailed({
+                "detail": "Your account has been locked or deactivated. Please reset your password to unlock it or contact support.",
+                "code": "account_locked"
+            })
+
+        if not user.check_password(password):
+            # Generic message to prevent user enumeration
+            raise AuthenticationFailed("No active account found with the given credentials.")
+
+        # Check if email is verified (forward-compatible with issue 371)
+        profile = getattr(user, 'profile', None)
+        is_verified = getattr(profile, 'is_verified', True) if profile else True
+        if not is_verified:
+            raise AuthenticationFailed({
+                "detail": "Your email address is not verified. Please verify your email to gain full account access.",
+                "code": "email_unverified",
+                "email": user.email
+            })
+
         data = super().validate(attrs)
         profile, _ = UserProfile.objects.get_or_create(user=self.user)
         if profile.avatar:

--- a/backend/analyzer/tests_login_errors.py
+++ b/backend/analyzer/tests_login_errors.py
@@ -1,0 +1,48 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.test import APIClient
+from analyzer.models import UserProfile
+
+
+class LoginErrorTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        # Normal user
+        self.user = User.objects.create_user(username="normaluser", password="password123", email="normal@example.com")
+
+        # Locked/inactive user
+        self.locked_user = User.objects.create_user(username="lockeduser", password="password123", email="locked@example.com")
+        self.locked_user.is_active = False
+        self.locked_user.save()
+
+        # Unverified user (profile exists and is_verified=False)
+        self.unverified_user = User.objects.create_user(username="unverifieduser", password="password123", email="unverified@example.com")
+        profile, _ = UserProfile.objects.get_or_create(user=self.unverified_user)
+        # Set is_verified attribute dynamically if the database field does not exist yet on main
+        profile.is_verified = False
+        profile.save()
+
+    def test_nonexistent_user_returns_generic_error(self):
+        resp = self.client.post("/api/auth/login/", {"username": "nonexistent", "password": "password123"})
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("No active account found with the given credentials.", resp.data["detail"])
+        # Verify no user enumeration: code/username is not leaked
+        self.assertNotIn("code", resp.data)
+
+    def test_wrong_password_returns_generic_error(self):
+        resp = self.client.post("/api/auth/login/", {"username": "normaluser", "password": "wrongpassword"})
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("No active account found with the given credentials.", resp.data["detail"])
+
+    def test_locked_user_returns_locked_error(self):
+        resp = self.client.post("/api/auth/login/", {"username": "lockeduser", "password": "password123"})
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("locked or deactivated", resp.data["detail"])
+        self.assertEqual(resp.data["code"], "account_locked")
+
+    def test_unverified_user_returns_unverified_error(self):
+        resp = self.client.post("/api/auth/login/", {"username": "unverifieduser", "password": "password123"})
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("not verified", resp.data["detail"])
+        self.assertEqual(resp.data["code"], "email_unverified")
+        self.assertEqual(resp.data["email"], "unverified@example.com")

--- a/frontend/src/AuthModal.tsx
+++ b/frontend/src/AuthModal.tsx
@@ -5,7 +5,12 @@ import { CaptchaChallenge } from './components/CaptchaChallenge'
 
 interface AuthModalProps {
   onSignup: (username: string, password: string, captchaToken?: string) => Promise<void>
-  onLogin: (username: string, password: string, rememberMe: boolean, captchaToken?: string) => Promise<void>
+  onLogin: (
+    username: string,
+    password: string,
+    rememberMe: boolean,
+    captchaToken?: string
+  ) => Promise<void>
   onClose: () => void
 }
 
@@ -15,6 +20,9 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [captchaToken, setCaptchaToken] = useState('')
+  const [unverifiedEmail, setUnverifiedEmail] = useState('')
+  const [resendStatus, setResendStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle')
+  const [resendMessage, setResendMessage] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
@@ -29,9 +37,31 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
 
+  const handleResendVerification = async () => {
+    if (!unverifiedEmail) return
+    setResendStatus('sending')
+    setResendMessage('')
+    try {
+      const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
+      await axios.post(`${backendUrl}/api/auth/resend-verification/`, { email: unverifiedEmail })
+      setResendStatus('success')
+      setResendMessage('Verification email has been resent successfully!')
+    } catch (err: any) {
+      setResendStatus('error')
+      setResendMessage(
+        err.response?.data?.detail ||
+          err.response?.data?.error ||
+          'Failed to resend verification email.'
+      )
+    }
+  }
+
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
+    setUnverifiedEmail('')
+    setResendStatus('idle')
+    setResendMessage('')
 
     if (mode !== 'forgot_password' && !captchaToken) {
       setError('Please complete the security check before submitting.')
@@ -53,9 +83,32 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
         await axios.post(`${backendUrl}/api/password-reset/`, { username })
         onClose()
       }
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Authentication failed'
+    } catch (err: any) {
+      let msg = 'Authentication failed'
+      let emailVal = ''
+      if (err.response?.data) {
+        const data = err.response.data
+        if (data.detail) {
+          msg = data.detail
+        } else if (data.error) {
+          msg = data.error
+        } else if (typeof data === 'string') {
+          msg = data
+        } else {
+          const firstKey = Object.keys(data)[0]
+          if (firstKey) {
+            msg = Array.isArray(data[firstKey]) ? data[firstKey][0] : data[firstKey]
+          }
+        }
+
+        if (data.code === 'email_unverified' && data.email) {
+          emailVal = data.email
+        }
+      } else if (err.message) {
+        msg = err.message
+      }
       setError(msg)
+      setUnverifiedEmail(emailVal)
     } finally {
       setLoading(false)
     }
@@ -237,6 +290,69 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onSignup, onLogin, onClose
             </button>
           </div>
           {error && <p className="auth-error">{error}</p>}
+
+          {unverifiedEmail && (
+            <div style={{ marginTop: '10px', marginBottom: '16px', textAlign: 'center' }}>
+              {resendStatus === 'success' ? (
+                <p style={{ color: 'var(--color-accent, #22c55e)', fontSize: '0.9rem', margin: 0 }}>
+                  {resendMessage}
+                </p>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={handleResendVerification}
+                    disabled={resendStatus === 'sending'}
+                    className="app-btn app-btn--secondary"
+                    style={{
+                      width: '100%',
+                      padding: '8px 12px',
+                      fontSize: '0.9rem',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {resendStatus === 'sending'
+                      ? 'Sending Verification Link...'
+                      : 'Resend Verification Email'}
+                  </button>
+                  {resendStatus === 'error' && (
+                    <p
+                      style={{
+                        color: 'var(--color-danger, #ef4444)',
+                        fontSize: '0.85rem',
+                        marginTop: '6px',
+                        margin: 0,
+                      }}
+                    >
+                      {resendMessage}
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {error && error.includes('locked') && (
+            <div style={{ marginTop: '10px', marginBottom: '16px', textAlign: 'center' }}>
+              <button
+                type="button"
+                onClick={() => {
+                  setMode('forgot_password')
+                  setError('')
+                }}
+                className="app-btn app-btn--secondary"
+                style={{
+                  width: '100%',
+                  padding: '8px 12px',
+                  fontSize: '0.9rem',
+                  cursor: 'pointer',
+                }}
+              >
+                Reset Password to Unlock
+              </button>
+            </div>
+          )}
+
           <button className="auth-submit-btn" type="submit" disabled={loading}>
             {loading ? (
               <>


### PR DESCRIPTION

## 📝 Summary

Currently, login failures display a generic error. This PR introduces distinct, descriptive error messages for invalid credentials, locked accounts, and unverified emails. To protect against user enumeration, credential failures remain generic, while locked and unverified states expose structured codes (`account_locked`, `email_unverified`) to render direct next actions (resetting passwords or resending verification emails) directly in the UI.

---

## 🏷️ Type of Change

- [x] New feature
- [x] Test suite additions

## 🔗 Related Issue

Closes #644

---

## ✨ Changes Made

- **Pre-Authentication Safety Layer (`backend/analyzer/serializers.py`)**:
  - Intercepts validation requests in `CustomTokenObtainPairSerializer` before standard authentication runs.
  - Returns a generic failure for non-existent users and wrong passwords.
  - Returns a descriptive alert with code `account_locked` if `is_active` is `False`.
  - Returns code `email_unverified` with the target address if `is_verified` is `False`.
- **Dynamic Frontend Actions (`frontend/src/AuthModal.tsx`)**:
  - Upgraded login error handlers to display the backend's detailed messages instead of generic status strings.
  - Renders a **Resend Verification Email** button on unverified email codes which triggers `/api/auth/resend-verification/` requests.
  - Renders a **Reset Password** link on locked account codes which transitions the modal into the forgot-password view.
- **Unit Verification Suite (`backend/analyzer/tests_login_errors.py`)**:
  - `LoginErrorTests`: Tests generic error responses for invalid logins, specific `account_locked` responses, and structured `email_unverified` parameters.
