### PR TITLE
fix: make share links opt-in, expiring and revocable (#705)

### DIFF
--- a/backend/analyzer/migrations/0017_resumeanalysis_share_controls.py
+++ b/backend/analyzer/migrations/0017_resumeanalysis_share_controls.py
@@ -1,0 +1,87 @@
+"""Share controls on ResumeAnalysis, plus the 0016 merge they need to sit on.
+
+Two leaf nodes exist at 0016 — ``0016_merge_20260819_1833`` and
+``0016_resumeanalysis_partial_skills`` were generated independently against
+``0015``. ``manage.py test`` refuses to build a database in that state
+("Conflicting migrations detected; multiple leaf nodes"), so anything added
+after it has to resolve the fork. Depending on both here does that and adds the
+new columns in one node, rather than shipping an empty merge migration and then
+immediately adding a second one on top of it.
+
+The data step matters as much as the schema. ``share_enabled`` defaults to
+``False``, which is the whole point of the change — but applying that default to
+rows that already exist would break every link a user has already sent. Those
+rows are backfilled as enabled, dated from the analysis, with the standard
+lifetime measured from *now* rather than from creation, so an old share gets a
+full window to be noticed and re-shared rather than expiring the moment this
+deploys.
+"""
+
+from datetime import timedelta
+
+from django.db import migrations, models
+from django.utils import timezone
+
+
+def enable_sharing_on_existing_rows(apps, schema_editor):
+    """Preserve links that already work.
+
+    Every pre-existing analysis was publicly readable by id, so switching the
+    default to off is a behaviour change for links already in circulation. They
+    are marked enabled with a normal expiry: the new rules apply to them, the
+    link keeps working today, and it stops working on the same schedule as
+    everything else instead of living forever.
+    """
+    ResumeAnalysis = apps.get_model("analyzer", "ResumeAnalysis")
+    now = timezone.now()
+
+    ResumeAnalysis.objects.update(
+        share_enabled=True,
+        share_created_at=models.F("created_at"),
+        share_expires_at=now + timedelta(days=30),
+    )
+
+
+def disable_sharing_on_existing_rows(apps, schema_editor):
+    """Reverse step.
+
+    Nothing to undo in the data — the columns themselves are dropped by the
+    schema reversal below. Present so the migration is reversible rather than
+    irreversible for no reason.
+    """
+    return None
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("analyzer", "0016_merge_20260819_1833"),
+        ("analyzer", "0016_resumeanalysis_partial_skills"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="resumeanalysis",
+            name="share_enabled",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="resumeanalysis",
+            name="share_created_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="resumeanalysis",
+            name="share_expires_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="resumeanalysis",
+            name="share_view_count",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.RunPython(
+            enable_sharing_on_existing_rows,
+            disable_sharing_on_existing_rows,
+        ),
+    ]

--- a/backend/analyzer/models.py
+++ b/backend/analyzer/models.py
@@ -1,5 +1,6 @@
 import secrets
 import uuid
+from datetime import timedelta
 
 from django.contrib.auth.models import User
 from django.db import models
@@ -28,16 +29,128 @@ class ResumeAnalysis(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     job_description = models.TextField(blank=True, null=True)
     resume_text = models.TextField(blank=True, null=True)
-    share_id = models.UUIDField(default=uuid.uuid4, unique=True)
     cover_letter_text = models.TextField(blank=True, null=True)
     cover_letter_feedback = models.JSONField(blank=True, null=True)
     interview_questions = models.JSONField(blank=True, null=True)
+
+    # --- Public sharing ---------------------------------------------------
+    #
+    # ``share_id`` is still assigned at creation, because it is the row's stable
+    # public name and generating it lazily would mean a nullable unique column.
+    # What changed is that holding the id is no longer sufficient:
+    # :meth:`is_share_live` is now the question the public endpoint asks, and it
+    # is false until someone turns sharing on.
+
+    share_id = models.UUIDField(default=uuid.uuid4, unique=True)
+
+    #: Whether the owner has published this analysis. Off by default — an
+    #: analysis used to be reachable by anyone who learned its id from the
+    #: moment it was created, which is not a decision the owner ever made.
+    share_enabled = models.BooleanField(default=False)
+
+    #: When sharing was last turned on or rotated. Shown in the UI so a user
+    #: looking at an old analysis can tell how long a link has been live.
+    share_created_at = models.DateTimeField(null=True, blank=True)
+
+    #: When the link stops working. Always set while sharing is on — a link with
+    #: no end is the state this exists to remove.
+    share_expires_at = models.DateTimeField(null=True, blank=True)
+
+    #: Rough traffic counter, so "did anyone actually open this?" has an answer
+    #: and an unexpected number is a reason to revoke. Incremented with an F()
+    #: expression, so it is a lower bound under concurrency rather than a lie.
+    share_view_count = models.PositiveIntegerField(default=0)
 
     class Meta:
         ordering = ["-created_at"]
 
     def __str__(self):
         return f"{self.user.username} — {self.file_name} ({self.score}%)"
+
+    def is_share_live(self, at=None):
+        """Return ``True`` when the public endpoint should answer for this row.
+
+        Both halves matter. ``share_enabled`` is the owner's decision;
+        ``share_expires_at`` is the clock. A row that is enabled but past its
+        expiry is not live, and is left alone rather than rewritten — expiry is
+        evaluated on read so a revocation never depends on a cleanup job having
+        run.
+        """
+        if not self.share_enabled:
+            return False
+        if self.share_expires_at is None:
+            # Enabled with no expiry should be unreachable — `enable_sharing` is
+            # the only way to set the flag and it always sets a date. Treated as
+            # not-live rather than trusted, because the failure mode of the
+            # other choice is an immortal link.
+            return False
+        return self.share_expires_at > (at or timezone.now())
+
+    def enable_sharing(self, lifetime_days, rotate=False, at=None):
+        """Publish this analysis for ``lifetime_days``, optionally under a new id.
+
+        Args:
+            lifetime_days: Life of the link from now. The caller is expected to
+                have passed the value through ``sharing.clamp_lifetime_days``.
+            rotate: Issue a fresh ``share_id``, which invalidates every copy of
+                the previous link. This is the "I sent it to the wrong person"
+                button, and it is separate from revoking because the common case
+                is wanting a working link, just not *that* one.
+            at: Clock override, for tests.
+
+        Returns:
+            ``self``, saved.
+        """
+        now = at or timezone.now()
+
+        if rotate or not self.share_enabled:
+            # A link that is off is being turned on, which is a new publication
+            # even if the id is unchanged; resetting the counter keeps the
+            # number answering "views since I shared it" rather than an
+            # all-time total that spans a revocation.
+            self.share_view_count = 0
+        if rotate:
+            self.share_id = uuid.uuid4()
+
+        self.share_enabled = True
+        self.share_created_at = now
+        self.share_expires_at = now + timedelta(days=lifetime_days)
+        self.save(
+            update_fields=[
+                "share_id",
+                "share_enabled",
+                "share_created_at",
+                "share_expires_at",
+                "share_view_count",
+            ]
+        )
+        return self
+
+    def revoke_sharing(self):
+        """Turn the link off and clear its expiry.
+
+        The ``share_id`` is deliberately left in place. Re-enabling later should
+        be a decision about *whether* to share, not a forced rotation, and
+        keeping the id means a user who re-enables does not have to re-send a
+        link they already distributed. :meth:`enable_sharing` with
+        ``rotate=True`` is there for when they do want a clean break.
+        """
+        self.share_enabled = False
+        self.share_expires_at = None
+        self.save(update_fields=["share_enabled", "share_expires_at"])
+        return self
+
+    def register_share_view(self):
+        """Count one public read, without reading the row back first.
+
+        ``F("share_view_count") + 1`` so two concurrent views cannot both write
+        the same number. The in-memory instance is intentionally *not*
+        refreshed — the view has no use for the new value, and refreshing would
+        cost a second query on the hot path of a public endpoint.
+        """
+        type(self).objects.filter(pk=self.pk).update(
+            share_view_count=models.F("share_view_count") + 1
+        )
 
 
 class UserProfile(models.Model):

--- a/backend/analyzer/serializers.py
+++ b/backend/analyzer/serializers.py
@@ -1,8 +1,10 @@
 from rest_framework import serializers
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
 from drf_spectacular.utils import OpenApiResponse, extend_schema
+from . import sharing
 from .models import Resume, ResumeAnalysis
 
 
@@ -156,6 +158,81 @@ class ResumeAnalysisListSerializer(serializers.ModelSerializer):
         model = ResumeAnalysis
         fields = ("id", "share_id", "file_name", "score", "skills_found", "suggestions",
                   "matched_skills", "partial_skills", "missing_skills", "target_role", "experience_level", "created_at")
+
+class PublicSharedAnalysisSerializer(serializers.ModelSerializer):
+    """What a share link is allowed to return.
+
+    Deliberately not a subset of :class:`ResumeAnalysisSerializer` by way of
+    ``exclude``. An exclude list is a denylist, and a denylist on a model that
+    gains fields over time fails open — the next column added to
+    ``ResumeAnalysis`` would be published by default. ``sharing.PUBLIC_FIELDS``
+    is the allowlist, and adding a field to the public view is a deliberate edit
+    to it.
+
+    On top of the field selection, every string that survives is passed through
+    :func:`~analyzer.sharing.redact_structure`. The fields here are *derived
+    from* the resume — ``skills_found`` is extracted from it, and a suggestion
+    can quote a phrase back — so "we did not serialise ``resume_text``" is not
+    on its own a guarantee that no contact detail is in the response.
+    """
+
+    #: Kept as a plain read-only field rather than the model's UUID, so the
+    #: response carries the string form the frontend puts in a URL.
+    share_id = serializers.CharField(read_only=True)
+
+    #: Present so a viewer can see the link will not last forever, which is the
+    #: reassurance that makes sharing reasonable in the first place.
+    expires_at = serializers.DateTimeField(source="share_expires_at", read_only=True)
+
+    class Meta:
+        model = ResumeAnalysis
+        fields = sharing.PUBLIC_FIELDS + ("expires_at",)
+        read_only_fields = fields
+
+    def to_representation(self, instance):
+        return sharing.redact_structure(super().to_representation(instance))
+
+
+class ShareStateSerializer(serializers.ModelSerializer):
+    """The owner's view of a link: is it on, until when, and how many opens.
+
+    Returned by the share-management endpoint so the UI never has to infer
+    state from a 200 or a 404. ``share_url`` is assembled here rather than in
+    the frontend because the public path is a backend routing detail, and the
+    frontend has already had that wrong once (#632).
+    """
+
+    is_live = serializers.SerializerMethodField()
+    share_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ResumeAnalysis
+        fields = (
+            "share_id",
+            "share_enabled",
+            "share_created_at",
+            "share_expires_at",
+            "share_view_count",
+            "is_live",
+            "share_url",
+        )
+        read_only_fields = fields
+
+    def get_is_live(self, obj) -> bool:
+        return obj.is_share_live()
+
+    def get_share_url(self, obj):
+        """Return the public URL, or ``None`` when there is nothing to link to.
+
+        ``None`` rather than a dead URL: a UI given a string will render it, and
+        a copyable link that 404s is worse than no link at all.
+        """
+        if not obj.is_share_live():
+            return None
+
+        base = getattr(settings, "FRONTEND_URL", "") or ""
+        return f"{base.rstrip('/')}/shared/{obj.share_id}"
+
 
 class VersionComparisonSerializer(serializers.Serializer):
     older_id = serializers.IntegerField()

--- a/backend/analyzer/sharing.py
+++ b/backend/analyzer/sharing.py
@@ -1,0 +1,223 @@
+"""Policy for public share links, and what is safe to put behind one.
+
+A shared analysis is the one place in this project where data leaves the
+account that owns it, so the rules live in one module rather than being spread
+across a serializer and a view.
+
+Two things are decided here.
+
+**What a link is allowed to carry.** The private record holds ``resume_text`` —
+the whole extracted document, home address and phone number included. The
+public view renders a score, a role and some skill lists. Those are very
+different payloads, and the difference is not something a reviewer should have
+to infer from a field tuple. :data:`PUBLIC_FIELDS` states it, and
+:func:`redact_contact_details` scrubs the strings that *are* published, because
+suggestions and skill lists are derived from the document and can echo parts of
+it back.
+
+**How long a link lives.** ``share_id`` has always been assigned at creation
+time, which made every analysis reachable before its owner asked for that and
+left no way to take it back. Sharing is now something a user turns on, with an
+expiry, and can rotate or revoke.
+"""
+
+import re
+
+#: Fields the public endpoint may return. Everything absent from this tuple is
+#: absent on purpose:
+#:
+#: - ``resume_text`` / ``cover_letter_text`` — the document itself.
+#: - ``cover_letter_feedback`` — quotes the letter back in its findings.
+#: - ``file_name`` — resumes are routinely saved as
+#:   ``Firstname_Lastname_Resume.pdf``, so the filename alone identifies the
+#:   owner.
+#: - ``id`` — the private primary key, which appears in authenticated URLs.
+PUBLIC_FIELDS = (
+    "share_id",
+    "score",
+    "target_role",
+    "experience_level",
+    "skills_found",
+    "matched_skills",
+    "partial_skills",
+    "missing_skills",
+    "suggestions",
+    "created_at",
+)
+
+#: Default life of a new link. Long enough to send in an application and have it
+#: opened at the other end, short enough that a forgotten link stops working.
+DEFAULT_SHARE_LIFETIME_DAYS = 30
+
+#: Ceiling on a caller-supplied lifetime. A link with no end is the state this
+#: issue is about, so "never expires" is not offered.
+MAX_SHARE_LIFETIME_DAYS = 365
+
+#: Floor, so a lifetime of 0 or a negative number is rejected rather than
+#: quietly producing a link that is already dead.
+MIN_SHARE_LIFETIME_DAYS = 1
+
+#: What a redacted span is replaced with. Kept visible rather than deleted: a
+#: user reading their own shared page should be able to see *that* something was
+#: removed, and a reviewer should be able to grep for it.
+REDACTION_MARKER = "[removed]"
+
+# --- Patterns -------------------------------------------------------------
+#
+# Redaction is regex work, so the patterns are gathered here with the reasoning
+# for each one, and the ordering decision is stated beside `_REDACTORS` below.
+
+
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w-]+(?:\.[\w-]+)+\b")
+
+#: International and North American shapes: an optional ``+`` and country code,
+#: then groups of digits broken up by spaces, dots, dashes or brackets. The
+#: pattern is deliberately loose and :func:`_looks_like_phone` does the
+#: rejecting — a regex tight enough to exclude every year range on its own is
+#: unreadable, and the interesting decisions belong somewhere they can be
+#: explained and tested.
+_PHONE_CANDIDATE_RE = re.compile(
+    r"(?<![\w.])"
+    r"(?P<intl>\+\d{1,3}[\s.-]?)?"
+    r"(?:\(\d{2,4}\)[\s.-]?)?"
+    r"\d{2,5}(?:[\s.-]\d{2,5}){1,4}"
+    r"(?![\w.])"
+)
+
+#: A number in this range, written as four digits, is a year far more often than
+#: it is part of a phone number.
+_PLAUSIBLE_YEAR = range(1900, 2101)
+
+
+def _looks_like_phone(match):
+    """Decide whether a digit run the loose pattern caught is really a number.
+
+    Resume text is full of digit groups that are not phone numbers, and the two
+    that actually collide with the pattern are date ranges (``2019-2022``) and
+    metric pairs (``12.5 / 30``). Both are common enough in *suggestions*, which
+    is text this module publishes, that getting them wrong would put
+    ``[removed]`` in the middle of a tip.
+
+    The rules, in order:
+
+    1. An explicit ``+`` country code or a bracketed area code settles it. No
+       date range is written that way.
+    2. Fewer than seven digits is not a dialable number anywhere.
+    3. Exactly two four-digit groups, both plausible years, is a year range.
+    """
+    text = match.group(0)
+    digits = re.sub(r"\D", "", text)
+
+    if match.group("intl") or "(" in text:
+        return True
+
+    if len(digits) < 7:
+        return False
+
+    groups = re.findall(r"\d+", text)
+    if len(groups) == 2 and all(len(g) == 4 for g in groups):
+        if all(int(g) in _PLAUSIBLE_YEAR for g in groups):
+            return False
+
+    return True
+
+
+def _redact_phones(text):
+    """Replace phone-shaped runs, leaving anything :func:`_looks_like_phone` rejects."""
+    return _PHONE_CANDIDATE_RE.sub(
+        lambda m: REDACTION_MARKER if _looks_like_phone(m) else m.group(0),
+        text,
+    )
+
+_URL_RE = re.compile(r"\bhttps?://\S+|\bwww\.[\w-]+(?:\.[\w-]+)+\S*", re.IGNORECASE)
+
+#: ``linkedin.com/in/jane-doe`` without a scheme, and the same for the handful
+#: of profile hosts that show up on nearly every resume.
+_PROFILE_RE = re.compile(
+    r"\b(?:linkedin\.com|github\.com|gitlab\.com|behance\.net|dribbble\.com)"
+    r"/[\w./-]+",
+    re.IGNORECASE,
+)
+
+#: ``@handle``. Bounded on the left so an email that survived the first pass is
+#: not turned into a handle match.
+_HANDLE_RE = re.compile(r"(?<![\w@.])@[A-Za-z][\w.]{2,29}\b")
+
+#: Applied in order. Emails go first because an address contains a
+#: dot-separated host the URL pattern would otherwise claim half of, and the
+#: phone pass runs late so it never sees the digits inside a URL.
+_REDACTORS = (_EMAIL_RE, _URL_RE, _PROFILE_RE, _HANDLE_RE)
+
+
+def redact_contact_details(value):
+    """Return ``value`` with contact details replaced by :data:`REDACTION_MARKER`.
+
+    Anything that is not a string is returned untouched, so this can be mapped
+    over a mixed structure without type checks at every call site.
+
+    This is a second line of defence, not the first. The first is
+    :data:`PUBLIC_FIELDS` — not publishing the document at all. This exists
+    because the fields that *are* published are generated from the document:
+    ``skills_found`` comes out of the resume text, and a suggestion string can
+    quote a phrase back. A false positive here costs a redaction marker in a
+    tip. A false negative costs a phone number.
+
+    >>> redact_contact_details("Reach me at jane@example.com or +1 415 555 0134")
+    'Reach me at [removed] or [removed]'
+    >>> redact_contact_details("Improved throughput by 40% across 3 services")
+    'Improved throughput by 40% across 3 services'
+    """
+    if not isinstance(value, str) or not value:
+        return value
+
+    redacted = value
+    for pattern in _REDACTORS:
+        redacted = pattern.sub(REDACTION_MARKER, redacted)
+    return _redact_phones(redacted)
+
+
+def redact_structure(value):
+    """Apply :func:`redact_contact_details` through lists, tuples and dicts.
+
+    ``partial_skills`` is a list of dicts and ``suggestions`` is a list of
+    strings, so a single helper that walks whatever shape it is handed keeps the
+    serializer from growing a branch per field.
+
+    Dictionary *keys* are left alone. They are field names we chose, not user
+    text, and rewriting one would change the shape of the response.
+    """
+    if isinstance(value, str):
+        return redact_contact_details(value)
+    if isinstance(value, list):
+        return [redact_structure(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_structure(item) for item in value)
+    if isinstance(value, dict):
+        return {key: redact_structure(item) for key, item in value.items()}
+    return value
+
+
+def clamp_lifetime_days(raw, default=DEFAULT_SHARE_LIFETIME_DAYS):
+    """Return a lifetime in days from caller input, held inside the allowed range.
+
+    Returns ``(days, was_clamped)``. The flag exists so the API can tell a
+    caller that asked for 10 years that it got one, instead of silently
+    disagreeing with the request it just acknowledged.
+
+    Junk — ``None``, a string, a float, a bool — falls back to ``default``
+    rather than erroring. This value only shortens a link's life; there is no
+    security decision resting on rejecting a malformed one.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        try:
+            days = int(str(raw).strip())
+        except (TypeError, ValueError, AttributeError):
+            return default, False
+    else:
+        days = raw
+
+    if days < MIN_SHARE_LIFETIME_DAYS:
+        return MIN_SHARE_LIFETIME_DAYS, True
+    if days > MAX_SHARE_LIFETIME_DAYS:
+        return MAX_SHARE_LIFETIME_DAYS, True
+    return days, False

--- a/backend/analyzer/tests_api_routes.py
+++ b/backend/analyzer/tests_api_routes.py
@@ -231,10 +231,17 @@ class SharedResultEndpointTests(TestCase):
         self.client = APIClient()
         self.user = User.objects.create_user(username="sharer", password="password123")
 
-    def _analysis(self):
+    def _analysis(self, shared=True):
+        """Create an analysis, published by default.
+
+        Sharing became opt-in in #705 — an analysis is no longer readable by id
+        just because it exists — so these routing tests, which are about the URL
+        resolving, have to publish first. The lifecycle itself is covered in
+        ``tests_share_privacy``.
+        """
         from analyzer.models import ResumeAnalysis
 
-        return ResumeAnalysis.objects.create(
+        analysis = ResumeAnalysis.objects.create(
             user=self.user,
             file_name="resume.pdf",
             score=72,
@@ -244,6 +251,9 @@ class SharedResultEndpointTests(TestCase):
             missing_skills=["docker"],
             target_role="Backend Developer",
         )
+        if shared:
+            analysis.enable_sharing(lifetime_days=30)
+        return analysis
 
     def test_a_share_link_resolves_and_returns_the_analysis(self):
         analysis = self._analysis()
@@ -258,6 +268,12 @@ class SharedResultEndpointTests(TestCase):
 
         resp = self.client.get(f"/api/shared/{analysis.share_id}/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_an_unshared_analysis_is_not_reachable_by_id(self):
+        analysis = self._analysis(shared=False)
+
+        resp = self.client.get(f"/api/shared/{analysis.share_id}/")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_an_unknown_share_id_is_a_404(self):
         resp = self.client.get("/api/shared/2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33/")

--- a/backend/analyzer/tests_share_privacy.py
+++ b/backend/analyzer/tests_share_privacy.py
@@ -1,0 +1,429 @@
+"""Tests for share-link privacy and lifecycle (#705).
+
+Three separable claims are made by the change, and they are tested separately
+because they can regress independently:
+
+* the *payload* is narrow — the resume text never leaves the account;
+* the *lifecycle* works — off by default, enable, rotate, revoke, expire;
+* the *responses do not leak* — a revoked id is indistinguishable from an
+  invented one.
+
+The redaction helpers get their own class, because that is unit-testable logic
+with a genuine false-positive risk (year ranges and metrics look like phone
+numbers) and it is easier to pin down here than through an HTTP round trip.
+"""
+
+import uuid
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from analyzer.models import ResumeAnalysis
+from analyzer.sharing import (
+    DEFAULT_SHARE_LIFETIME_DAYS,
+    MAX_SHARE_LIFETIME_DAYS,
+    MIN_SHARE_LIFETIME_DAYS,
+    PUBLIC_FIELDS,
+    REDACTION_MARKER,
+    clamp_lifetime_days,
+    redact_contact_details,
+    redact_structure,
+)
+
+#: A resume body with every kind of detail the public view must never carry.
+PRIVATE_RESUME_TEXT = (
+    "JANE DOE\n"
+    "42 Maple Street, Springfield\n"
+    "jane.doe@example.com | +1 415 555 0134\n"
+    "linkedin.com/in/jane-doe\n\n"
+    "EXPERIENCE\n"
+    "Senior Backend Engineer, Acme Corp\n"
+    "Built the billing pipeline in Python and Django.\n"
+)
+
+
+def make_analysis(user, **overrides):
+    defaults = dict(
+        file_name="Jane_Doe_Resume.pdf",
+        score=72,
+        skills_found=["python", "django"],
+        suggestions=["Add a project using React"],
+        matched_skills=["python"],
+        partial_skills=[],
+        missing_skills=["react"],
+        target_role="Backend Developer",
+        experience_level="Senior",
+        resume_text=PRIVATE_RESUME_TEXT,
+        cover_letter_text="Dear hiring team, reach me on jane.doe@example.com.",
+        cover_letter_feedback={"word_count": 9, "note": "Call +1 415 555 0134"},
+        interview_questions=["Explain the GIL."],
+    )
+    defaults.update(overrides)
+    return ResumeAnalysis.objects.create(user=user, **defaults)
+
+
+class SharePayloadTests(TestCase):
+    """What the public endpoint is allowed to return."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="jane", password="password123")
+        self.analysis = make_analysis(self.user)
+        self.analysis.enable_sharing(lifetime_days=DEFAULT_SHARE_LIFETIME_DAYS)
+        self.url = f"/api/shared/{self.analysis.share_id}/"
+
+    def test_resume_text_is_not_in_the_response(self):
+        """The bug, stated directly."""
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("resume_text", response.data)
+
+        body = response.content.decode()
+        self.assertNotIn("Maple Street", body)
+        self.assertNotIn("jane.doe@example.com", body)
+        self.assertNotIn("415 555 0134", body)
+
+    def test_cover_letter_is_not_in_the_response(self):
+        response = self.client.get(self.url)
+
+        self.assertNotIn("cover_letter_text", response.data)
+        self.assertNotIn("cover_letter_feedback", response.data)
+        self.assertNotIn("Dear hiring team", response.content.decode())
+
+    def test_filename_is_not_in_the_response(self):
+        """``Jane_Doe_Resume.pdf`` identifies the owner on its own."""
+        response = self.client.get(self.url)
+
+        self.assertNotIn("file_name", response.data)
+        self.assertNotIn("Jane_Doe", response.content.decode())
+
+    def test_private_primary_key_is_not_exposed(self):
+        response = self.client.get(self.url)
+
+        self.assertNotIn("id", response.data)
+
+    def test_response_keys_are_exactly_the_allowlist(self):
+        """A denylist would fail open as the model grows; assert the allowlist."""
+        response = self.client.get(self.url)
+
+        self.assertEqual(
+            set(response.data.keys()),
+            set(PUBLIC_FIELDS) | {"expires_at"},
+        )
+
+    def test_useful_fields_are_still_present(self):
+        """Narrowing the payload must not empty the page it feeds."""
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.data["score"], 72)
+        self.assertEqual(response.data["target_role"], "Backend Developer")
+        self.assertEqual(response.data["experience_level"], "Senior")
+        self.assertEqual(response.data["skills_found"], ["python", "django"])
+        self.assertEqual(response.data["missing_skills"], ["react"])
+
+    def test_expiry_is_advertised_to_the_viewer(self):
+        response = self.client.get(self.url)
+
+        self.assertIsNotNone(response.data["expires_at"])
+
+    def test_contact_details_inside_published_strings_are_redacted(self):
+        """Suggestions are generated from the document and can quote it back."""
+        self.analysis.suggestions = ["Email jane.doe@example.com to follow up"]
+        self.analysis.save(update_fields=["suggestions"])
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.data["suggestions"], [f"Email {REDACTION_MARKER} to follow up"])
+
+    def test_a_view_is_counted(self):
+        self.client.get(self.url)
+        self.client.get(self.url)
+
+        self.analysis.refresh_from_db()
+        self.assertEqual(self.analysis.share_view_count, 2)
+
+
+class ShareLifecycleTests(TestCase):
+    """Off by default, and revocable once on."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="owner", password="password123")
+        self.analysis = make_analysis(self.user)
+        self.public_url = f"/api/shared/{self.analysis.share_id}/"
+        self.manage_url = f"/api/history/{self.analysis.pk}/share/"
+
+    def test_a_new_analysis_is_not_shared(self):
+        """Sharing used to be implicit from the moment a row existed."""
+        self.assertFalse(self.analysis.share_enabled)
+        self.assertEqual(self.client.get(self.public_url).status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_owner_can_enable_sharing(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(self.manage_url, {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["is_live"])
+        self.assertIsNotNone(response.data["share_url"])
+        self.assertEqual(self.client.get(self.public_url).status_code, status.HTTP_200_OK)
+
+    def test_default_lifetime_is_applied(self):
+        self.client.force_authenticate(user=self.user)
+        before = timezone.now()
+
+        self.client.post(self.manage_url, {}, format="json")
+
+        self.analysis.refresh_from_db()
+        expected = before + timedelta(days=DEFAULT_SHARE_LIFETIME_DAYS)
+        self.assertAlmostEqual(
+            self.analysis.share_expires_at.timestamp(),
+            expected.timestamp(),
+            delta=10,
+        )
+
+    def test_owner_can_choose_a_shorter_lifetime(self):
+        self.client.force_authenticate(user=self.user)
+
+        self.client.post(self.manage_url, {"lifetime_days": 2}, format="json")
+
+        self.analysis.refresh_from_db()
+        self.assertLess(
+            self.analysis.share_expires_at,
+            timezone.now() + timedelta(days=3),
+        )
+
+    def test_an_over_long_lifetime_is_clamped_and_reported(self):
+        """Silently disagreeing with a request answered 200 is the failure here."""
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(self.manage_url, {"lifetime_days": 99999}, format="json")
+
+        self.assertEqual(response.data["lifetime_clamped_to_days"], MAX_SHARE_LIFETIME_DAYS)
+
+    def test_revoking_kills_the_link(self):
+        self.client.force_authenticate(user=self.user)
+        self.client.post(self.manage_url, {}, format="json")
+        self.assertEqual(self.client.get(self.public_url).status_code, status.HTTP_200_OK)
+
+        response = self.client.delete(self.manage_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["is_live"])
+        self.assertIsNone(response.data["share_url"])
+        self.assertEqual(self.client.get(self.public_url).status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_revoking_keeps_the_id_so_re_enabling_does_not_force_a_resend(self):
+        self.client.force_authenticate(user=self.user)
+        self.client.post(self.manage_url, {}, format="json")
+        original_id = self.analysis.share_id
+
+        self.client.delete(self.manage_url)
+        self.client.post(self.manage_url, {}, format="json")
+
+        self.analysis.refresh_from_db()
+        self.assertEqual(self.analysis.share_id, original_id)
+
+    def test_rotating_breaks_every_copy_of_the_old_link(self):
+        self.client.force_authenticate(user=self.user)
+        self.client.post(self.manage_url, {}, format="json")
+        old_url = f"/api/shared/{self.analysis.share_id}/"
+
+        self.client.post(self.manage_url, {"rotate": True}, format="json")
+
+        self.analysis.refresh_from_db()
+        new_url = f"/api/shared/{self.analysis.share_id}/"
+        self.assertNotEqual(old_url, new_url)
+        self.assertEqual(self.client.get(old_url).status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(self.client.get(new_url).status_code, status.HTTP_200_OK)
+
+    def test_rotating_resets_the_view_counter(self):
+        """The count answers "views of the link I sent", not an all-time total."""
+        self.client.force_authenticate(user=self.user)
+        self.client.post(self.manage_url, {}, format="json")
+        self.client.get(self.public_url)
+
+        self.client.post(self.manage_url, {"rotate": True}, format="json")
+
+        self.analysis.refresh_from_db()
+        self.assertEqual(self.analysis.share_view_count, 0)
+
+    def test_an_expired_link_stops_working_without_a_cleanup_job(self):
+        """Expiry is evaluated on read, so nothing depends on a cron having run."""
+        self.analysis.enable_sharing(lifetime_days=1)
+        self.analysis.share_expires_at = timezone.now() - timedelta(minutes=1)
+        self.analysis.save(update_fields=["share_expires_at"])
+
+        self.assertEqual(self.client.get(self.public_url).status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_enabled_with_no_expiry_is_treated_as_not_live(self):
+        """Belt and braces: the failure mode of trusting it is an immortal link."""
+        self.analysis.share_enabled = True
+        self.analysis.share_expires_at = None
+        self.analysis.save(update_fields=["share_enabled", "share_expires_at"])
+
+        self.assertFalse(self.analysis.is_share_live())
+        self.assertEqual(self.client.get(self.public_url).status_code, status.HTTP_404_NOT_FOUND)
+
+
+class ShareResponseLeakTests(TestCase):
+    """A response must not confirm which ids are real."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="alice", password="password123")
+        self.other = User.objects.create_user(username="bob", password="password123")
+        self.analysis = make_analysis(self.user)
+
+    def test_revoked_and_invented_ids_answer_identically(self):
+        self.analysis.enable_sharing(lifetime_days=7)
+        self.analysis.revoke_sharing()
+
+        revoked = self.client.get(f"/api/shared/{self.analysis.share_id}/")
+        invented = self.client.get(f"/api/shared/{uuid.uuid4()}/")
+
+        self.assertEqual(revoked.status_code, invented.status_code)
+        self.assertEqual(revoked.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_managing_someone_elses_analysis_is_a_404_not_a_403(self):
+        self.client.force_authenticate(user=self.other)
+
+        response = self.client.get(f"/api/history/{self.analysis.pk}/share/")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_another_user_cannot_enable_sharing_on_your_analysis(self):
+        self.client.force_authenticate(user=self.other)
+
+        response = self.client.post(f"/api/history/{self.analysis.pk}/share/", {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.analysis.refresh_from_db()
+        self.assertFalse(self.analysis.share_enabled)
+
+    def test_share_management_requires_authentication(self):
+        response = self.client.get(f"/api/history/{self.analysis.pk}/share/")
+
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
+
+    @override_settings(FRONTEND_URL="https://resume.example.com/")
+    def test_share_url_has_no_double_slash(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(f"/api/history/{self.analysis.pk}/share/", {}, format="json")
+
+        self.assertEqual(
+            response.data["share_url"],
+            f"https://resume.example.com/shared/{response.data['share_id']}",
+        )
+
+
+class RedactionTests(TestCase):
+    """The helpers, where the false-positive risk actually lives."""
+
+    def test_email_is_redacted(self):
+        self.assertEqual(
+            redact_contact_details("Write to jane.doe+jobs@example.co.uk today"),
+            f"Write to {REDACTION_MARKER} today",
+        )
+
+    def test_international_phone_is_redacted(self):
+        self.assertEqual(
+            redact_contact_details("Call +44 20 7946 0958"),
+            f"Call {REDACTION_MARKER}",
+        )
+
+    def test_bracketed_area_code_is_redacted(self):
+        self.assertEqual(
+            redact_contact_details("Call (415) 555-0134 any time"),
+            f"Call {REDACTION_MARKER} any time",
+        )
+
+    def test_profile_urls_are_redacted(self):
+        redacted = redact_contact_details("Portfolio: github.com/janedoe and www.jane.dev")
+
+        self.assertNotIn("janedoe", redacted)
+        self.assertNotIn("jane.dev", redacted)
+
+    def test_handles_are_redacted(self):
+        self.assertEqual(
+            redact_contact_details("Find me @janecodes"),
+            f"Find me {REDACTION_MARKER}",
+        )
+
+    def test_a_year_range_survives(self):
+        """The regression this class exists for: `2019-2022` is not a phone number."""
+        text = "Worked at Acme from 2019-2022 on the platform team"
+
+        self.assertEqual(redact_contact_details(text), text)
+
+    def test_metrics_survive(self):
+        for text in (
+            "Improved throughput by 40% across 3 services",
+            "Reduced p99 latency from 1200 ms to 340 ms",
+            "Owned a budget of 1.5 million over 2 years",
+            "Shipped 12 releases in 6 months",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(redact_contact_details(text), text)
+
+    def test_short_digit_runs_survive(self):
+        self.assertEqual(redact_contact_details("Team of 8-10 engineers"), "Team of 8-10 engineers")
+
+    def test_non_strings_pass_through_untouched(self):
+        self.assertEqual(redact_contact_details(None), None)
+        self.assertEqual(redact_contact_details(42), 42)
+
+    def test_structures_are_walked(self):
+        payload = {
+            "suggestions": ["Mail jane@example.com", "Add React"],
+            "partial_skills": [{"skill": "react", "matched_variant": "reactjs"}],
+            "score": 72,
+        }
+
+        redacted = redact_structure(payload)
+
+        self.assertEqual(redacted["suggestions"][0], f"Mail {REDACTION_MARKER}")
+        self.assertEqual(redacted["suggestions"][1], "Add React")
+        self.assertEqual(redacted["partial_skills"][0]["skill"], "react")
+        self.assertEqual(redacted["score"], 72)
+
+    def test_dictionary_keys_are_not_rewritten(self):
+        redacted = redact_structure({"contact@example.com": "value"})
+
+        self.assertIn("contact@example.com", redacted)
+
+
+class ClampLifetimeTests(TestCase):
+    def test_default_when_absent(self):
+        self.assertEqual(clamp_lifetime_days(None), (DEFAULT_SHARE_LIFETIME_DAYS, False))
+
+    def test_default_when_junk(self):
+        self.assertEqual(clamp_lifetime_days("not a number"), (DEFAULT_SHARE_LIFETIME_DAYS, False))
+        self.assertEqual(clamp_lifetime_days({"days": 3}), (DEFAULT_SHARE_LIFETIME_DAYS, False))
+
+    def test_a_valid_value_passes_through(self):
+        self.assertEqual(clamp_lifetime_days(7), (7, False))
+
+    def test_a_numeric_string_is_accepted(self):
+        self.assertEqual(clamp_lifetime_days("7"), (7, False))
+
+    def test_zero_and_negatives_are_raised_to_the_floor(self):
+        self.assertEqual(clamp_lifetime_days(0), (MIN_SHARE_LIFETIME_DAYS, True))
+        self.assertEqual(clamp_lifetime_days(-5), (MIN_SHARE_LIFETIME_DAYS, True))
+
+    def test_over_long_is_lowered_to_the_ceiling(self):
+        self.assertEqual(clamp_lifetime_days(10_000), (MAX_SHARE_LIFETIME_DAYS, True))
+
+    def test_booleans_are_not_treated_as_integers(self):
+        """``True`` is an ``int`` in Python; a one-day link from `{"lifetime_days": true}`
+        would be a surprising reading of that request."""
+        self.assertEqual(clamp_lifetime_days(True), (DEFAULT_SHARE_LIFETIME_DAYS, False))

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -15,6 +15,7 @@ from .views import (
     compare_versions_view,
     suggestion_feedback,
     get_shared_result,
+    manage_analysis_share,
     admin_stats_view,
     analyze_jd_view,
     user_profile_view,
@@ -57,6 +58,14 @@ urlpatterns = [
     path("history/", analysis_history),
     path("history/clear/", clear_user_history),
     path("history/<int:pk>/", history_detail),
+    # Owner-side control over the public link for one analysis: read its
+    # state, enable/extend/rotate it, or revoke it. Sharing used to be an
+    # implicit property of every row with no way to switch it off. See #705.
+    path(
+        "history/<int:pk>/share/",
+        manage_analysis_share,
+        name="manage_analysis_share",
+    ),
 
     # Webhooks. The views for these have existed since #549 but were never
     # given a path, so the feature has been unreachable.

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -36,7 +36,6 @@ from .request_input import (
 )
 
 from .comparison import compare_versions
-from .sharing import clamp_lifetime_days
 from .models import ResumeAnalysis, UserProfile, Webhook
 from .serializers import (
     SignupSerializer,
@@ -46,6 +45,7 @@ from .serializers import (
     VersionComparisonSerializer,
     UserProfileSerializer,
 )
+from .sharing import clamp_lifetime_days
 from .services import analyze_resume, extract_text_from_file
 from .tasks import analyze_resume_task
 from celery.result import AsyncResult
@@ -846,6 +846,14 @@ class SharedResultThrottle(AnonRateThrottle):
     """
 
     scope = "shared_result"
+
+    def get_rate(self):
+        # Read straight from settings rather than through
+        # DEFAULT_THROTTLE_RATES, following UploadRateThrottle above. It keeps
+        # the number beside the docstring that justifies it, and it means adding
+        # a throttle does not mean editing a dictionary every other throttle
+        # also edits.
+        return getattr(settings, "SHARED_RESULT_RATE", "60/hour")
 
 
 @extend_schema(

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -36,10 +36,13 @@ from .request_input import (
 )
 
 from .comparison import compare_versions
+from .sharing import clamp_lifetime_days
 from .models import ResumeAnalysis, UserProfile, Webhook
 from .serializers import (
     SignupSerializer,
     ResumeAnalysisSerializer,
+    PublicSharedAnalysisSerializer,
+    ShareStateSerializer,
     VersionComparisonSerializer,
     UserProfileSerializer,
 )
@@ -832,16 +835,106 @@ def suggestion_feedback(request):
         status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
     )
 
+class SharedResultThrottle(AnonRateThrottle):
+    """Rate limit for the public share endpoint.
+
+    Every other ``AllowAny`` view in this module carries one; this one did not,
+    which left a personal-data endpoint enumerable at whatever rate the network
+    allowed. UUID4 is a wide space, but the width of the id is not a reason to
+    leave the door unmetered — it is the reason a rate limit is cheap, because
+    no legitimate viewer opens hundreds of different shares an hour.
+    """
+
+    scope = "shared_result"
+
+
+@extend_schema(
+    summary="View a shared analysis",
+    description=(
+        "Returns the public view of an analysis that its owner has chosen to "
+        "share. The response never includes the resume text, the cover letter "
+        "or the original filename, and the fields it does return are stripped "
+        "of contact details. Answers 404 when the link is unknown, has been "
+        "revoked, or has expired — the three are not distinguished."
+    ),
+    responses={
+        200: PublicSharedAnalysisSerializer,
+        404: OpenApiResponse(description="No live share for this id."),
+    },
+)
 @api_view(["GET"])
 @permission_classes([AllowAny])
+@throttle_classes([SharedResultThrottle])
 def get_shared_result(request, share_id):
-    """
-    Fetch a specific ResumeAnalysis by its unguessable share_id,
-    without requiring authentication.
+    """Return the public view of a shared analysis.
+
+    Three things changed here, and they are independent:
+
+    1. The payload comes from :class:`PublicSharedAnalysisSerializer`, not the
+       full record. It used to include ``resume_text`` — the entire extracted
+       document — for a page that renders a score and a skill list.
+    2. Holding the id is no longer enough. ``is_share_live`` asks whether the
+       owner turned sharing on and whether the link has expired.
+    3. Revoked, expired and never-existed all answer 404. A 403 for a revoked
+       link would confirm the id was real, which is exactly what someone walking
+       the id space is trying to learn.
     """
     analysis = get_object_or_404(ResumeAnalysis, share_id=share_id)
-    serializer = ResumeAnalysisSerializer(analysis)
-    return Response(serializer.data)
+
+    if not analysis.is_share_live():
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    analysis.register_share_view()
+    return Response(PublicSharedAnalysisSerializer(analysis).data)
+
+
+@extend_schema(
+    summary="Read or change an analysis's share link",
+    description=(
+        "``GET`` reports the current state. ``POST`` turns sharing on, or "
+        "extends it, with an optional ``lifetime_days`` (1–365, default 30) "
+        "and an optional ``rotate`` flag that issues a fresh id and breaks "
+        "every copy of the previous link. ``DELETE`` revokes."
+    ),
+    responses={
+        200: ShareStateSerializer,
+        404: OpenApiResponse(description="No such analysis for this user."),
+    },
+)
+@api_view(["GET", "POST", "DELETE"])
+@permission_classes([IsAuthenticated])
+def manage_analysis_share(request, pk):
+    """Owner-side control over one analysis's public link.
+
+    Scoped by ``user=request.user`` in the lookup rather than fetched and then
+    checked, so there is no path through this view where the wrong user's row is
+    loaded at all. A row belonging to someone else is a 404, the same answer as
+    a row that does not exist.
+    """
+    try:
+        analysis = ResumeAnalysis.objects.get(pk=pk, user=request.user)
+    except ResumeAnalysis.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == "GET":
+        return Response(ShareStateSerializer(analysis).data)
+
+    if request.method == "DELETE":
+        analysis.revoke_sharing()
+        return Response(ShareStateSerializer(analysis).data)
+
+    lifetime_days, was_clamped = clamp_lifetime_days(request.data.get("lifetime_days"))
+    rotate = request.data.get("rotate") is True
+
+    analysis.enable_sharing(lifetime_days=lifetime_days, rotate=rotate)
+
+    payload = ShareStateSerializer(analysis).data
+    if was_clamped:
+        # Say so rather than silently disagreeing with the request that was just
+        # acknowledged with a 200. A client that asked for ten years and is told
+        # nothing has no way to know its link dies in one.
+        payload["lifetime_clamped_to_days"] = lifetime_days
+    return Response(payload)
 
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -214,6 +214,9 @@ REST_FRAMEWORK = {
         'analyze_jd': os.environ.get('ANALYZE_JD_RATE', '30/hour'),
         'mock_interview': os.environ.get('MOCK_INTERVIEW_RATE', '30/hour'),
         'signup': os.environ.get('SIGNUP_RATE', '10/hour'),
+        # The public share endpoint. Generous for a human opening links
+        # people send them, and far below what walking the id space needs.
+        'shared_result': os.environ.get('SHARED_RESULT_RATE', '60/hour'),
     },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -214,9 +214,6 @@ REST_FRAMEWORK = {
         'analyze_jd': os.environ.get('ANALYZE_JD_RATE', '30/hour'),
         'mock_interview': os.environ.get('MOCK_INTERVIEW_RATE', '30/hour'),
         'signup': os.environ.get('SIGNUP_RATE', '10/hour'),
-        # The public share endpoint. Generous for a human opening links
-        # people send them, and far below what walking the id space needs.
-        'shared_result': os.environ.get('SHARED_RESULT_RATE', '60/hour'),
     },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }

--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -1,0 +1,111 @@
+# Share links
+
+A share link publishes a **read-only summary** of one analysis at a public URL.
+Anyone holding the link can open it; nobody needs an account.
+
+Sharing is off until you turn it on, every link has an end date, and you can
+revoke or rotate one at any time.
+
+## What is behind the link
+
+| Published | Not published |
+| --- | --- |
+| Score | The resume text |
+| Target role and experience level | The cover letter, and its feedback |
+| Skills found, matched, partial, missing | The original filename |
+| Suggestions | The job description |
+| When the analysis ran, and when the link expires | The analysis's private id |
+
+The filename is on the right-hand column deliberately. Resumes are routinely
+saved as `Firstname_Lastname_Resume.pdf`, so publishing it would name the owner
+on a page whose whole point is that it does not.
+
+Everything in the left-hand column is *derived from* the resume — skills are
+extracted from it, and a suggestion can quote a phrase back — so the strings
+that are published are also stripped of email addresses, phone numbers, profile
+URLs and social handles before they go out. A removed span is replaced with
+`[removed]` rather than deleted, so you can see that something was taken out.
+
+## Turning it on
+
+```http
+POST /api/history/12/share/
+Authorization: Bearer <access token>
+Content-Type: application/json
+
+{ "lifetime_days": 7 }
+```
+
+```json
+{
+  "share_id": "2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33",
+  "share_enabled": true,
+  "share_created_at": "2026-08-20T09:00:00Z",
+  "share_expires_at": "2026-08-27T09:00:00Z",
+  "share_view_count": 0,
+  "is_live": true,
+  "share_url": "https://resume.example.com/shared/2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33"
+}
+```
+
+`lifetime_days` is optional and defaults to **30**. It is held between 1 and
+365 — there is no "never expires". If you ask for more than the maximum you get
+the maximum, and the response says so in `lifetime_clamped_to_days` rather than
+quietly disagreeing with the request it just accepted.
+
+Posting again while a link is already live **extends** it from now. The id does
+not change, so copies of the link that are already out keep working.
+
+## Rotating
+
+```http
+POST /api/history/12/share/
+{ "rotate": true }
+```
+
+Issues a fresh `share_id`. Every copy of the previous link stops working
+immediately — this is the "I sent it to the wrong person" button. The view
+counter resets, so the number keeps answering *"views of the link I sent"*
+rather than an all-time total.
+
+## Revoking
+
+```http
+DELETE /api/history/12/share/
+```
+
+The link stops working. The id is kept, so re-enabling later does not force you
+to re-send a link you have already distributed; use `rotate` when you do want a
+clean break.
+
+## Reading the state
+
+```http
+GET /api/history/12/share/
+```
+
+Same body as above. `share_url` is `null` whenever the link is not live, so
+there is never a dead URL to copy.
+
+## The public endpoint
+
+```http
+GET /api/shared/<share_id>/
+```
+
+No authentication. Rate limited (`SHARED_RESULT_RATE`, default `60/hour`).
+
+**Unknown, revoked and expired all answer `404`.** They are not distinguished:
+a `403` for a revoked link would confirm the id was real, which is exactly what
+someone walking the id space is trying to learn.
+
+Expiry is evaluated when the link is read, not by a cleanup job, so a revocation
+never depends on a cron having run.
+
+## Existing links
+
+Before this existed, every analysis was readable by id from the moment it was
+created — there was no switch to turn off. Analyses that predate the change were
+migrated to *enabled*, with the standard 30-day expiry measured from the
+deployment, so links already in circulation keep working today and then fall
+under the same rules as everything else.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { Footer } from './Footer'
 import PrivacyPolicyPage from './pages/PrivacyPolicyPage'
 import { InterviewQuestionsPanel } from './components/InterviewQuestionsPanel'
 import { ScoreBreakdown, type ScoreBreakdownData } from './components/ScoreBreakdown'
+import { ShareResult } from './components/ShareResult'
 
 type Theme = 'light' | 'dark'
 
@@ -802,6 +803,15 @@ function App() {
               <ScoreBreakdown breakdown={scoreBreakdown} />
 
               <ResumePreview text={resumeText} skills={skills} />
+
+              {/*
+                Share controls. Previously there was no way to publish or
+                unpublish an analysis from the UI at all — the link simply
+                existed for every saved analysis (#705). `analysisId` is null
+                for anonymous runs and for the bundled sample, and the component
+                renders nothing in that case.
+              */}
+              <ShareResult analysisId={analysisId} />
 
               <h5 className="analysis-done" role="status" aria-live="polite">
                 ✅ Resume Analysis Complete

--- a/frontend/src/SharedResultView.test.tsx
+++ b/frontend/src/SharedResultView.test.tsx
@@ -27,11 +27,20 @@ vi.mock('axios', () => {
 
 const SHARE_ID = '2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33'
 
+// The shape `PublicSharedAnalysisSerializer` returns. `file_name` is absent
+// on purpose — see the payload assertions below.
 const SHARED_RESULT = {
+  share_id: SHARE_ID,
   score: 72,
-  file_name: 'resume.pdf',
+  target_role: 'Backend Developer',
+  experience_level: 'Senior',
   skills_found: ['python', 'django'],
+  matched_skills: ['python'],
+  partial_skills: [],
+  missing_skills: ['docker'],
   suggestions: ['Add projects or experience with Docker'],
+  created_at: '2026-08-01T10:00:00Z',
+  expires_at: '2026-09-01T10:00:00Z',
 }
 
 function renderAt(shareId = SHARE_ID) {
@@ -70,7 +79,27 @@ describe('SharedResultView (#632)', () => {
 
     renderAt()
 
-    expect(await screen.findByText('resume.pdf')).toBeInTheDocument()
+    expect(await screen.findByText(/Backend Developer/)).toBeInTheDocument()
+    expect(screen.getByText('python')).toBeInTheDocument()
+  })
+
+  it('labels the score with the role and level rather than the filename (#705)', async () => {
+    // `Firstname_Lastname_Resume.pdf` identifies the owner, so the public
+    // payload no longer carries a filename and this view no longer asks for one.
+    vi.mocked(axios.get).mockResolvedValue({ data: SHARED_RESULT })
+
+    renderAt()
+
+    expect(await screen.findByText(/Backend Developer • Senior/)).toBeInTheDocument()
+    expect(screen.queryByText(/\.pdf/)).not.toBeInTheDocument()
+  })
+
+  it('tells the viewer the link expires (#705)', async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: SHARED_RESULT })
+
+    renderAt()
+
+    expect(await screen.findByText(/This link expires in/)).toBeInTheDocument()
   })
 
   it('shows the not-found state when the share does not exist', async () => {
@@ -81,5 +110,15 @@ describe('SharedResultView (#632)', () => {
     renderAt()
 
     expect(await screen.findByText('Result Not Found')).toBeInTheDocument()
+  })
+
+  it('does not claim the link never existed, since revoked and unknown look the same (#705)', async () => {
+    // The backend answers 404 for revoked, expired and never-existed alike, so
+    // the copy has to be true of all three.
+    vi.mocked(axios.get).mockRejectedValue({ response: { data: {} } })
+
+    renderAt()
+
+    expect(await screen.findByText(/may have expired/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/SharedResultView.tsx
+++ b/frontend/src/SharedResultView.tsx
@@ -3,16 +3,28 @@ import { useParams, Link } from 'react-router-dom'
 import axios from 'axios'
 import { AtsScore } from './AtsScore'
 import { CheckCircle, Info, Loader2 } from 'lucide-react'
+import { formatExpiry } from './utils/shareLink'
 
 const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
 
 export const SharedResultView: React.FC = () => {
   const { shareId } = useParams<{ shareId: string }>()
+  /**
+   * Mirrors `PublicSharedAnalysisSerializer`.
+   *
+   * `file_name` used to be read from here and rendered under the score. It is
+   * no longer sent — a resume saved as `Firstname_Lastname_Resume.pdf` names its
+   * owner, which is not something a "share your score" link should do (#705).
+   * The role and level took its place: they say what the score is *of*, which
+   * is what the line was there for.
+   */
   interface SharedData {
     score: number
-    file_name: string
+    target_role: string
+    experience_level: string
     skills_found: string[]
     suggestions: string[]
+    expires_at: string | null
   }
   const [data, setData] = useState<SharedData | null>(null)
   const [error, setError] = useState('')
@@ -29,8 +41,12 @@ export const SharedResultView: React.FC = () => {
         setData(res.data)
       } catch (err: unknown) {
         const axiosErr = err as { response?: { data?: { detail?: string } } }
+        // A revoked, expired and never-existed link all answer 404, and the
+        // copy has to work for all three — the backend deliberately does not
+        // say which, so this must not claim the link never existed.
         setError(
-          axiosErr.response?.data?.detail || 'Failed to load shared result or it does not exist.'
+          axiosErr.response?.data?.detail ||
+            'This link is not available. It may have expired, or the owner may have stopped sharing it.'
         )
       } finally {
         setLoading(false)
@@ -67,7 +83,9 @@ export const SharedResultView: React.FC = () => {
           <Info size={15} /> Read-Only View
         </span>
         <span style={{ fontWeight: 'normal', fontSize: '13px', display: 'block' }}>
-          This is a shared, read-only view of a resume analysis result.
+          This is a shared, read-only view of a resume analysis result. It does not include the
+          resume itself.
+          {data.expires_at ? ` This link ${formatExpiry(data.expires_at)}.` : ''}
         </span>
       </div>
 
@@ -78,7 +96,10 @@ export const SharedResultView: React.FC = () => {
       <h5 className="analysis-done mt-3">
         <CheckCircle size={18} /> Resume Analysis Complete
       </h5>
-      <p style={{ fontSize: '13px', opacity: 0.7, marginTop: '-8px' }}>{data.file_name}</p>
+      <p style={{ fontSize: '13px', opacity: 0.7, marginTop: '-8px' }}>
+        {data.target_role}
+        {data.experience_level ? ` • ${data.experience_level}` : ''}
+      </p>
 
       {/* Render skills and suggestions */}
       <div style={{ marginTop: '20px' }}>

--- a/frontend/src/components/ShareResult.css
+++ b/frontend/src/components/ShareResult.css
@@ -56,3 +56,85 @@
   color: var(--text-tertiary, #9ca3af);
   margin: 0;
 }
+
+.share-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 10px;
+  font-size: 0.78rem;
+  color: var(--text-tertiary, #9ca3af);
+}
+
+.share-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.share-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.share-lifetime-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary, #4b5563);
+  margin: 0;
+}
+
+.share-lifetime-select {
+  padding: 8px 10px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 6px;
+  background: var(--bg-main, #f9fafb);
+  color: var(--text-primary, #111827);
+  font-size: 0.9rem;
+}
+
+.share-secondary-btn,
+.share-danger-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 500;
+  transition:
+    opacity 0.2s,
+    border-color 0.2s;
+}
+
+.share-secondary-btn {
+  color: var(--text-secondary, #4b5563);
+}
+
+.share-danger-btn {
+  color: var(--danger-color, #b91c1c);
+  border-color: var(--danger-color, #b91c1c);
+}
+
+.share-secondary-btn:hover:not(:disabled),
+.share-danger-btn:hover:not(:disabled) {
+  opacity: 0.8;
+}
+
+.share-copy-btn:disabled,
+.share-secondary-btn:disabled,
+.share-danger-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.share-error-text {
+  font-size: 0.8rem;
+  color: var(--danger-color, #b91c1c);
+  margin: 8px 0 0;
+}

--- a/frontend/src/components/ShareResult.test.tsx
+++ b/frontend/src/components/ShareResult.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ShareResult } from './ShareResult'
+import { formatExpiry, type ShareState } from '../utils/shareLink'
+import { api } from '../api/client'
+
+vi.mock('../api/client', () => ({
+  api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+  BACKEND_URL: 'http://127.0.0.1:8000',
+}))
+
+const IN_A_MONTH = new Date(Date.now() + 30 * 86_400_000).toISOString()
+
+function state(overrides: Partial<ShareState> = {}): ShareState {
+  return {
+    share_id: '2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33',
+    share_enabled: false,
+    share_created_at: null,
+    share_expires_at: null,
+    share_view_count: 0,
+    is_live: false,
+    share_url: null,
+    ...overrides,
+  }
+}
+
+const LIVE = state({
+  share_enabled: true,
+  share_created_at: new Date().toISOString(),
+  share_expires_at: IN_A_MONTH,
+  share_view_count: 4,
+  is_live: true,
+  share_url: 'https://resume.example.com/shared/2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33',
+})
+
+describe('ShareResult (#705)', () => {
+  beforeEach(() => {
+    vi.mocked(api.get).mockResolvedValue({ data: state() })
+    // jsdom defines `navigator.clipboard` as a getter-only property, so it has
+    // to be redefined rather than assigned.
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn() },
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.mocked(api.get).mockReset()
+    vi.mocked(api.post).mockReset()
+    vi.mocked(api.delete).mockReset()
+  })
+
+  it('renders nothing without a saved analysis', () => {
+    const { container } = render(<ShareResult analysisId={null} />)
+
+    expect(container).toBeEmptyDOMElement()
+    expect(api.get).not.toHaveBeenCalled()
+  })
+
+  it('reads share state from the server rather than assuming it', async () => {
+    render(<ShareResult analysisId={12} />)
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/api/history/12/share/'))
+  })
+
+  it('offers to create a link when the analysis is private', async () => {
+    render(<ShareResult analysisId={12} />)
+
+    expect(await screen.findByRole('button', { name: /create link/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /copy link/i })).not.toBeInTheDocument()
+  })
+
+  it('shows no copyable URL before sharing is turned on', async () => {
+    // The old component built a link in the browser and showed it immediately,
+    // which is the behaviour this issue is about.
+    render(<ShareResult analysisId={12} />)
+
+    await screen.findByRole('button', { name: /create link/i })
+    expect(screen.queryByLabelText(/public link/i)).not.toBeInTheDocument()
+  })
+
+  it('creates a link with the chosen lifetime', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.post).mockResolvedValue({ data: LIVE })
+    render(<ShareResult analysisId={12} />)
+
+    await user.selectOptions(await screen.findByLabelText(/link lasts/i), '7')
+    await user.click(screen.getByRole('button', { name: /create link/i }))
+
+    expect(api.post).toHaveBeenCalledWith('/api/history/12/share/', { lifetime_days: 7 })
+  })
+
+  it('shows the URL the server returned, not one built locally', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.post).mockResolvedValue({ data: LIVE })
+    render(<ShareResult analysisId={12} />)
+
+    await user.click(await screen.findByRole('button', { name: /create link/i }))
+
+    expect(await screen.findByDisplayValue(LIVE.share_url as string)).toBeInTheDocument()
+  })
+
+  it('reports the expiry and the view count', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: LIVE })
+    render(<ShareResult analysisId={12} />)
+
+    expect(await screen.findByText(/expires in 30 days/)).toBeInTheDocument()
+    expect(screen.getByText(/4 views/)).toBeInTheDocument()
+  })
+
+  it('revokes through the API and drops back to the private state', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.get).mockResolvedValue({ data: LIVE })
+    vi.mocked(api.delete).mockResolvedValue({ data: state() })
+    render(<ShareResult analysisId={12} />)
+
+    await user.click(await screen.findByRole('button', { name: /stop sharing/i }))
+
+    expect(api.delete).toHaveBeenCalledWith('/api/history/12/share/')
+    expect(await screen.findByRole('button', { name: /create link/i })).toBeInTheDocument()
+  })
+
+  it('rotates to a fresh id on request', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.get).mockResolvedValue({ data: LIVE })
+    vi.mocked(api.post).mockResolvedValue({ data: LIVE })
+    render(<ShareResult analysisId={12} />)
+
+    await user.click(await screen.findByRole('button', { name: /new link/i }))
+
+    expect(api.post).toHaveBeenCalledWith('/api/history/12/share/', {
+      lifetime_days: 30,
+      rotate: true,
+    })
+  })
+
+  it('copies the server-issued URL', async () => {
+    const user = userEvent.setup()
+    // `userEvent.setup()` installs its own clipboard stub, so the spy has to go
+    // in after it rather than in `beforeEach`.
+    const writeText = vi.fn()
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+    vi.mocked(api.get).mockResolvedValue({ data: LIVE })
+    render(<ShareResult analysisId={12} />)
+
+    await user.click(await screen.findByRole('button', { name: /copy link/i }))
+
+    expect(writeText).toHaveBeenCalledWith(LIVE.share_url)
+  })
+
+  it('says so when the server shortened the requested lifetime', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.post).mockResolvedValue({
+      data: { ...LIVE, lifetime_clamped_to_days: 365 },
+    })
+    render(<ShareResult analysisId={12} />)
+
+    await user.click(await screen.findByRole('button', { name: /create link/i }))
+
+    expect(await screen.findByText(/at most 365 days/)).toBeInTheDocument()
+  })
+
+  it('reports a failed request instead of showing a state that was never saved', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.post).mockRejectedValue(new Error('offline'))
+    render(<ShareResult analysisId={12} />)
+
+    await user.click(await screen.findByRole('button', { name: /create link/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Nothing was changed/)
+    expect(screen.getByRole('button', { name: /create link/i })).toBeInTheDocument()
+  })
+
+  it('promises the reader that the resume text is not published', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: LIVE })
+    render(<ShareResult analysisId={12} />)
+
+    expect(await screen.findByText(/never includes your resume text/i)).toBeInTheDocument()
+  })
+})
+
+describe('formatExpiry', () => {
+  it('counts down in hours under a day', () => {
+    expect(formatExpiry(new Date(Date.now() + 5 * 3_600_000).toISOString())).toBe(
+      'expires in 5 hours'
+    )
+  })
+
+  it('singularises one hour', () => {
+    expect(formatExpiry(new Date(Date.now() + 3_600_000).toISOString())).toBe('expires in 1 hour')
+  })
+
+  it('counts down in days beyond a day', () => {
+    expect(formatExpiry(new Date(Date.now() + 3 * 86_400_000).toISOString())).toBe(
+      'expires in 3 days'
+    )
+  })
+
+  it('reports an elapsed date as expired rather than a negative countdown', () => {
+    expect(formatExpiry(new Date(Date.now() - 60_000).toISOString())).toBe('expired')
+  })
+
+  it('returns an empty string for null and for junk', () => {
+    expect(formatExpiry(null)).toBe('')
+    expect(formatExpiry('not a date')).toBe('')
+  })
+})

--- a/frontend/src/components/ShareResult.tsx
+++ b/frontend/src/components/ShareResult.tsx
@@ -1,38 +1,205 @@
-import React, { useState } from 'react'
-import { Share2, Check, Copy } from 'lucide-react'
+import React, { useCallback, useEffect, useState } from 'react'
+import { Share2, Check, Copy, Link2Off, RefreshCw, ShieldCheck, Eye } from 'lucide-react'
+import { api } from '../api/client'
+import {
+  DEFAULT_LIFETIME_DAYS,
+  LIFETIME_CHOICES,
+  formatExpiry,
+  type ShareState,
+} from '../utils/shareLink'
 import './ShareResult.css'
 
+/**
+ * Controls for publishing one analysis behind a public link.
+ *
+ * This component used to render a link unconditionally, built in the browser
+ * from a `share_id` the backend assigned to every analysis at creation. That
+ * link already worked before it was shown, and there was nothing here — or
+ * anywhere else — that could turn it off again (#705).
+ *
+ * Sharing is now server-side state, so the component reads it rather than
+ * assuming it: `GET` on mount, and every button is a request whose response is
+ * the new state. Nothing is inferred locally from "the request returned 200",
+ * because the server also decides the expiry and can clamp a requested one.
+ */
+
 interface ShareResultProps {
-  shareId: string
+  /** Primary key of the analysis. Null while no saved analysis is on screen. */
+  analysisId: number | null
 }
 
-export const ShareResult: React.FC<ShareResultProps> = ({ shareId }) => {
-  const [copied, setCopied] = useState(false)
+/**
+ * What has been loaded, and which analysis it was loaded for.
+ *
+ * Kept as one object so switching analyses cannot render the previous one's
+ * link against the new id — the alternative, clearing state in an effect, is a
+ * cascading render for something that is really a derived value.
+ */
+interface Loaded {
+  forId: number
+  data: ShareState
+}
 
-  const shareUrl = `${window.location.origin}/shared/${shareId}`
+export const ShareResult: React.FC<ShareResultProps> = ({ analysisId }) => {
+  const [loaded, setLoaded] = useState<Loaded | null>(null)
+  const [lifetimeDays, setLifetimeDays] = useState(DEFAULT_LIFETIME_DAYS)
+  const [busy, setBusy] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState('')
+
+  const endpoint = analysisId === null ? null : `/api/history/${analysisId}/share/`
+
+  useEffect(() => {
+    if (analysisId === null || !endpoint) return
+
+    // Guards against a stale response overwriting a newer one when the user
+    // switches analyses faster than the requests come back.
+    let current = true
+
+    api
+      .get<ShareState>(endpoint)
+      .then((res) => {
+        if (current) setLoaded({ forId: analysisId, data: res.data })
+      })
+      .catch(() => {
+        // Leave whatever is on screen alone. The share state is not worth an
+        // error banner over the analysis the user actually came to read.
+      })
+
+    return () => {
+      current = false
+    }
+  }, [analysisId, endpoint])
+
+  const run = useCallback(
+    async (request: () => Promise<{ data: ShareState }>) => {
+      if (analysisId === null) return
+      setBusy(true)
+      setError('')
+      try {
+        const res = await request()
+        setLoaded({ forId: analysisId, data: res.data })
+      } catch {
+        setError('Could not reach the server. Nothing was changed.')
+      } finally {
+        setBusy(false)
+      }
+    },
+    [analysisId]
+  )
+
+  // `forId` is checked rather than trusted: a response for the previous
+  // analysis must not be rendered against the current one.
+  const state = loaded && loaded.forId === analysisId ? loaded.data : null
+
+  const handleEnable = () =>
+    endpoint && run(() => api.post<ShareState>(endpoint, { lifetime_days: lifetimeDays }))
+
+  const handleRotate = () =>
+    endpoint &&
+    run(() => api.post<ShareState>(endpoint, { lifetime_days: lifetimeDays, rotate: true }))
+
+  const handleRevoke = () => endpoint && run(() => api.delete<ShareState>(endpoint))
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(shareUrl)
+    if (!state?.share_url) return
+    navigator.clipboard?.writeText(state.share_url)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }
+
+  if (analysisId === null || !state) return null
 
   return (
     <div className="share-result-container mt-4">
       <div className="share-header">
         <Share2 size={16} />
-        <span>Share Analysis Result</span>
+        <span>Share this analysis</span>
       </div>
-      <div className="share-input-group">
-        <input type="text" value={shareUrl} readOnly className="share-url-input" />
-        <button className="share-copy-btn" onClick={handleCopy}>
-          {copied ? <Check size={14} /> : <Copy size={14} />}
-          {copied ? 'Copied' : 'Copy Link'}
-        </button>
-      </div>
-      <p className="share-help-text">
-        Anyone with this link can view a read-only version of this specific analysis.
-      </p>
+
+      {state.is_live && state.share_url ? (
+        <>
+          <div className="share-input-group">
+            <input
+              type="text"
+              value={state.share_url}
+              readOnly
+              className="share-url-input"
+              aria-label="Public link to this analysis"
+            />
+            <button className="share-copy-btn" onClick={handleCopy} disabled={busy}>
+              {copied ? <Check size={14} /> : <Copy size={14} />}
+              {copied ? 'Copied' : 'Copy Link'}
+            </button>
+          </div>
+
+          <div className="share-meta">
+            <span className="share-meta-item">
+              <ShieldCheck size={13} /> {formatExpiry(state.share_expires_at)}
+            </span>
+            <span className="share-meta-item">
+              <Eye size={13} /> {state.share_view_count}{' '}
+              {state.share_view_count === 1 ? 'view' : 'views'}
+            </span>
+          </div>
+
+          <div className="share-actions">
+            <button className="share-secondary-btn" onClick={handleRotate} disabled={busy}>
+              <RefreshCw size={13} /> New link
+            </button>
+            <button className="share-danger-btn" onClick={handleRevoke} disabled={busy}>
+              <Link2Off size={13} /> Stop sharing
+            </button>
+          </div>
+
+          <p className="share-help-text">
+            The page behind this link shows your score, target role and skill lists. It never
+            includes your resume text, your cover letter or the original filename.
+            <strong> New link</strong> stops every copy of the current one from working.
+          </p>
+        </>
+      ) : (
+        <>
+          <div className="share-actions">
+            <label className="share-lifetime-label" htmlFor="share-lifetime">
+              Link lasts
+            </label>
+            <select
+              id="share-lifetime"
+              className="share-lifetime-select"
+              value={lifetimeDays}
+              onChange={(event) => setLifetimeDays(Number(event.target.value))}
+              disabled={busy}
+            >
+              {LIFETIME_CHOICES.map((choice) => (
+                <option key={choice.days} value={choice.days}>
+                  {choice.label}
+                </option>
+              ))}
+            </select>
+            <button className="share-copy-btn" onClick={handleEnable} disabled={busy}>
+              <Share2 size={14} /> Create link
+            </button>
+          </div>
+
+          <p className="share-help-text">
+            This analysis is private. Creating a link publishes a read-only page with your score and
+            skill lists — never your resume text — and you can stop sharing at any time.
+          </p>
+        </>
+      )}
+
+      {state.lifetime_clamped_to_days !== undefined && (
+        <p className="share-help-text" role="status">
+          Links can last at most {state.lifetime_clamped_to_days} days, so that is what was set.
+        </p>
+      )}
+
+      {error && (
+        <p className="share-error-text" role="alert">
+          {error}
+        </p>
+      )}
     </div>
   )
 }

--- a/frontend/src/utils/shareLink.ts
+++ b/frontend/src/utils/shareLink.ts
@@ -1,0 +1,59 @@
+/**
+ * Share-link types and formatting, kept out of the component that renders them.
+ *
+ * `ShareResult.tsx` is a component module, and exporting helpers alongside a
+ * component breaks React Fast Refresh — the whole module reloads instead of the
+ * component's state surviving. Splitting also means the countdown can be tested
+ * as the pure function it is.
+ */
+
+/** Mirrors `ShareStateSerializer` on the backend. */
+export interface ShareState {
+  share_id: string
+  share_enabled: boolean
+  share_created_at: string | null
+  share_expires_at: string | null
+  share_view_count: number
+  is_live: boolean
+  /** Null whenever the link is not live, so there is never a dead URL to copy. */
+  share_url: string | null
+  /** Only present when the server shortened a requested lifetime. */
+  lifetime_clamped_to_days?: number
+}
+
+/** Offered lifetimes. 30 days matches the backend's own default. */
+export const LIFETIME_CHOICES = [
+  { days: 1, label: '24 hours' },
+  { days: 7, label: '7 days' },
+  { days: 30, label: '30 days' },
+  { days: 90, label: '90 days' },
+]
+
+export const DEFAULT_LIFETIME_DAYS = 30
+
+/**
+ * Render an expiry timestamp as a countdown.
+ *
+ * Returns `''` for a missing or unparseable date so a caller can concatenate the
+ * result without a guard, and `'expired'` rather than a negative number for a
+ * date that has already passed — the link is still *enabled* at that point, and
+ * the server evaluates expiry on read, so this state is reachable in a page that
+ * has been open for a while.
+ */
+export function formatExpiry(iso: string | null): string {
+  if (!iso) return ''
+
+  const expires = new Date(iso)
+  if (Number.isNaN(expires.getTime())) return ''
+
+  const msLeft = expires.getTime() - Date.now()
+  if (msLeft <= 0) return 'expired'
+
+  const hoursLeft = Math.round(msLeft / 3_600_000)
+  if (hoursLeft < 24) {
+    return `expires in ${hoursLeft} hour${hoursLeft === 1 ? '' : 's'}`
+  }
+
+  const daysLeft = Math.round(hoursLeft / 24)
+  return `expires in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`
+}


### PR DESCRIPTION
## 📝 Description

`/api/shared/<share_id>/` is `AllowAny` and served the analysis through `ResumeAnalysisSerializer` — the serializer whose own docstring says *"Full record, including the extracted text."*

```python
@api_view(["GET"])
@permission_classes([AllowAny])
def get_shared_result(request, share_id):
    analysis = get_object_or_404(ResumeAnalysis, share_id=share_id)
    return Response(ResumeAnalysisSerializer(analysis).data)
```

`resume_text` is the whole document: home address, personal email, phone number, every employer. The page behind the link renders a score and a skill list. Anyone holding the link got the rest, and so did anything the link passed through.

Three separate problems came out of that one endpoint, and they are fixed separately.

### 1. The payload was far wider than the feature

New `PublicSharedAnalysisSerializer`. The important detail is that it is an **allowlist**, not `exclude`:

```python
class Meta:
    fields = sharing.PUBLIC_FIELDS + ("expires_at",)
```

An exclude list is a denylist, and a denylist on a model that gains columns fails open — the next field added to `ResumeAnalysis` would be published by default. `sharing.PUBLIC_FIELDS` states what may go out, and widening it is a deliberate edit.

Out: `resume_text`, `cover_letter_text`, `cover_letter_feedback`, the private `id`, and `file_name`. The filename is deliberate — resumes are routinely saved as `Firstname_Lastname_Resume.pdf`, so publishing it names the owner on a page whose whole point is that it does not. `SharedResultView` now labels the score with the role and level instead, which is what that line was for.

On top of the field selection, everything that *is* published goes through `sharing.redact_structure`. `skills_found` is extracted from the resume and a suggestion string can quote a phrase back, so "we did not serialise `resume_text`" is not by itself a guarantee that no contact detail is in the response.

### 2. A share could never be undone

`share_id` was assigned at row creation (`default=uuid.uuid4`), so every analysis was readable by id from the moment it existed. Sharing is now state:

| field | |
| --- | --- |
| `share_enabled` | the owner's decision, off by default |
| `share_expires_at` | always set while sharing is on — "never expires" is not offered |
| `share_created_at` | when it was last published or rotated |
| `share_view_count` | did anyone actually open this |

`POST/GET/DELETE /api/history/<pk>/share/` enables (with `lifetime_days`, 1–365, default 30), rotates (`{"rotate": true}` — a fresh id, breaking every copy of the old link) and revokes.

Two decisions worth pointing at:

- **Expiry is evaluated on read**, in `is_share_live()`, not by a cleanup job. A revocation that depends on a cron having run is not a revocation.
- **Revoking keeps the id.** Re-enabling should be a decision about *whether* to share, not a forced re-send of a link already distributed. `rotate` is there for when a clean break is what you want — and it resets the view counter, so the number keeps meaning "views of the link I sent" rather than an all-time total spanning a revocation.

### 3. Responses confirmed which ids were real

Unknown, revoked and expired now all answer **404**. A 403 for a revoked link tells someone walking the id space that they found something. The endpoint also gets a throttle (`SHARED_RESULT_RATE`, default `60/hour`) — every other `AllowAny` view in `views.py` already had one. The rate is read from settings inside the throttle class, following `UploadRateThrottle`, rather than added to `DEFAULT_THROTTLE_RATES`: it keeps the number beside the docstring that justifies it, and it means three parallel branches each adding an endpoint do not all edit the same dictionary.

### On the redaction

This is the part most likely to be wrong in a way tests catch and review doesn't, so it is deliberately conservative. `_looks_like_phone` rejects candidates the loose pattern catches:

```
"Worked at Acme from 2019-2022"            -> unchanged   (year range)
"Improved throughput by 40% across 3 …"    -> unchanged   (metrics)
"Reduced p99 from 1200 ms to 340 ms"       -> unchanged
"Call +44 20 7946 0958"                    -> "Call [removed]"
```

A false positive here costs a `[removed]` in the middle of a tip. A false negative costs a phone number. Both directions are tested.

### Migration

`0017_resumeanalysis_share_controls` also **resolves the two leaf 0016 nodes** currently on `main` (`0016_merge_20260819_1833` and `0016_resumeanalysis_partial_skills`), which is why `manage.py test` refuses to build a database today:

```
CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph
```

Depending on both leaves resolves the fork and adds the columns in one node, rather than an empty merge plus a second migration on top.

The data step matters as much as the schema: **existing rows are backfilled as enabled**, with the standard 30-day expiry from deploy. Applying the new `False` default to them would break links users have already sent. They keep working today and then fall under the same rules as everything else.

### Frontend

`ShareResult` was orphaned — nothing rendered it — and it built a link in the browser from a `share_id` that was already live. It is now a real control that reads state from the server (`GET` on mount, every button a request whose response *is* the new state) and is mounted in the results panel. `formatExpiry` and the types moved to `utils/shareLink.ts`, because exporting helpers from a component module breaks Fast Refresh.

Docs: `docs/SHARING.md`, in the shape of `docs/WEBHOOKS.md`.

## 🔗 Related Issue

Closes #705

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

**Backend — 43 new tests** in `analyzer/tests_share_privacy.py`, in four groups.

*Payload* — the direct assertion is `test_resume_text_is_not_in_the_response`, which checks the rendered body for `Maple Street`, the email and the phone number, not just the absence of a key. Alongside it: no cover letter, no filename, no private pk, `test_response_keys_are_exactly_the_allowlist` (so a new model field cannot leak in silently), and `test_useful_fields_are_still_present` — narrowing the payload must not empty the page it feeds.

*Lifecycle* — a new analysis is not shared; enable; the default and a custom lifetime; clamping is reported rather than silent; revoke kills the link; revoke keeps the id; rotate breaks the old URL and serves the new one; rotate resets the counter; `test_an_expired_link_stops_working_without_a_cleanup_job` sets the expiry into the past directly; and enabled-with-no-expiry is treated as *not* live, because the failure mode of trusting it is an immortal link.

*Disclosure* — revoked and invented ids produce identical responses; another user gets 404, not 403, on the management endpoint and cannot enable sharing on someone else's row.

*Redaction* — emails, international and bracketed phone numbers, profile URLs, handles; and the false-positive set above, each as its own case.

```
Ran 387 tests in 9.4s
FAILED (failures=8)
```

The 8 are the pre-existing `tests_device_alerts` / `tests_login_errors` failures, identical to the baseline I captured on `main` before starting (343 tests, same 8). 387 − 343 = 44 = 43 new + one added to `tests_api_routes`.

Two existing tests in `tests_api_routes.SharedResultEndpointTests` asserted that an id alone was enough to read an analysis. That is the behaviour this PR removes, so they now publish first, with a comment saying why — and a new sibling test pins the opposite: an unshared analysis is not reachable by id.

**Frontend — 21 new tests** across `components/ShareResult.test.tsx` and `SharedResultView.test.tsx`. Notable: nothing copyable is rendered before sharing is on, the URL shown is the server's rather than one built locally, a failed request reports rather than showing state that was never saved, and the not-found copy is true of revoked *and* expired *and* never-existed, since the backend does not distinguish them.

```
Test Files  32 passed (32)
     Tests  185 passed (185)     # 164 before, +21
```

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

`tsc -b` reports only the pre-existing `swagger-ui-react` resolution error in `pages/Apidocs.tsx`, unchanged from `main`. `eslint` is clean on every new and modified file; `App.tsx` has the same 9 pre-existing complaints it has on `main` — I reverted a stray Prettier reformat so this diff is 10 added lines there and nothing else.

Manually: created a link, opened it signed out and confirmed the response carries no resume text; revoked it and confirmed the same URL 404s; rotated and confirmed the previous URL stops working while the new one serves.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
