### PR TITLE
fix: use correct parameter names for actions/first-interaction@v1

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -18,15 +18,15 @@ jobs:
         uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-comment: |
+          issue-message: |
             Welcome to **AI Resume Analyzer**! 🎉 
 
-            Thank you for opening your first issue in this repository! Please take a moment to review our [CONTRIBUTING.md](https://github.com/Babin123456/AI-Resume-Analyzer/blob/main/CONTRIBUTING.md) and our [Code of Conduct](https://github.com/Babin123456/AI-Resume-Analyzer/blob/main/CODE_OF_CONDUCT.md) (#180).
+            Thank you for opening your first issue in this repository! Please take a moment to review our [CONTRIBUTING.md](https://github.com/Muskankr/AI-Resume-Analyzer/blob/main/CONTRIBUTING.md) and adhere to our [Code of Conduct](https://github.com/Muskankr/AI-Resume-Analyzer/blob/main/CODE_OF_CONDUCT.md).
 
             We appreciate your contribution and our maintainers will review it shortly.
-          pr-comment: |
+          pr-message: |
             Welcome to **AI Resume Analyzer**! 🎉 
 
-            Thank you for opening your first pull request in this repository! Please ensure you have reviewed our [CONTRIBUTING.md](https://github.com/Babin123456/AI-Resume-Analyzer/blob/main/CONTRIBUTING.md) and adhere to our [Code of Conduct](https://github.com/Babin123456/AI-Resume-Analyzer/blob/main/CODE_OF_CONDUCT.md) (#180).
+            Thank you for opening your first pull request in this repository! Please ensure you have reviewed our [CONTRIBUTING.md](https://github.com/Muskankr/AI-Resume-Analyzer/blob/main/CONTRIBUTING.md) and adhere to our [Code of Conduct](https://github.com/Muskankr/AI-Resume-Analyzer/blob/main/CODE_OF_CONDUCT.md).
 
             Our team will review your PR soon. Happy contributing! 🚀


### PR DESCRIPTION
## Problem
Job #95974369553 failed with:
> Action must have at least one of `issue-message` or `pr-message` set

The workflow was using `issue-comment` and `pr-comment`, which are not valid parameters for `actions/first-interaction@v1`.

## Changes
- `issue-comment` → `issue-message`
- `pr-comment` → `pr-message`
- Updated repo owner links from `Babin123456` → `Muskankr`

## References
- Fixes job #95974369553
- [actions/first-interaction docs](https://github.com/actions/first-interaction)