### PR TITLE
Add currency converter utility

### DIFF
--- a/backend/utils/currencyConverter.ts
+++ b/backend/utils/currencyConverter.ts
@@ -1,0 +1,30 @@
+export type CurrencyCode = 'USD' | 'INR' | 'EUR' | 'GBP' | 'CAD';
+
+export interface CurrencyConfig {
+  code: CurrencyCode;
+  symbol: string;
+  rateFromUSD: number; // Base conversion relative to USD
+  locale: string;
+}
+
+export const SUPPORTED_CURRENCIES: Record<CurrencyCode, CurrencyConfig> = {
+  USD: { code: 'USD', symbol: '$', rateFromUSD: 1.0, locale: 'en-US' },
+  INR: { code: 'INR', symbol: '₹', rateFromUSD: 83.0, locale: 'en-IN' },
+  EUR: { code: 'EUR', symbol: '€', rateFromUSD: 0.92, locale: 'de-DE' },
+  GBP: { code: 'GBP', symbol: '£', rateFromUSD: 0.79, locale: 'en-GB' },
+  CAD: { code: 'CAD', symbol: 'CA$', rateFromUSD: 1.35, locale: 'en-CA' },
+};
+
+/**
+ * Converts a base USD amount to the target currency and formats it cleanly.
+ */
+export function formatSalary(amountInUSD: number, targetCurrency: CurrencyCode): string {
+  const config = SUPPORTED_CURRENCIES[targetCurrency] || SUPPORTED_CURRENCIES.USD;
+  const convertedAmount = amountInUSD * config.rateFromUSD;
+
+  return new Intl.NumberFormat(config.locale, {
+    style: 'currency',
+    currency: targetCurrency,
+    maximumFractionDigits: 0,
+  }).format(convertedAmount);
+}

--- a/frontend/components/SalaryCurrencySelector.tsx
+++ b/frontend/components/SalaryCurrencySelector.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+import { SUPPORTED_CURRENCIES, CurrencyCode } from '@/utils/currencyConverter';
+import { Globe } from 'lucide-react';
+
+interface SalaryCurrencySelectorProps {
+  currentCurrency: CurrencyCode;
+  onCurrencyChange: (currency: CurrencyCode) => void;
+}
+
+export const SalaryCurrencySelector: React.FC<SalaryCurrencySelectorProps> = ({
+  currentCurrency,
+  onCurrencyChange,
+}) => {
+  return (
+    <div className="flex items-center gap-2 bg-slate-900 border border-slate-800 px-3 py-1.5 rounded-lg text-slate-200 shadow-sm">
+      <Globe className="h-4 w-4 text-teal-400" />
+      <span className="text-xs font-medium text-slate-400">Currency:</span>
+      <select
+        value={currentCurrency}
+        onChange={(e) => onCurrencyChange(e.target.value as CurrencyCode)}
+        aria-label="Select salary display currency"
+        className="bg-slate-950 border border-slate-700 text-xs font-semibold rounded px-2 py-1 text-teal-300 focus:outline-none focus:ring-1 focus:ring-teal-500 cursor-pointer"
+      >
+        {Object.keys(SUPPORTED_CURRENCIES).map((code) => (
+          <option key={code} value={code}>
+            {code} ({SUPPORTED_CURRENCIES[code as CurrencyCode].symbol})
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};

--- a/frontend/components/SalaryInsightsPanel.tsx
+++ b/frontend/components/SalaryInsightsPanel.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React, { useState } from 'react';
+import { CurrencyCode } from '@/utils/currencyConverter';
+import { formatSalary } from '@/utils/currencyConverter';
+import { SalaryCurrencySelector } from '@/components/SalaryCurrencySelector';
+import { DollarSign, TrendingUp } from 'lucide-react';
+
+interface SalaryInsightsProps {
+  baseSalaryUSD: number; // Assuming internal data is indexed in USD
+  marketAverageUSD: number;
+}
+
+export const SalaryInsightsPanel: React.FC<SalaryInsightsProps> = ({
+  baseSalaryUSD,
+  marketAverageUSD,
+}) => {
+  const [currency, setCurrency] = useState<CurrencyCode>('USD');
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 space-y-6 text-slate-100 shadow-xl">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 border-b border-slate-800 pb-4">
+        <div>
+          <h3 className="text-lg font-bold text-white flex items-center gap-2">
+            <DollarSign className="h-5 w-5 text-teal-400" />
+            Estimated Salary Insights
+          </h3>
+          <p className="text-xs text-slate-400 mt-0.5">
+            Based on your resume profile and current market benchmarks.
+          </p>
+        </div>
+        
+        {/* Currency Selector Control */}
+        <SalaryCurrencySelector currentCurrency={currency} onCurrencyChange={setCurrency} />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="bg-slate-950 p-4 rounded-xl border border-slate-800 space-y-1">
+          <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Estimated Match Salary</span>
+          <div className="text-2xl font-black text-teal-400">
+            {formatSalary(baseSalaryUSD, currency)}
+          </div>
+          <span className="text-[10px] text-slate-500">Displayed in {currency} (converted from base model data)</span>
+        </div>
+
+        <div className="bg-slate-950 p-4 rounded-xl border border-slate-800 space-y-1">
+          <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider flex items-center gap-1">
+            <TrendingUp className="h-3.5 w-3.5 text-teal-400" /> Market Average
+          </span>
+          <div className="text-2xl font-black text-white">
+            {formatSalary(marketAverageUSD, currency)}
+          </div>
+          <span className="text-[10px] text-slate-500">Industry baseline for matched role requirements</span>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description
Added multi-currency display support for resume salary insights, fulfilling [Issue #603](https://github.com/Muskankr/AI-Resume-Analyzer/issues/603). Users can now toggle between different global currencies (USD, INR, EUR, GBP, CAD) with automatic conversion and clear formatting labels.

---

## Related Issue
Closes #603

---

## Changes Made
- **Currency Utility (`utils/currencyConverter.ts`)**:
  - Implemented exchange rate configurations and localized international number formatting via `Intl.NumberFormat`.
- **Selector Component (`components/SalaryCurrencySelector.tsx`)**:
  - Built a lightweight currency dropdown selector component.
- **Insights Integration (`components/SalaryInsightsPanel.tsx`)**:
  - Updated salary metric cards to accept currency changes dynamically and render correct symbols and rates.

