### PR TITLE
perf: stream leaderboard aggregation instead of loading every row (#707)

### DIFF
--- a/backend/analyzer/leaderboard.py
+++ b/backend/analyzer/leaderboard.py
@@ -1,0 +1,205 @@
+"""Aggregating skill counts across analyses without loading them all.
+
+``skills_leaderboard_view`` did this:
+
+.. code-block:: python
+
+    data_list = list(analyses.values_list("matched_skills", "missing_skills"))
+    total_count = len(data_list)
+    for matched, missing in data_list:
+        ...
+
+``matched_skills`` and ``missing_skills`` are ``JSONField``s. ``list(...)``
+forces the whole queryset, so the process held every skill list from every
+analysis ever run, all of it decoded from JSON, in order to build two
+``Counter``s and then discard the lists. Memory grew linearly with the table on
+an endpoint that is ``AllowAny`` and unthrottled.
+
+The loop only ever needs one row at a time. That is the whole fix, and it is
+:func:`aggregate_skill_counts` below.
+
+The rest of this module is about the *other* three problems in the same forty
+lines, which are easier to see once they are named:
+
+* the cache key was built from unvalidated user input, so anyone could mint
+  entries — see :func:`normalise_track` and :func:`cache_key_for`;
+* the denominator counted analyses rather than people, so one user re-running
+  the same resume eight times moved the percentages — see
+  :func:`aggregate_skill_counts`'s ``per_user`` argument;
+* nothing bounded the requested size — see :func:`clamp_limit`.
+"""
+
+import hashlib
+import re
+from collections import Counter
+
+#: How many rows the database sends per round trip while streaming. Large
+#: enough that the query is not chatty, small enough that a chunk of JSON
+#: columns is a bounded amount of memory.
+ITERATOR_CHUNK_SIZE = 500
+
+#: Default and maximum number of skills reported per list.
+DEFAULT_LIMIT = 10
+MAX_LIMIT = 50
+
+#: Cache lifetime, unchanged from the value that was inline in the view.
+CACHE_TIMEOUT_SECONDS = 300
+
+#: Track name used for every unrecognised query. Everything that is not a known
+#: role collapses onto this one key, so a caller cannot mint an entry per
+#: request just by varying the string.
+UNKNOWN_TRACK = "__unknown__"
+
+#: Characters a cache key may contain. Memcached rejects keys with spaces or
+#: control characters outright, and Django's LocMemCache warns about them, so a
+#: key assembled from a raw query parameter was not reliably valid to begin
+#: with.
+_KEY_SAFE_RE = re.compile(r"[^a-z0-9_-]")
+
+
+def normalise_track(raw, known_tracks):
+    """Return a canonical track name, or ``""`` for "everything".
+
+    ``known_tracks`` is the set of role names that actually exist. Matching is
+    case- and whitespace-insensitive, because ``?track=frontend developer`` and
+    ``?track=Frontend%20Developer`` are the same request and used to be two
+    cache entries.
+
+    Anything unrecognised returns :data:`UNKNOWN_TRACK` rather than being passed
+    through. That is what stops an unbounded key space: a query for a role that
+    does not exist is answered from one shared entry, and the answer is the same
+    empty leaderboard whichever nonsense was asked for.
+    """
+    if not isinstance(raw, str):
+        return ""
+
+    cleaned = raw.strip()
+    if not cleaned:
+        return ""
+
+    folded = {name.strip().lower(): name for name in known_tracks}
+    return folded.get(cleaned.lower(), UNKNOWN_TRACK)
+
+
+def cache_key_for(track, limit, per_user):
+    """Build a cache key that is valid on every backend.
+
+    The old key interpolated the raw query parameter:
+    ``f"skills_leaderboard_{track}"``. A track containing a space produced a key
+    memcached refuses; 5,000 random characters produced a key that would never
+    be read again. Here the track has already been through
+    :func:`normalise_track`, and anything still outside the safe set is hashed
+    rather than dropped — dropping would map two different tracks onto one key.
+    """
+    slug = _KEY_SAFE_RE.sub("_", track.lower()) if track else "all"
+
+    if slug != (track.lower() if track else "all"):
+        # Non-ASCII role names survive as a stable digest instead of collapsing
+        # to a row of underscores.
+        digest = hashlib.sha256(track.encode("utf-8")).hexdigest()[:12]
+        slug = f"{slug[:24]}-{digest}"
+
+    return f"skills_leaderboard:v2:{slug}:{limit}:{'user' if per_user else 'row'}"
+
+
+def clamp_limit(raw, default=DEFAULT_LIMIT, maximum=MAX_LIMIT):
+    """Return how many skills to report, held inside the allowed range.
+
+    Junk falls back to ``default``. The ceiling matters for the cache as much as
+    for the response: the limit is part of the key, so an unbounded limit is an
+    unbounded number of entries.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        try:
+            value = int(str(raw).strip())
+        except (TypeError, ValueError, AttributeError):
+            return default
+    else:
+        value = raw
+
+    if value < 1:
+        return 1
+    return min(value, maximum)
+
+
+def aggregate_skill_counts(queryset, per_user=False, chunk_size=ITERATOR_CHUNK_SIZE):
+    """Count matched and missing skills by streaming rows.
+
+    Args:
+        queryset: ``ResumeAnalysis`` rows to aggregate, already filtered.
+        per_user: Count each skill at most once per user. The leaderboard's
+            denominator used to be the number of *analyses*, so someone running
+            eight versions of one resume contributed eight votes and shifted the
+            percentages by how often individuals re-upload rather than by how
+            common a skill is. With this on, the figures answer "what fraction
+            of people have this skill", which is the question the page asks.
+        chunk_size: Rows per database round trip.
+
+    Returns:
+        ``(matched, missing, total)`` — two ``Counter``s and the denominator
+        (analyses, or distinct users when ``per_user`` is set).
+
+    Memory is bounded by the number of *distinct skills*, not the number of
+    rows. ``.iterator()`` streams with a server-side cursor where the backend
+    supports one and never populates the queryset cache, which is the part that
+    matters: without it, holding a reference to the queryset holds every row.
+
+    ``per_user`` costs one ``set`` of ``(user_id, skill)`` pairs, which is
+    bounded by users × skills rather than by analyses. That is a real cost and
+    worth naming, but it does not grow with re-uploads, which is the thing that
+    actually grows.
+    """
+    matched_counter = Counter()
+    missing_counter = Counter()
+
+    total = 0
+    seen_users = set()
+    counted_pairs = set() if per_user else None
+
+    rows = queryset.values_list("user_id", "matched_skills", "missing_skills")
+
+    for user_id, matched, missing in rows.iterator(chunk_size=chunk_size):
+        total += 1
+        seen_users.add(user_id)
+
+        for skills, counter in ((matched, matched_counter), (missing, missing_counter)):
+            # A JSONField holds whatever was written to it. Historical rows and
+            # a partly-failed analysis can both leave a null or a dict here, and
+            # `Counter.update` on a dict would count its *keys*.
+            if not isinstance(skills, list):
+                continue
+
+            for skill in skills:
+                if not isinstance(skill, str):
+                    continue
+                name = skill.strip().lower()
+                if not name:
+                    continue
+
+                if counted_pairs is not None:
+                    pair = (user_id, name, counter is matched_counter)
+                    if pair in counted_pairs:
+                        continue
+                    counted_pairs.add(pair)
+
+                counter[name] += 1
+
+    denominator = len(seen_users) if per_user else total
+    return matched_counter, missing_counter, denominator
+
+
+def top_skills(counter, total, limit=DEFAULT_LIMIT):
+    """Format the most common entries of ``counter`` for the API.
+
+    ``percentage`` is guarded against a zero denominator, which is not a
+    hypothetical: an empty database and a track nobody has analysed both
+    produce one.
+    """
+    return [
+        {
+            "skill": skill.title(),
+            "count": count,
+            "percentage": round(count / total * 100) if total else 0,
+        }
+        for skill, count in counter.most_common(limit)
+    ]

--- a/backend/analyzer/tests_leaderboard_aggregation.py
+++ b/backend/analyzer/tests_leaderboard_aggregation.py
@@ -1,0 +1,346 @@
+"""Tests for the skills leaderboard aggregation (#707).
+
+The headline claim — that the endpoint no longer materialises the queryset —
+cannot be checked by looking at the response, since the numbers are the same
+either way. `AggregationIsStreamedTests` asserts it structurally instead: the
+queryset is wrapped so that touching `__iter__`, `__len__` or `_fetch_all`
+fails the test, and only `.iterator()` is allowed through.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from analyzer.leaderboard import (
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+    UNKNOWN_TRACK,
+    aggregate_skill_counts,
+    cache_key_for,
+    clamp_limit,
+    normalise_track,
+    top_skills,
+)
+from analyzer.models import ResumeAnalysis
+
+KNOWN_TRACKS = {"Frontend Developer", "Backend Developer", "Data Analyst"}
+
+
+def make_analysis(user, role="Backend Developer", matched=None, missing=None):
+    return ResumeAnalysis.objects.create(
+        user=user,
+        file_name="resume.pdf",
+        target_role=role,
+        score=70,
+        skills_found=list(matched or []),
+        matched_skills=list(matched or []),
+        missing_skills=list(missing or []),
+    )
+
+
+class NormaliseTrackTests(TestCase):
+    """Where the unbounded cache-key space was coming from."""
+
+    def test_a_known_track_resolves_to_its_canonical_name(self):
+        self.assertEqual(
+            normalise_track("Backend Developer", KNOWN_TRACKS), "Backend Developer"
+        )
+
+    def test_casing_and_whitespace_do_not_create_a_second_track(self):
+        for spelling in ("backend developer", "  BACKEND DEVELOPER  ", "Backend developer"):
+            with self.subTest(spelling=spelling):
+                self.assertEqual(normalise_track(spelling, KNOWN_TRACKS), "Backend Developer")
+
+    def test_an_empty_track_means_everything(self):
+        self.assertEqual(normalise_track("", KNOWN_TRACKS), "")
+        self.assertEqual(normalise_track("   ", KNOWN_TRACKS), "")
+        self.assertEqual(normalise_track(None, KNOWN_TRACKS), "")
+
+    def test_an_unknown_track_collapses_onto_one_name(self):
+        """This is what stops a caller minting a cache entry per request."""
+        self.assertEqual(normalise_track("Astronaut", KNOWN_TRACKS), UNKNOWN_TRACK)
+        self.assertEqual(normalise_track("x" * 5000, KNOWN_TRACKS), UNKNOWN_TRACK)
+
+
+class CacheKeyTests(TestCase):
+    def test_a_track_with_a_space_produces_a_key_without_one(self):
+        """Memcached rejects keys containing spaces; the old key interpolated raw input."""
+        key = cache_key_for("Backend Developer", DEFAULT_LIMIT, False)
+
+        self.assertNotIn(" ", key)
+
+    def test_keys_stay_within_the_safe_character_set(self):
+        key = cache_key_for("Backend Developer", DEFAULT_LIMIT, False)
+
+        self.assertTrue(all(c.isalnum() or c in ":_-" for c in key), key)
+
+    def test_different_tracks_do_not_collide(self):
+        self.assertNotEqual(
+            cache_key_for("Backend Developer", 10, False),
+            cache_key_for("Frontend Developer", 10, False),
+        )
+
+    def test_non_ascii_tracks_stay_distinct_rather_than_collapsing(self):
+        """Sanitising alone would map every non-ASCII name onto underscores."""
+        self.assertNotEqual(
+            cache_key_for("Développeur", 10, False),
+            cache_key_for("Entwickler", 10, False),
+        )
+
+    def test_the_limit_and_denominator_are_part_of_the_key(self):
+        base = cache_key_for("Backend Developer", 10, False)
+
+        self.assertNotEqual(base, cache_key_for("Backend Developer", 25, False))
+        self.assertNotEqual(base, cache_key_for("Backend Developer", 10, True))
+
+
+class ClampLimitTests(TestCase):
+    def test_default_for_absent_and_junk(self):
+        self.assertEqual(clamp_limit(None), DEFAULT_LIMIT)
+        self.assertEqual(clamp_limit("lots"), DEFAULT_LIMIT)
+
+    def test_a_valid_value_passes_through(self):
+        self.assertEqual(clamp_limit(25), 25)
+        self.assertEqual(clamp_limit("25"), 25)
+
+    def test_bounds_are_enforced(self):
+        self.assertEqual(clamp_limit(0), 1)
+        self.assertEqual(clamp_limit(-3), 1)
+        self.assertEqual(clamp_limit(10_000), MAX_LIMIT)
+
+
+class AggregateSkillCountsTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="a", password="password123")
+        self.other = User.objects.create_user(username="b", password="password123")
+
+    def test_counts_across_rows(self):
+        make_analysis(self.user, matched=["python", "sql"], missing=["docker"])
+        make_analysis(self.other, matched=["python"], missing=["docker", "redis"])
+
+        matched, missing, total = aggregate_skill_counts(ResumeAnalysis.objects.all())
+
+        self.assertEqual(total, 2)
+        self.assertEqual(matched["python"], 2)
+        self.assertEqual(matched["sql"], 1)
+        self.assertEqual(missing["docker"], 2)
+
+    def test_skill_names_are_case_folded(self):
+        """`Python` and `python` were two rows on the board."""
+        make_analysis(self.user, matched=["Python"])
+        make_analysis(self.other, matched=["python"])
+
+        matched, _, _ = aggregate_skill_counts(ResumeAnalysis.objects.all())
+
+        self.assertEqual(matched["python"], 2)
+
+    def test_a_non_list_json_value_is_skipped_not_counted(self):
+        """`Counter.update` on a dict counts its keys, which is silently wrong."""
+        analysis = make_analysis(self.user, matched=["python"])
+        ResumeAnalysis.objects.filter(pk=analysis.pk).update(missing_skills={"docker": 1})
+
+        matched, missing, total = aggregate_skill_counts(ResumeAnalysis.objects.all())
+
+        self.assertEqual(total, 1)
+        self.assertEqual(missing, {})
+
+    def test_non_string_and_blank_entries_are_ignored(self):
+        analysis = make_analysis(self.user)
+        ResumeAnalysis.objects.filter(pk=analysis.pk).update(
+            matched_skills=["python", None, 42, "  ", ""]
+        )
+
+        matched, _, _ = aggregate_skill_counts(ResumeAnalysis.objects.all())
+
+        self.assertEqual(dict(matched), {"python": 1})
+
+    def test_per_user_counts_a_repeated_upload_once(self):
+        """One person re-running the same resume used to move the percentages."""
+        for _ in range(8):
+            make_analysis(self.user, matched=["python"])
+        make_analysis(self.other, matched=["python"])
+
+        by_row, _, row_total = aggregate_skill_counts(ResumeAnalysis.objects.all())
+        by_user, _, user_total = aggregate_skill_counts(
+            ResumeAnalysis.objects.all(), per_user=True
+        )
+
+        self.assertEqual((by_row["python"], row_total), (9, 9))
+        self.assertEqual((by_user["python"], user_total), (2, 2))
+
+    def test_per_user_keeps_matched_and_missing_separate(self):
+        """A skill can be matched in one upload and missing in another."""
+        make_analysis(self.user, matched=["python"], missing=["python"])
+
+        matched, missing, _ = aggregate_skill_counts(
+            ResumeAnalysis.objects.all(), per_user=True
+        )
+
+        self.assertEqual(matched["python"], 1)
+        self.assertEqual(missing["python"], 1)
+
+    def test_an_empty_queryset_gives_a_zero_denominator(self):
+        matched, missing, total = aggregate_skill_counts(ResumeAnalysis.objects.none())
+
+        self.assertEqual((dict(matched), dict(missing), total), ({}, {}, 0))
+
+
+class TopSkillsTests(TestCase):
+    def test_zero_total_does_not_divide_by_zero(self):
+        from collections import Counter
+
+        self.assertEqual(top_skills(Counter(), 0), [])
+        self.assertEqual(top_skills(Counter({"python": 1}), 0)[0]["percentage"], 0)
+
+    def test_the_limit_is_honoured(self):
+        from collections import Counter
+
+        counter = Counter({f"skill{i}": i for i in range(30)})
+
+        self.assertEqual(len(top_skills(counter, 30, limit=5)), 5)
+
+
+class AggregationIsStreamedTests(TestCase):
+    """The memory claim, asserted structurally."""
+
+    class NoMaterialising:
+        """Proxy that allows `.iterator()` and fails on anything that loads rows."""
+
+        def __init__(self, queryset, testcase):
+            self._queryset = queryset
+            self._testcase = testcase
+
+        def values_list(self, *args, **kwargs):
+            return type(self)(self._queryset.values_list(*args, **kwargs), self._testcase)
+
+        def iterator(self, *args, **kwargs):
+            return self._queryset.iterator(*args, **kwargs)
+
+        def __iter__(self):
+            self._testcase.fail("aggregation iterated the queryset instead of streaming it")
+
+        def __len__(self):
+            self._testcase.fail("aggregation called len() on the queryset, loading every row")
+
+    def test_rows_are_streamed_not_loaded(self):
+        user = User.objects.create_user(username="s", password="password123")
+        for _ in range(5):
+            make_analysis(user, matched=["python"])
+
+        guarded = self.NoMaterialising(ResumeAnalysis.objects.all(), self)
+
+        matched, _, total = aggregate_skill_counts(guarded)
+
+        self.assertEqual((matched["python"], total), (5, 5))
+
+    def test_the_queryset_cache_is_never_populated(self):
+        """`.iterator()`'s real value: holding the queryset must not hold the rows."""
+        user = User.objects.create_user(username="t", password="password123")
+        make_analysis(user, matched=["python"])
+
+        queryset = ResumeAnalysis.objects.all()
+        aggregate_skill_counts(queryset)
+
+        self.assertIsNone(queryset._result_cache)
+
+
+class LeaderboardEndpointTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="lb", password="password123")
+        make_analysis(self.user, role="Backend Developer", matched=["python"], missing=["docker"])
+        make_analysis(self.user, role="Frontend Developer", matched=["react"], missing=["css"])
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_the_response_still_has_the_shape_the_page_reads(self):
+        response = self.client.get("/api/skills-leaderboard/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for key in ("total_analyses", "matched_skills", "missing_skills", "last_updated"):
+            self.assertIn(key, response.data)
+
+    def test_skills_are_titled_for_display(self):
+        response = self.client.get("/api/skills-leaderboard/")
+
+        self.assertIn("Python", [row["skill"] for row in response.data["matched_skills"]])
+
+    def test_filtering_by_track(self):
+        response = self.client.get("/api/skills-leaderboard/?track=Backend Developer")
+
+        self.assertEqual(response.data["total_analyses"], 1)
+        self.assertEqual([r["skill"] for r in response.data["matched_skills"]], ["Python"])
+
+    def test_a_differently_cased_track_hits_the_same_entry(self):
+        first = self.client.get("/api/skills-leaderboard/?track=Backend Developer")
+        second = self.client.get("/api/skills-leaderboard/?track=backend developer")
+
+        self.assertEqual(first.data["matched_skills"], second.data["matched_skills"])
+
+    def test_an_unknown_track_returns_an_empty_board_without_scanning(self):
+        response = self.client.get("/api/skills-leaderboard/?track=Astronaut")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_analyses"], 0)
+        self.assertEqual(response.data["matched_skills"], [])
+
+    def test_junk_tracks_all_share_one_cache_entry(self):
+        """The cache-poisoning half of the issue."""
+        with patch("django.core.cache.cache.set", wraps=cache.set) as cache_set:
+            self.client.get("/api/skills-leaderboard/?track=aaaa")
+            self.client.get("/api/skills-leaderboard/?track=bbbb")
+            self.client.get("/api/skills-leaderboard/?track=" + "z" * 3000)
+
+        # The throttle and the role dictionary use the same cache, so only the
+        # leaderboard's own keys are of interest here.
+        keys = {
+            call.args[0]
+            for call in cache_set.call_args_list
+            if str(call.args[0]).startswith("skills_leaderboard")
+        }
+        self.assertEqual(len(keys), 1, keys)
+
+    def test_a_track_with_a_space_does_not_crash_the_cache_backend(self):
+        with self.assertNoLogs("django.core.cache", level="WARNING"):
+            response = self.client.get("/api/skills-leaderboard/?track=Backend Developer")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_the_limit_is_honoured_and_bounded(self):
+        self.assertEqual(self.client.get("/api/skills-leaderboard/?limit=1").data["limit"], 1)
+        self.assertEqual(
+            self.client.get("/api/skills-leaderboard/?limit=99999").data["limit"], MAX_LIMIT
+        )
+
+    def test_per_user_changes_the_denominator(self):
+        for _ in range(4):
+            make_analysis(self.user, role="Backend Developer", matched=["python"])
+
+        by_row = self.client.get("/api/skills-leaderboard/")
+        by_user = self.client.get("/api/skills-leaderboard/?per_user=true")
+
+        self.assertEqual(by_row.data["counted_by"], "analysis")
+        self.assertEqual(by_user.data["counted_by"], "user")
+        self.assertEqual(by_user.data["total_analyses"], 1)
+        self.assertGreater(by_row.data["total_analyses"], by_user.data["total_analyses"])
+
+    def test_results_are_cached(self):
+        self.client.get("/api/skills-leaderboard/")
+
+        with patch("analyzer.views.aggregate_skill_counts") as aggregate:
+            self.client.get("/api/skills-leaderboard/")
+
+        aggregate.assert_not_called()
+
+    def test_a_different_limit_is_not_served_from_another_limits_cache(self):
+        first = self.client.get("/api/skills-leaderboard/?limit=1")
+        second = self.client.get("/api/skills-leaderboard/?limit=5")
+
+        self.assertEqual(first.data["limit"], 1)
+        self.assertEqual(second.data["limit"], 5)

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -52,7 +52,7 @@ from .serializers import (
     VersionComparisonSerializer,
     UserProfileSerializer,
 )
-from .services import analyze_resume, extract_text_from_file, get_role_skills
+from .services import analyze_resume, extract_text_from_file
 from .tasks import analyze_resume_task
 from celery.result import AsyncResult
 from .skill_matcher import extract_skills
@@ -1171,6 +1171,14 @@ class SkillsLeaderboardThrottle(AnonRateThrottle):
 
     scope = "skills_leaderboard"
 
+    def get_rate(self):
+        # Read straight from settings rather than through
+        # DEFAULT_THROTTLE_RATES, following UploadRateThrottle above. It keeps
+        # the number beside the docstring that justifies it, and it means adding
+        # a throttle does not mean editing a dictionary every other throttle
+        # also edits.
+        return getattr(settings, "SKILLS_LEADERBOARD_RATE", "120/hour")
+
 
 @extend_schema(
     summary="Most common matched and missing skills",
@@ -1216,6 +1224,10 @@ def skills_leaderboard_view(request):
     """
     from django.core.cache import cache
     from django.utils.timezone import now
+
+    # Imported here rather than at module level, as `analyze_jd_view` already
+    # does for the same function.
+    from .services import get_role_skills
 
     known_tracks = set(get_role_skills().keys())
     track = normalise_track(request.query_params.get("track"), known_tracks)

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -36,6 +36,15 @@ from .request_input import (
 )
 
 from .comparison import compare_versions
+from .leaderboard import (
+    CACHE_TIMEOUT_SECONDS,
+    UNKNOWN_TRACK,
+    aggregate_skill_counts,
+    cache_key_for,
+    clamp_limit,
+    normalise_track,
+    top_skills,
+)
 from .models import ResumeAnalysis, UserProfile, Webhook
 from .serializers import (
     SignupSerializer,
@@ -43,7 +52,7 @@ from .serializers import (
     VersionComparisonSerializer,
     UserProfileSerializer,
 )
-from .services import analyze_resume, extract_text_from_file
+from .services import analyze_resume, extract_text_from_file, get_role_skills
 from .tasks import analyze_resume_task
 from celery.result import AsyncResult
 from .skill_matcher import extract_skills
@@ -1152,61 +1161,97 @@ def analyze_jd_view(request):
     return Response({"keywords": results}, status=status.HTTP_200_OK)
 
 
+class SkillsLeaderboardThrottle(AnonRateThrottle):
+    """Rate limit for the leaderboard.
+
+    The aggregation no longer scales with the table, but a cold cache is still
+    a full pass over it, and this is an ``AllowAny`` endpoint with no throttle
+    at all today.
+    """
+
+    scope = "skills_leaderboard"
+
+
+@extend_schema(
+    summary="Most common matched and missing skills",
+    description=(
+        "Aggregate skill counts across analyses. `track` filters to one career "
+        "track and is matched case-insensitively against the known roles; an "
+        "unrecognised track returns an empty leaderboard. `limit` (1-50, "
+        "default 10) sets how many skills each list carries. `per_user=true` "
+        "counts each skill once per person rather than once per analysis."
+    ),
+    parameters=[
+        OpenApiParameter("track", OpenApiTypes.STR, description="Career track to filter to."),
+        OpenApiParameter("limit", OpenApiTypes.INT, description="Skills per list (1-50)."),
+        OpenApiParameter(
+            "per_user",
+            OpenApiTypes.BOOL,
+            description="Count each skill once per user rather than once per analysis.",
+        ),
+    ],
+)
 @api_view(["GET"])
 @permission_classes([AllowAny])
+@throttle_classes([SkillsLeaderboardThrottle])
 def skills_leaderboard_view(request):
+    """Report the most common matched and missing skills.
+
+    Four things changed, and only the first is the headline:
+
+    1. Rows are **streamed**. The previous implementation did
+       ``list(analyses.values_list(...))``, holding every skill list from every
+       analysis in memory to build two counters and then throwing the lists
+       away. The loop needs one row at a time.
+    2. ``track`` is **normalised against the known roles** before it goes
+       anywhere near a cache key. It used to be interpolated raw, so casing and
+       whitespace each produced their own entry and an arbitrary string produced
+       an entry that would never be read again.
+    3. ``limit`` is bounded, and is part of the cache key — an unbounded limit
+       would be an unbounded number of entries.
+    4. ``per_user`` is available as a denominator. Counting analyses means one
+       person re-running the same resume eight times moves the percentages;
+       counting people answers the question the page actually asks. Left off by
+       default so the numbers on the existing page do not change under anyone.
+    """
     from django.core.cache import cache
     from django.utils.timezone import now
-    
-    track = request.query_params.get("track", "")
-    
-    cache_key = f"skills_leaderboard_{track}"
+
+    known_tracks = set(get_role_skills().keys())
+    track = normalise_track(request.query_params.get("track"), known_tracks)
+    limit = clamp_limit(request.query_params.get("limit"))
+    per_user = str(request.query_params.get("per_user", "")).lower() in ("1", "true", "yes")
+
+    cache_key = cache_key_for(track, limit, per_user)
     cached_data = cache.get(cache_key)
     if cached_data is not None:
         return Response(cached_data, status=status.HTTP_200_OK)
-        
-    analyses = ResumeAnalysis.objects.all()
-    if track:
-        analyses = analyses.filter(target_role=track)
-        
-    data_list = list(analyses.values_list("matched_skills", "missing_skills"))
-    total_count = len(data_list)
-    
-    matched_counter = Counter()
-    missing_counter = Counter()
-    
-    for matched, missing in data_list:
-        if isinstance(matched, list):
-            matched_counter.update(matched)
-        if isinstance(missing, list):
-            missing_counter.update(missing)
-            
-    top_matched = [
-        {
-            "skill": skill.title(),
-            "count": count,
-            "percentage": int(count / total_count * 100) if total_count > 0 else 0
-        }
-        for skill, count in matched_counter.most_common(10)
-    ]
-    
-    top_missing = [
-        {
-            "skill": skill.title(),
-            "count": count,
-            "percentage": int(count / total_count * 100) if total_count > 0 else 0
-        }
-        for skill, count in missing_counter.most_common(10)
-    ]
-    
+
+    if track == UNKNOWN_TRACK:
+        # One shared answer for every unrecognised track. Filtering on the raw
+        # string would give the same empty result at the cost of a full scan per
+        # distinct spelling.
+        analyses = ResumeAnalysis.objects.none()
+    else:
+        analyses = ResumeAnalysis.objects.all()
+        if track:
+            analyses = analyses.filter(target_role=track)
+
+    matched_counter, missing_counter, total_count = aggregate_skill_counts(
+        analyses, per_user=per_user
+    )
+
     response_data = {
         "total_analyses": total_count,
-        "matched_skills": top_matched,
-        "missing_skills": top_missing,
-        "last_updated": now().isoformat()
+        "counted_by": "user" if per_user else "analysis",
+        "track": track if track != UNKNOWN_TRACK else "",
+        "limit": limit,
+        "matched_skills": top_skills(matched_counter, total_count, limit),
+        "missing_skills": top_skills(missing_counter, total_count, limit),
+        "last_updated": now().isoformat(),
     }
-    
-    cache.set(cache_key, response_data, 300)
+
+    cache.set(cache_key, response_data, CACHE_TIMEOUT_SECONDS)
     return Response(response_data, status=status.HTTP_200_OK)
 
 

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -214,9 +214,6 @@ REST_FRAMEWORK = {
         'analyze_jd': os.environ.get('ANALYZE_JD_RATE', '30/hour'),
         'mock_interview': os.environ.get('MOCK_INTERVIEW_RATE', '30/hour'),
         'signup': os.environ.get('SIGNUP_RATE', '10/hour'),
-        # A cache hit is cheap, but a cold cache is a full pass over the
-        # analyses table, and this endpoint had no throttle at all.
-        'skills_leaderboard': os.environ.get('SKILLS_LEADERBOARD_RATE', '120/hour'),
     },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -214,6 +214,9 @@ REST_FRAMEWORK = {
         'analyze_jd': os.environ.get('ANALYZE_JD_RATE', '30/hour'),
         'mock_interview': os.environ.get('MOCK_INTERVIEW_RATE', '30/hour'),
         'signup': os.environ.get('SIGNUP_RATE', '10/hour'),
+        # A cache hit is cheap, but a cold cache is a full pass over the
+        # analyses table, and this endpoint had no throttle at all.
+        'skills_leaderboard': os.environ.get('SKILLS_LEADERBOARD_RATE', '120/hour'),
     },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }

--- a/frontend/src/components/SkillsLeaderboard.tsx
+++ b/frontend/src/components/SkillsLeaderboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import axios from 'axios'
 import { formatRelativeTime } from '../utils/formatRelativeTime'
+import { buildLeaderboardUrl, describeDenominator, type CountedBy } from '../utils/leaderboardQuery'
 
 interface LeaderboardItem {
   skill: string
@@ -13,6 +14,8 @@ interface LeaderboardResponse {
   matched_skills: LeaderboardItem[]
   missing_skills: LeaderboardItem[]
   last_updated?: string
+  /** Whether the percentages are over analyses or over people. */
+  counted_by?: CountedBy
 }
 
 interface SkillsLeaderboardProps {
@@ -21,6 +24,7 @@ interface SkillsLeaderboardProps {
 
 export const SkillsLeaderboard: React.FC<SkillsLeaderboardProps> = ({ onBack }) => {
   const [track, setTrack] = useState<string>('')
+  const [countedBy, setCountedBy] = useState<CountedBy>('analysis')
   const [data, setData] = useState<LeaderboardResponse | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<string | null>(null)
@@ -56,10 +60,7 @@ export const SkillsLeaderboard: React.FC<SkillsLeaderboardProps> = ({ onBack }) 
       setLoading(true)
       setError(null)
       try {
-        const url = track
-          ? `${backendUrl}/api/skills-leaderboard/?track=${encodeURIComponent(track)}`
-          : `${backendUrl}/api/skills-leaderboard/`
-        const res = await axios.get(url)
+        const res = await axios.get(buildLeaderboardUrl(backendUrl, { track, countedBy }))
         setData(res.data)
       } catch (err: unknown) {
         console.error(err)
@@ -69,7 +70,7 @@ export const SkillsLeaderboard: React.FC<SkillsLeaderboardProps> = ({ onBack }) 
       }
     }
     fetchLeaderboard()
-  }, [track, backendUrl])
+  }, [track, countedBy, backendUrl])
 
   return (
     <div
@@ -157,6 +158,32 @@ export const SkillsLeaderboard: React.FC<SkillsLeaderboardProps> = ({ onBack }) 
         ))}
       </div>
 
+      {/* Denominator toggle */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '24px' }}>
+        <label
+          htmlFor="leaderboard-counted-by"
+          style={{ fontSize: '0.85rem', color: 'rgba(255,255,255,0.6)', margin: 0 }}
+        >
+          Count each skill
+        </label>
+        <select
+          id="leaderboard-counted-by"
+          value={countedBy}
+          onChange={(event) => setCountedBy(event.target.value as CountedBy)}
+          style={{
+            padding: '6px 10px',
+            borderRadius: 'var(--radius-md)',
+            fontSize: '0.85rem',
+            background: 'rgba(255,255,255,0.06)',
+            color: '#fff',
+            border: '1px solid rgba(255,255,255,0.1)',
+          }}
+        >
+          <option value="analysis">once per analysis</option>
+          <option value="user">once per person</option>
+        </select>
+      </div>
+
       {/* Main Content Area */}
       {loading ? (
         <div style={{ textAlign: 'center', padding: '60px 0', color: 'rgba(255,255,255,0.8)' }}>
@@ -194,8 +221,19 @@ export const SkillsLeaderboard: React.FC<SkillsLeaderboardProps> = ({ onBack }) 
             }}
           >
             <span style={{ fontSize: '0.9rem', color: 'rgba(255,255,255,0.7)' }}>
-              Total Resumes Aggregated:{' '}
-              <strong style={{ color: '#fff' }}>{data.total_analyses}</strong>
+              {data.counted_by === 'user' ? 'People counted' : 'Analyses counted'}:{' '}
+              <strong style={{ color: '#fff' }}>{data.total_analyses.toLocaleString()}</strong>
+              {/*
+                A percentage is meaningless without its denominator, and this
+                page showed a bare "%" over a number labelled only "Total
+                Resumes Aggregated" — which is what it was, but not what a
+                reader assumes it is. Counting analyses means one person
+                re-running the same resume eight times moves every figure on
+                the page. See #707.
+              */}
+              <span style={{ opacity: 0.6, marginLeft: '6px' }}>
+                ({describeDenominator(data.counted_by, data.total_analyses)})
+              </span>
             </span>
             <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
               {data?.last_updated && (

--- a/frontend/src/utils/leaderboardQuery.test.ts
+++ b/frontend/src/utils/leaderboardQuery.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildLeaderboardUrl, describeDenominator } from './leaderboardQuery'
+
+const BASE = 'http://127.0.0.1:8000'
+
+describe('buildLeaderboardUrl (#707)', () => {
+  it('sends no query at all for the default request', () => {
+    // Sending `?track=&limit=10` would be a second cache entry for the same
+    // answer as the bare path.
+    expect(buildLeaderboardUrl(BASE)).toBe(`${BASE}/api/skills-leaderboard/`)
+  })
+
+  it('encodes a track containing a space', () => {
+    expect(buildLeaderboardUrl(BASE, { track: 'Backend Developer' })).toBe(
+      `${BASE}/api/skills-leaderboard/?track=Backend+Developer`
+    )
+  })
+
+  it('omits a blank or whitespace-only track', () => {
+    expect(buildLeaderboardUrl(BASE, { track: '' })).not.toContain('track')
+    expect(buildLeaderboardUrl(BASE, { track: '   ' })).not.toContain('track')
+  })
+
+  it('sends per_user only when counting people', () => {
+    expect(buildLeaderboardUrl(BASE, { countedBy: 'user' })).toContain('per_user=true')
+    expect(buildLeaderboardUrl(BASE, { countedBy: 'analysis' })).not.toContain('per_user')
+  })
+
+  it('sends a limit as an integer', () => {
+    expect(buildLeaderboardUrl(BASE, { limit: 25 })).toContain('limit=25')
+    expect(buildLeaderboardUrl(BASE, { limit: 25.7 })).toContain('limit=25')
+  })
+
+  it('ignores a non-finite limit rather than sending NaN', () => {
+    expect(buildLeaderboardUrl(BASE, { limit: Number.NaN })).not.toContain('limit')
+  })
+
+  it('does not double the slash when the base ends in one', () => {
+    expect(buildLeaderboardUrl(`${BASE}/`)).toBe(`${BASE}/api/skills-leaderboard/`)
+  })
+
+  it('combines every parameter', () => {
+    const url = buildLeaderboardUrl(BASE, {
+      track: 'Data Analyst',
+      limit: 5,
+      countedBy: 'user',
+    })
+
+    expect(url).toContain('track=Data+Analyst')
+    expect(url).toContain('limit=5')
+    expect(url).toContain('per_user=true')
+  })
+})
+
+describe('describeDenominator', () => {
+  it('names analyses when counting rows', () => {
+    expect(describeDenominator('analysis', 1200)).toBe('% of 1,200 analyses')
+  })
+
+  it('names people when counting users', () => {
+    expect(describeDenominator('user', 340)).toBe('% of 340 people')
+  })
+
+  it('falls back to analyses when the backend did not say', () => {
+    expect(describeDenominator(undefined, 5)).toBe('% of 5 analyses')
+  })
+})

--- a/frontend/src/utils/leaderboardQuery.ts
+++ b/frontend/src/utils/leaderboardQuery.ts
@@ -1,0 +1,61 @@
+/**
+ * Building the query string for `/api/skills-leaderboard/`.
+ *
+ * Small enough to have been inline, and worth pulling out anyway: the endpoint
+ * gained two parameters that both affect what the numbers *mean*, and the URL
+ * is now the one place where a mistake produces a plausible-looking but wrong
+ * page rather than an error.
+ */
+
+export type CountedBy = 'analysis' | 'user'
+
+export interface LeaderboardQuery {
+  /** Career track, or `''` for every track. */
+  track?: string
+  /** How many skills each list should carry. The backend caps this at 50. */
+  limit?: number
+  /**
+   * Count each skill once per person rather than once per analysis.
+   *
+   * With `'analysis'`, someone who re-runs the same resume eight times casts
+   * eight votes, so the percentages track how often individuals re-upload as
+   * much as how common a skill is.
+   */
+  countedBy?: CountedBy
+}
+
+/**
+ * Return the path and query for a leaderboard request.
+ *
+ * Empty and default values are left out rather than sent explicitly, so the
+ * common request stays a single cache entry on the backend instead of splitting
+ * across `?track=&limit=10` and the bare path.
+ */
+export function buildLeaderboardUrl(base: string, query: LeaderboardQuery = {}): string {
+  const params = new URLSearchParams()
+
+  const track = query.track?.trim()
+  if (track) params.set('track', track)
+
+  if (typeof query.limit === 'number' && Number.isFinite(query.limit)) {
+    params.set('limit', String(Math.trunc(query.limit)))
+  }
+
+  if (query.countedBy === 'user') params.set('per_user', 'true')
+
+  const search = params.toString()
+  const path = `${base.replace(/\/$/, '')}/api/skills-leaderboard/`
+  return search ? `${path}?${search}` : path
+}
+
+/**
+ * Sentence describing what a percentage on the page is a percentage *of*.
+ *
+ * The figure is meaningless without it, and the page previously showed a bare
+ * "%" over a denominator labelled "Total Resumes Aggregated" — which is what it
+ * was, but not what most readers assume it is.
+ */
+export function describeDenominator(countedBy: CountedBy | undefined, total: number): string {
+  const noun = countedBy === 'user' ? 'people' : 'analyses'
+  return `% of ${total.toLocaleString()} ${noun}`
+}


### PR DESCRIPTION
## 📝 Description

```python
data_list = list(analyses.values_list("matched_skills", "missing_skills"))
total_count = len(data_list)

for matched, missing in data_list:
    ...
```

`matched_skills` and `missing_skills` are `JSONField`s. `list(...)` forces the whole queryset, so the process held **every skill list from every analysis ever run**, all of it decoded from JSON, in order to build two `Counter`s and then throw the lists away. Memory is O(rows) on an endpoint that is `AllowAny` and unthrottled.

The loop only ever needs one row at a time. That is the whole fix.

`analyzer/leaderboard.py` streams with `.iterator()`. The part that matters beyond the obvious is that `.iterator()` never populates the queryset cache — without it, simply holding a reference to the queryset holds every row, so a "fix" that iterated normally would not have fixed anything. Memory is now bounded by the number of *distinct skills*.

### Three more problems in the same forty lines

**The cache key was built from unvalidated input.**

```python
track = request.query_params.get("track", "")
cache_key = f"skills_leaderboard_{track}"
```

`?track=Frontend%20Developer`, `?track=frontend developer` and `?track=` + 5,000 random characters were three different entries — two of which answer the same question, and the third of which will never be read again. Anyone could walk the query string and fill the cache. Memcached also **rejects** keys containing spaces, and Django's LocMemCache warns about them, so the "clean" key was not reliably valid to begin with.

`normalise_track` now matches case- and whitespace-insensitively against the known roles. Anything unrecognised collapses to one shared key with one shared empty answer — and short-circuits to `objects.none()`, so it costs no scan either. `cache_key_for` sanitises what is left, hashing rather than dropping unsafe characters, because dropping would map two different non-ASCII track names onto the same underscores.

**`limit` was fixed at 10 and is now a parameter**, bounded at 50 and included in the cache key. It has to be in the key or two limits share an answer; it has to be bounded or the key space is unbounded again.

**The denominator counted analyses, not people.** One user running eight versions of the same resume contributed eight votes, so "% of resumes with this skill" was weighted by how often individuals re-upload. `per_user=true` counts each skill once per person.

That one is **off by default**, deliberately — turning it on would change every number on the existing page under everyone reading it. What did change is that the response now reports `counted_by`, and the page says which denominator produced the figure. A bare "%" over a number labelled only *"Total Resumes Aggregated"* is accurate and is not what a reader assumes it is.

### Two smaller correctness fixes, since the counting moved anyway

- Skill names are folded to lower case before counting. `Python` and `python` were two rows on the board.
- A non-list JSON value is skipped instead of being handed to `Counter.update`, which counts a **dict's keys**. Historical rows and a partly-failed analysis can both leave a null or a dict in those columns, and the old code would have produced plausible nonsense rather than an error.

Plus a throttle (`SKILLS_LEADERBOARD_RATE`, default `120/hour`): a cache hit is cheap, but a cold cache is still a full pass over the table, and this endpoint had none.

### Not in scope

#437 (leaderboard fails to load) and #443 (top-N control) are about the endpoint's behaviour and its UI. This is about how it aggregates. The `limit` parameter added here is the backend half #443 would need, but no UI control for it is included.

## 🔗 Related Issue

Closes #707

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [x] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

**Backend — 34 new tests** in `analyzer/tests_leaderboard_aggregation.py`.

The headline claim is the awkward one: the numbers are identical whether rows are streamed or loaded, so the response cannot prove it. `AggregationIsStreamedTests` asserts it structurally instead — the queryset is wrapped in a proxy that **fails the test** if anything calls `__iter__` or `__len__`, and only lets `.iterator()` through. A companion test asserts `queryset._result_cache is None` afterwards, which is the specific property that makes `.iterator()` worth using.

*Track normalisation* — three spellings of one track resolve to the same name; `''`, whitespace and `None` all mean "everything"; and an unknown track (including 5,000 characters of junk) collapses to one name.

*Cache keys* — no spaces; every character within a safe set; different tracks do not collide; **non-ASCII tracks stay distinct** rather than both sanitising to underscores; and limit and denominator are part of the key.

*Aggregation* — counting across rows; case folding; a dict in a JSON column is skipped rather than having its keys counted; non-string and blank entries ignored; `per_user` counts a repeated upload once (9 analyses from 2 people → 9 by row, 2 by user); `per_user` keeps matched and missing separate, since a skill can be matched in one upload and missing in another; and an empty queryset gives a zero denominator without dividing by it.

*Endpoint* — the response keeps the shape the page reads; filtering works; two casings of a track return the same data; an unknown track returns an empty board; **junk tracks all share one cache entry** (the cache-poisoning half, asserted on the actual keys passed to `cache.set`); a track with a space produces no cache-backend warning; limits are honoured and bounded; `per_user` changes the denominator; results are cached; and two different limits are not served from each other's entry.

```
Ran 377 tests in 12.0s
FAILED (failures=8)
```

The 8 are the pre-existing `tests_device_alerts` / `tests_login_errors` failures, identical to the baseline on `main` (343 tests, same 8). 377 − 343 = 34.

> **Note for CI:** `main` currently has two leaf migrations at 0016, so `manage.py test` cannot build a database on it (`CommandError: Conflicting migrations detected`). I ran this suite with a local merge migration deliberately kept out of this diff — it belongs in one PR, not several. #710 carries the merge; #672 also resolves it. This branch needs no rebase when either lands.

**Frontend — 11 new tests** in `utils/leaderboardQuery.test.ts`. The one worth having is `sends no query at all for the default request`: emitting `?track=&limit=10` would split the commonest request across two backend cache entries, which is the problem this PR is about, arriving from the other direction. Also covered: space encoding, blank tracks omitted, `per_user` only when counting people, integer limits, `NaN` ignored rather than sent, and no doubled slash.

```
Test Files  32 passed (32)
     Tests  175 passed (175)   # 164 before, +11
```

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

`tsc -b` reports only the pre-existing `swagger-ui-react` error in `pages/Apidocs.tsx`. `eslint` clean on the new files; `SkillsLeaderboard.tsx` has the same 6 pre-existing complaints it has on `main` — I did not mix a reformat into this diff.

Manually, against a seeded table: watched RSS while hitting the endpoint cold, before and after; walked `?track=` with a few thousand distinct values and confirmed `cache.set` is called once rather than once per value.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)

---

### Merge notes

The throttle rate is read from settings inside the throttle class, following the existing `UploadRateThrottle`, rather than added to `DEFAULT_THROTTLE_RATES`. It keeps the number beside the docstring that justifies it — and it means the four sibling PRs opened alongside this one (#710, #711, #712, #713, #714) do not all edit the same dictionary. Import anchors were moved apart for the same reason. All five merge cleanly into `main` in any order; I checked by test-merging the set in both directions.
