### PR TITLE
fix: let database-managed career tracks actually affect scoring (#708)

### DIFF
--- a/backend/analyzer/admin.py
+++ b/backend/analyzer/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import SuggestionFeedback
+from .models import Role, Skill, SuggestionFeedback
 
 
 @admin.register(SuggestionFeedback)
@@ -35,3 +35,51 @@ class SuggestionFeedbackAdmin(admin.ModelAdmin):
     def has_add_permission(self, request):
         # Feedback comes from users through the API, not from the admin.
         return False
+
+
+@admin.register(Skill)
+class SkillAdmin(admin.ModelAdmin):
+    """The skill vocabulary the career tracks are built from.
+
+    Registered because it was not. ``Role`` and ``Skill`` have been in the model
+    layer since ``0011_role_skills_schema`` with no admin, so the only way to
+    change a track's requirements was a shell session — and until #708 the
+    analyzer ignored the result anyway. Now that the database is authoritative,
+    the store has to be reachable.
+    """
+
+    list_display = ("name", "role_count")
+    search_fields = ("name",)
+    ordering = ("name",)
+
+    def get_queryset(self, request):
+        # Without this the role count is one query per row.
+        return super().get_queryset(request).prefetch_related("roles")
+
+    @admin.display(description="Used by roles")
+    def role_count(self, obj):
+        return obj.roles.count()
+
+
+@admin.register(Role)
+class RoleAdmin(admin.ModelAdmin):
+    """A career track and the skills it requires.
+
+    Editing skills here changes what analyses are scored against, for every
+    experience level. The packaged defaults in ``services.EXPERIENCE_LEVEL_SKILLS``
+    are only consulted for roles this table does not have, so adding a role here
+    takes it over completely rather than merging with the defaults —
+    ``analyzer.role_skills`` explains why that is deliberate.
+    """
+
+    list_display = ("name", "skill_count")
+    search_fields = ("name",)
+    ordering = ("name",)
+    filter_horizontal = ("skills",)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).prefetch_related("skills")
+
+    @admin.display(description="Required skills")
+    def skill_count(self, obj):
+        return obj.skills.count()

--- a/backend/analyzer/role_skills.py
+++ b/backend/analyzer/role_skills.py
@@ -1,0 +1,374 @@
+"""Which skills a career track requires, and which store answers that question.
+
+There are two stores, and until now the one nobody can edit won.
+
+``services.EXPERIENCE_LEVEL_SKILLS`` is a dictionary in a Python module.
+``Role`` / ``Skill`` are tables, seeded by migration ``0012_populate_role_skills``
+and kept fresh by cache-invalidating signals in ``models.py``. The resolver
+looked at the dictionary first:
+
+.. code-block:: python
+
+    level_dict = EXPERIENCE_LEVEL_SKILLS.get(norm_level, {})
+    if target_role in level_dict:
+        return level_dict[target_role]          # <- database never consulted
+    return get_role_skills().get(target_role, [])
+
+For the only three roles the product ships — Frontend Developer, Backend
+Developer, Data Analyst — the dictionary always matched, so the database branch
+was dead code. Editing a ``Role``'s skills changed nothing: the m2m signal
+cleared the cache correctly, ``get_role_skills()`` re-read the table correctly,
+and the result was discarded one line later.
+
+That matters now rather than in the abstract, because #545 and #546 both propose
+an admin UI over exactly those tables. Built on the old resolver, that UI would
+be a no-op for every role a user can pick.
+
+The obvious fix is wrong
+------------------------
+"Read the database first, fall back to the packaged defaults" loses experience
+levels. The ``Role`` table has **no level column** — it holds one skill list per
+role — and ``0012`` seeded it with the *Mid-Level* lists. So a database-first
+resolver answers the Mid-Level set at every level, and a Junior resume is
+suddenly measured against Senior requirements. The existing
+``ExperienceLevelTests`` catch exactly that, which is how I found it.
+
+What actually holds
+-------------------
+The two stores answer different questions, and neither is redundant:
+
+* the **database** says *which skills this role needs* — the thing an operator
+  edits, and the thing that was being ignored;
+* the packaged **level tiers** say *how a role's requirements move with
+  seniority* — expressed nowhere in the schema, and not something an operator
+  can currently state.
+
+So a level is treated as a **delta from Mid-Level**, derived from the packaged
+data rather than hand-maintained:
+
+.. code-block:: text
+
+    added   = EXPERIENCE_LEVEL_SKILLS[level][role] - EXPERIENCE_LEVEL_SKILLS["Mid-Level"][role]
+    removed = EXPERIENCE_LEVEL_SKILLS["Mid-Level"][role] - EXPERIENCE_LEVEL_SKILLS[level][role]
+
+and the result is ``(baseline - removed) | added``, where ``baseline`` is the
+database's list when it has the role and the packaged Mid-Level list otherwise.
+
+Two properties fall out of that, and both are tested:
+
+1. On an untouched install the baseline *is* the Mid-Level list, so every level
+   resolves to exactly the packaged list it always did. Nothing moves.
+2. An operator who adds ``rust`` to Backend Developer gets it at all three
+   levels, because it appears in no level's ``removed`` set — and one who
+   removes ``webpack`` loses it at all three, for the same reason.
+
+The limitation this leaves
+--------------------------
+An operator still cannot say "Docker, but only from Senior". That needs a level
+dimension on ``Role``, which is a schema change and belongs with the admin UI
+work in #545/#546 rather than in a bug fix. Naming it here so the next person
+does not read the delta machinery as the intended end state.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Sequence, Tuple
+
+#: Canonical experience levels, in order of seniority.
+JUNIOR = "Junior"
+MID_LEVEL = "Mid-Level"
+SENIOR = "Senior"
+
+LEVELS = (JUNIOR, MID_LEVEL, SENIOR)
+
+#: The level the packaged deltas are measured from, and the one assumed when
+#: nothing recognisable was supplied. Mid-Level on both counts because it is the
+#: middle of the range: reading an unknown level as Junior or Senior is wrong by
+#: two steps half the time, and by one step this way.
+BASELINE_LEVEL = MID_LEVEL
+DEFAULT_LEVEL = MID_LEVEL
+
+#: Words that identify a level, checked as substrings because callers send
+#: things like "Senior / Staff Engineer" and "Entry level".
+#:
+#: Ordered most specific first, so adding a keyword that is a substring of
+#: another stays safe.
+LEVEL_KEYWORDS = (
+    (JUNIOR, ("junior", "entry", "intern", "graduate", "trainee", "associate")),
+    (SENIOR, ("senior", "lead", "staff", "principal", "architect", "head of", "director")),
+    (MID_LEVEL, ("mid", "intermediate", "regular")),
+)
+
+#: Where a baseline came from. Reported alongside the list because the two
+#: stores can disagree and a reader needs to know which one they are looking at.
+SOURCE_DATABASE = "database"
+SOURCE_DEFAULTS = "packaged-defaults"
+SOURCE_NONE = "none"
+
+
+@dataclass(frozen=True)
+class RoleSkillSet:
+    """A resolved skill list, with its provenance.
+
+    Attributes:
+        role: The role as resolved, canonically cased.
+        level: The canonical level actually used for scoring.
+        skills: Required skills, lower-cased and de-duplicated, order preserved.
+        source: Which store supplied the baseline — one of
+            :data:`SOURCE_DATABASE`, :data:`SOURCE_DEFAULTS`, :data:`SOURCE_NONE`.
+        level_adjusted: Whether a level delta was applied on top of the
+            baseline. ``False`` for a database-only role, which has no packaged
+            tiers to move it.
+        level_recognised: ``False`` when the caller's level was not understood
+            and :data:`DEFAULT_LEVEL` was substituted. The caller decides what to
+            do about it; this only refuses to hide it.
+        level_as_requested: Exactly what the caller sent, so a response can
+            report both what was asked for and what was used.
+    """
+
+    role: str
+    level: str
+    skills: List[str] = field(default_factory=list)
+    source: str = SOURCE_NONE
+    level_adjusted: bool = False
+    level_recognised: bool = True
+    level_as_requested: str = ""
+
+    def as_dict(self):
+        return {
+            "role": self.role,
+            "level": self.level,
+            "level_as_requested": self.level_as_requested,
+            "level_recognised": self.level_recognised,
+            "level_adjusted": self.level_adjusted,
+            "skills": list(self.skills),
+            "source": self.source,
+        }
+
+
+def normalise_level(raw) -> Tuple[str, bool]:
+    """Return ``(level, recognised)`` for a caller-supplied experience level.
+
+    ``recognised`` is the point of this function. The previous version returned
+    only the level, so "we understood you" and "we gave up and picked the
+    middle" were the same answer — and ``"Principal"`` was scored as Mid-Level
+    while the response echoed ``"Principal"`` straight back.
+
+    >>> normalise_level("Senior Engineer")
+    ('Senior', True)
+    >>> normalise_level("Principal")
+    ('Senior', True)
+    >>> normalise_level("Wizard")
+    ('Mid-Level', False)
+    >>> normalise_level(None)
+    ('Mid-Level', False)
+    """
+    if not isinstance(raw, str):
+        return DEFAULT_LEVEL, False
+
+    text = raw.strip().lower()
+    if not text:
+        return DEFAULT_LEVEL, False
+
+    # An exact canonical name should not depend on keyword matching.
+    for level in LEVELS:
+        if text == level.lower():
+            return level, True
+
+    for level, keywords in LEVEL_KEYWORDS:
+        if any(keyword in text for keyword in keywords):
+            return level, True
+
+    return DEFAULT_LEVEL, False
+
+
+def normalise_skills(skills: Sequence) -> List[str]:
+    """Lower-case, trim and de-duplicate a skill list, preserving order.
+
+    The two stores are populated by different routes — a migration now, an admin
+    form later — so their casing and spacing will not agree. Matching is
+    case-insensitive downstream, but the list is also counted, echoed into
+    suggestions and compared between roles, so normalising once here keeps
+    ``Docker`` and ``docker`` from behaving like two requirements.
+    """
+    seen = set()
+    result = []
+
+    for skill in skills or ():
+        if not isinstance(skill, str):
+            continue
+        name = skill.strip().lower()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        result.append(name)
+
+    return result
+
+
+def canonical_role(raw, known: Sequence[str]) -> str:
+    """Return ``raw`` matched case-insensitively against ``known``.
+
+    Returns the caller's string unchanged when nothing matches, so an unknown
+    role reaches the "no skills for this role" path rather than being silently
+    rewritten to one that does exist.
+    """
+    if not isinstance(raw, str):
+        return ""
+
+    text = raw.strip()
+    if not text:
+        return ""
+
+    for name in known:
+        if isinstance(name, str) and name.strip().lower() == text.lower():
+            return name
+
+    return text
+
+
+def _lookup(mapping: Dict[str, Sequence[str]], role: str):
+    """Case-insensitive lookup, so the two stores need not agree on casing."""
+    if role in mapping:
+        return mapping[role]
+
+    folded = role.strip().lower()
+    for name, value in mapping.items():
+        if isinstance(name, str) and name.strip().lower() == folded:
+            return value
+
+    return None
+
+
+def level_delta(role, level, default_roles_by_level) -> Tuple[List[str], set]:
+    """Return ``(added, removed)`` for ``role`` at ``level``, against Mid-Level.
+
+    Derived from the packaged data rather than written out by hand, so the tiers
+    cannot drift away from the lists they are supposed to describe.
+
+    ``added`` is a list to keep its order stable in the resolved output;
+    ``removed`` is a set because nothing iterates it.
+
+    Both are empty when the role has no packaged tiers — a role that exists only
+    in the database has nothing to move it, and inventing a movement from
+    another role's tiers would be worse than not varying by level.
+    """
+    baseline = _lookup(default_roles_by_level.get(BASELINE_LEVEL, {}), role)
+    at_level = _lookup(default_roles_by_level.get(level, {}), role)
+
+    if baseline is None or at_level is None:
+        return [], set()
+
+    baseline_skills = normalise_skills(baseline)
+    level_skills = normalise_skills(at_level)
+    baseline_set = set(baseline_skills)
+    level_set = set(level_skills)
+
+    added = [skill for skill in level_skills if skill not in baseline_set]
+    removed = baseline_set - level_set
+
+    return added, removed
+
+
+def apply_level(baseline: Sequence[str], added: Sequence[str], removed) -> List[str]:
+    """Return ``baseline`` with ``removed`` dropped and ``added`` appended.
+
+    Order follows the baseline, with additions appended. Which order that is
+    depends on which store answered — the packaged lists are in their written
+    order, the database's are sorted — but it is *stable* either way, which is
+    what matters: the list is shown to the user and each entry is worth one over
+    its length, so two runs of the same resume must read the same way.
+    """
+    result = [skill for skill in normalise_skills(baseline) if skill not in removed]
+    known = set(result)
+
+    for skill in normalise_skills(added):
+        if skill not in known:
+            known.add(skill)
+            result.append(skill)
+
+    return result
+
+
+def resolve(
+    role,
+    level,
+    database_roles: Dict[str, Sequence[str]],
+    default_roles_by_level: Dict[str, Dict[str, Sequence[str]]],
+) -> RoleSkillSet:
+    """Resolve the required skills for one role at one level.
+
+    Args:
+        role: Role name as supplied by the caller.
+        level: Experience level as supplied by the caller.
+        database_roles: ``{role_name: [skill, ...]}`` from the ``Role`` table.
+            Passed in rather than queried, so this module is testable without a
+            database and the dependency runs one way.
+        default_roles_by_level: ``{level: {role_name: [skill, ...]}}`` — the
+            packaged tiers.
+
+    Returns:
+        A :class:`RoleSkillSet`, always. An unknown role gives an empty list
+        with :data:`SOURCE_NONE` rather than raising: an unrecognised role is
+        something a user can type, not an exceptional condition.
+    """
+    known = list(database_roles.keys()) + [
+        name for level_map in default_roles_by_level.values() for name in level_map
+    ]
+    canonical = canonical_role(role, known)
+    resolved_level, recognised = normalise_level(level)
+    requested = level if isinstance(level, str) else ""
+
+    baseline = _lookup(database_roles, canonical)
+    source = SOURCE_DATABASE
+
+    if not baseline:
+        baseline = _lookup(default_roles_by_level.get(BASELINE_LEVEL, {}), canonical)
+        source = SOURCE_DEFAULTS
+
+    if not baseline:
+        return RoleSkillSet(
+            role=canonical,
+            level=resolved_level,
+            skills=[],
+            source=SOURCE_NONE,
+            level_recognised=recognised,
+            level_as_requested=requested,
+        )
+
+    added, removed = level_delta(canonical, resolved_level, default_roles_by_level)
+
+    return RoleSkillSet(
+        role=canonical,
+        level=resolved_level,
+        skills=apply_level(baseline, added, removed),
+        source=source,
+        level_adjusted=bool(added or removed),
+        level_recognised=recognised,
+        level_as_requested=requested,
+    )
+
+
+def known_roles(
+    database_roles: Dict[str, Sequence[str]],
+    default_roles_by_level: Dict[str, Dict[str, Sequence[str]]],
+) -> List[str]:
+    """Every role either store knows about, database names winning on casing.
+
+    ``analyze_resume`` builds its track comparison by iterating the roles it
+    knows. It used to iterate only the database's, so a deployment whose
+    ``Role`` table had never been seeded produced an empty comparison table
+    while still scoring the requested role perfectly well from the packaged
+    defaults — two different answers to "which roles exist" in one response.
+    """
+    names = [name for name in database_roles if isinstance(name, str)]
+    lowered = {name.strip().lower() for name in names}
+
+    for level_map in default_roles_by_level.values():
+        for name in level_map:
+            if not isinstance(name, str):
+                continue
+            if name.strip().lower() not in lowered:
+                lowered.add(name.strip().lower())
+                names.append(name)
+
+    return names

--- a/backend/analyzer/services.py
+++ b/backend/analyzer/services.py
@@ -4,6 +4,7 @@ import docx
 import textstat
 from django.contrib.auth import get_user_model
 from .models import ResumeAnalysis
+from . import role_skills
 from .skill_matcher import extract_skills, match_skills_with_partial
 from .scoring import compute_score_breakdown
 from resume_analyzer.quantify_checker import flag_unquantified_bullets
@@ -58,36 +59,57 @@ def get_role_skills():
         from .models import Role
         role_skills = {}
         for role in Role.objects.prefetch_related("skills").all():
-            role_skills[role.name] = [skill.name for skill in role.skills.all()]
+            # Sorted because the m2m read has no ordering of its own, so two
+            # calls could return the same skills in different orders. The list
+            # is shown to the user and each entry is worth 1/len of the score,
+            # so an unstable order makes two runs of one resume read
+            # differently for no reason. Sorted in Python rather than with
+            # order_by(), which would defeat the prefetch above.
+            role_skills[role.name] = sorted(skill.name for skill in role.skills.all())
         cache.set("role_skills_dict", role_skills, timeout=60*60*24)
     return role_skills
 
-def get_role_skills_for_level(target_role, experience_level="Mid-Level"):
-    norm_level = "Mid-Level"
-    if experience_level:
-        el_lower = str(experience_level).strip().lower()
-        if "junior" in el_lower or "entry" in el_lower:
-            norm_level = "Junior"
-        elif "senior" in el_lower or "lead" in el_lower or "staff" in el_lower:
-            norm_level = "Senior"
-        else:
-            norm_level = "Mid-Level"
+def resolve_role_skills(target_role, experience_level="Mid-Level"):
+    """Resolve a role's required skills, database first.
 
-    level_dict = EXPERIENCE_LEVEL_SKILLS.get(norm_level, {})
-    if target_role in level_dict:
-        return level_dict[target_role]
-    return get_role_skills().get(target_role, [])
+    Returns a :class:`~analyzer.role_skills.RoleSkillSet` — the list plus which
+    store answered and whether the requested level was understood.
+
+    This used to check ``EXPERIENCE_LEVEL_SKILLS`` first and only fall through
+    to the database for roles the dictionary did not have. Since the dictionary
+    covers every role the product ships, the database branch never ran, and
+    editing a ``Role``'s skills had no effect on anything. See #708 and
+    ``analyzer.role_skills`` for why the precedence is the other way round.
+    """
+    return role_skills.resolve(
+        role=target_role,
+        level=experience_level,
+        database_roles=get_role_skills(),
+        default_roles_by_level=EXPERIENCE_LEVEL_SKILLS,
+    )
+
+
+def get_role_skills_for_level(target_role, experience_level="Mid-Level"):
+    """Required skills for a role at a level, as a plain list.
+
+    Kept as the narrow form because most callers only want the list. Use
+    :func:`resolve_role_skills` where the provenance matters.
+    """
+    return resolve_role_skills(target_role, experience_level).skills
+
+
+def get_known_roles():
+    """Every role either store knows about.
+
+    ``analyze_resume`` used to build its track comparison from the database
+    alone, so an unseeded ``Role`` table produced an empty comparison while the
+    requested role still scored fine from the packaged defaults.
+    """
+    return role_skills.known_roles(get_role_skills(), EXPERIENCE_LEVEL_SKILLS)
+
 
 def generate_level_tailored_suggestions(missing_skills, experience_level="Mid-Level", target_role=""):
-    norm_level = "Mid-Level"
-    if experience_level:
-        el_lower = str(experience_level).strip().lower()
-        if "junior" in el_lower or "entry" in el_lower:
-            norm_level = "Junior"
-        elif "senior" in el_lower or "lead" in el_lower or "staff" in el_lower:
-            norm_level = "Senior"
-        else:
-            norm_level = "Mid-Level"
+    norm_level, _ = role_skills.normalise_level(experience_level)
 
     suggestions = []
     if norm_level == "Senior":
@@ -430,8 +452,10 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
 
     if job_description and job_description.strip():
         required = extract_skills(job_description)
+        role_skill_set = None
     else:
-        required = get_role_skills_for_level(target_role, experience_level)
+        role_skill_set = resolve_role_skills(target_role, experience_level)
+        required = role_skill_set.skills
 
     matched, partial, missing = match_skills_with_partial(required, raw_text, detected)
 
@@ -494,9 +518,14 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
         "stages": PIPELINE_STAGES,
     }
 
+    # Every role either store knows about, not just the database's. An unseeded
+    # `Role` table used to produce an empty comparison table while the requested
+    # role scored perfectly well from the packaged defaults -- two different
+    # answers to "which roles exist" in one response. See #708.
     track_comparisons = {}
-    for role, _ in get_role_skills().items():
-        role_req_skills = get_role_skills_for_level(role, experience_level)
+    for role in get_known_roles():
+        role_set = resolve_role_skills(role, experience_level)
+        role_req_skills = role_set.skills
         role_matched, role_partial, role_missing = match_skills_with_partial(role_req_skills, raw_text, detected)
         role_credit = len(role_matched) + (0.5 * len(role_partial))
         role_score = (
@@ -505,13 +534,17 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
             else min(len(detected) * 10, 100)
         )
         role_suggestions = generate_level_tailored_suggestions(role_missing, experience_level, role)
-        
+
         track_comparisons[role] = {
             "score": role_score,
             "matched_skills": role_matched,
             "partial_skills": role_partial,
             "missing_skills": role_missing,
             "suggestions": role_suggestions,
+            # Which store answered for this row. Two rows in one table can come
+            # from different sources, and a score whose provenance is invisible
+            # is one nobody can debug.
+            "skills_source": role_set.source,
         }
 
     quantify_nudges = flag_unquantified_bullets(raw_text.split('\n'))
@@ -545,6 +578,21 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
         "missing_skills": missing,
         "target_role": target_role,
         "experience_level": experience_level or "Mid-Level",
+        # What the scoring actually used, and where the requirements came from.
+        # The response used to echo back whatever level the caller sent while
+        # scoring against a different one -- "Principal" was silently read as
+        # Mid-Level and nothing said so. See #708.
+        "role_skills": role_skill_set.as_dict() if role_skill_set else {
+            "role": target_role,
+            "level": role_skills.normalise_level(experience_level)[0],
+            "level_as_requested": experience_level if isinstance(experience_level, str) else "",
+            "level_recognised": role_skills.normalise_level(experience_level)[1],
+            "skills": list(required),
+            # A pasted job description overrides both stores, which is the
+            # documented behaviour and worth naming rather than leaving the
+            # caller to infer it from an absent field.
+            "source": "job-description",
+        },
         "resume_text": raw_text,
         "cover_letter_text": cover_letter_text if cover_letter_text else None,
         "cover_letter_feedback": cover_letter_feedback,

--- a/backend/analyzer/tests_role_skills.py
+++ b/backend/analyzer/tests_role_skills.py
@@ -1,0 +1,417 @@
+"""Tests for career-track skill resolution (#708).
+
+Two claims are being made, and they pull against each other, which is why the
+first attempt at this fix was wrong:
+
+* **database edits must take effect** — they were being discarded;
+* **experience levels must keep working** — a naive "database first" resolver
+  answers the Mid-Level list at every level, because ``Role`` has no level
+  column and ``0012`` seeded it with the Mid-Level lists.
+
+`UntouchedInstallTests` pins the second and `DatabaseEditsTakeEffectTests` pins
+the first. Most of the file needs no database: ``resolve`` takes both stores as
+arguments precisely so it can be exercised as a function.
+"""
+
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import TestCase
+
+from analyzer import role_skills
+from analyzer.role_skills import (
+    DEFAULT_LEVEL,
+    JUNIOR,
+    MID_LEVEL,
+    SENIOR,
+    SOURCE_DATABASE,
+    SOURCE_DEFAULTS,
+    SOURCE_NONE,
+    apply_level,
+    canonical_role,
+    known_roles,
+    level_delta,
+    normalise_level,
+    normalise_skills,
+    resolve,
+)
+from analyzer.services import EXPERIENCE_LEVEL_SKILLS, get_role_skills, resolve_role_skills
+
+class RoleSkillTestCase(TestCase):
+    """Base class that clears the role-skill cache around each test.
+
+    ``get_role_skills()`` memoises the ``Role`` table in the process cache for a
+    day. ``TestCase`` rolls the *database* back between tests but not the cache,
+    so a test that edits a role and then reads it leaves the edited list cached
+    for whatever runs next — and the failure lands in the innocent test.
+
+    Clearing on both sides of the test rather than only before it, so this class
+    also cannot leave a mess for a test that does not inherit from it.
+    """
+
+    ROLE_SKILL_CACHE_KEY = "role_skills_dict"
+
+    def setUp(self):
+        super().setUp()
+        cache.delete(self.ROLE_SKILL_CACHE_KEY)
+
+    def tearDown(self):
+        cache.delete(self.ROLE_SKILL_CACHE_KEY)
+        super().tearDown()
+
+
+#: A miniature pair of stores, so the tests are not reading the real dictionary
+#: and cannot be broken by an unrelated edit to it.
+DEFAULTS = {
+    JUNIOR: {"Widget Engineer": ["python", "git"]},
+    MID_LEVEL: {"Widget Engineer": ["python", "git", "docker", "sql"]},
+    SENIOR: {"Widget Engineer": ["python", "git", "docker", "sql", "leadership"]},
+}
+
+
+class NormaliseLevelTests(TestCase):
+    def test_canonical_names_resolve_exactly(self):
+        for level in (JUNIOR, MID_LEVEL, SENIOR):
+            with self.subTest(level=level):
+                self.assertEqual(normalise_level(level), (level, True))
+
+    def test_common_phrasings_resolve(self):
+        cases = {
+            "Senior Engineer": SENIOR,
+            "Staff Software Engineer": SENIOR,
+            "Tech Lead": SENIOR,
+            "Principal": SENIOR,
+            "Entry level": JUNIOR,
+            "Intern": JUNIOR,
+            "Graduate": JUNIOR,
+            "Intermediate": MID_LEVEL,
+        }
+        for raw, expected in cases.items():
+            with self.subTest(raw=raw):
+                self.assertEqual(normalise_level(raw), (expected, True))
+
+    def test_an_unrecognised_level_says_so(self):
+        """The whole point: "understood" and "gave up" used to be one answer."""
+        level, recognised = normalise_level("Wizard")
+
+        self.assertEqual(level, DEFAULT_LEVEL)
+        self.assertFalse(recognised)
+
+    def test_missing_and_non_string_levels_are_not_recognised(self):
+        for raw in (None, "", "   ", 42, ["Senior"]):
+            with self.subTest(raw=raw):
+                self.assertEqual(normalise_level(raw), (DEFAULT_LEVEL, False))
+
+    def test_principal_is_no_longer_scored_as_mid_level(self):
+        """It was, and the response echoed "Principal" back while doing it."""
+        self.assertEqual(normalise_level("Principal")[0], SENIOR)
+
+
+class NormaliseSkillsTests(TestCase):
+    def test_case_and_whitespace_are_folded(self):
+        self.assertEqual(normalise_skills([" Docker ", "docker", "DOCKER"]), ["docker"])
+
+    def test_order_is_preserved(self):
+        self.assertEqual(normalise_skills(["sql", "python", "git"]), ["sql", "python", "git"])
+
+    def test_blanks_and_non_strings_are_dropped(self):
+        self.assertEqual(normalise_skills(["python", "", "  ", None, 7]), ["python"])
+
+    def test_none_is_an_empty_list(self):
+        self.assertEqual(normalise_skills(None), [])
+
+
+class CanonicalRoleTests(TestCase):
+    def test_casing_is_corrected_against_the_known_set(self):
+        self.assertEqual(canonical_role("backend developer", ["Backend Developer"]), "Backend Developer")
+
+    def test_an_unknown_role_is_returned_unchanged(self):
+        """Rewriting it to a role that does exist would be worse than not matching."""
+        self.assertEqual(canonical_role("Astronaut", ["Backend Developer"]), "Astronaut")
+
+    def test_blank_and_non_string_roles(self):
+        self.assertEqual(canonical_role("", ["Backend Developer"]), "")
+        self.assertEqual(canonical_role(None, ["Backend Developer"]), "")
+
+
+class LevelDeltaTests(TestCase):
+    def test_a_senior_delta_adds(self):
+        added, removed = level_delta("Widget Engineer", SENIOR, DEFAULTS)
+
+        self.assertEqual(added, ["leadership"])
+        self.assertEqual(removed, set())
+
+    def test_a_junior_delta_removes(self):
+        added, removed = level_delta("Widget Engineer", JUNIOR, DEFAULTS)
+
+        self.assertEqual(added, [])
+        self.assertEqual(removed, {"docker", "sql"})
+
+    def test_the_baseline_level_has_no_delta(self):
+        self.assertEqual(level_delta("Widget Engineer", MID_LEVEL, DEFAULTS), ([], set()))
+
+    def test_a_role_with_no_packaged_tiers_has_no_delta(self):
+        """Borrowing another role's tiers would invent requirements."""
+        self.assertEqual(level_delta("Astronaut", SENIOR, DEFAULTS), ([], set()))
+
+    def test_a_delta_can_both_add_and_remove(self):
+        """Backend Junior really does add `javascript` while dropping several."""
+        added, removed = level_delta("Backend Developer", JUNIOR, EXPERIENCE_LEVEL_SKILLS)
+
+        self.assertIn("javascript", added)
+        self.assertIn("django", removed)
+
+
+class ApplyLevelTests(TestCase):
+    def test_removals_then_additions(self):
+        self.assertEqual(
+            apply_level(["python", "git", "docker"], ["leadership"], {"docker"}),
+            ["python", "git", "leadership"],
+        )
+
+    def test_an_addition_already_present_is_not_duplicated(self):
+        self.assertEqual(apply_level(["python"], ["python", "git"], set()), ["python", "git"])
+
+    def test_the_baseline_order_survives(self):
+        self.assertEqual(apply_level(["c", "b", "a"], [], set()), ["c", "b", "a"])
+
+
+class ResolvePrecedenceTests(TestCase):
+    """Which store answers, and what happens to the level."""
+
+    def test_the_database_supplies_the_baseline_when_it_has_the_role(self):
+        result = resolve("Widget Engineer", MID_LEVEL, {"Widget Engineer": ["rust"]}, DEFAULTS)
+
+        self.assertEqual(result.source, SOURCE_DATABASE)
+        self.assertEqual(result.skills, ["rust"])
+
+    def test_the_defaults_answer_when_the_database_does_not_have_the_role(self):
+        result = resolve("Widget Engineer", MID_LEVEL, {}, DEFAULTS)
+
+        self.assertEqual(result.source, SOURCE_DEFAULTS)
+        self.assertEqual(result.skills, ["python", "git", "docker", "sql"])
+
+    def test_an_empty_database_list_does_not_blank_the_role(self):
+        """A Role row with no skills attached is a half-finished edit, not an intent."""
+        result = resolve("Widget Engineer", MID_LEVEL, {"Widget Engineer": []}, DEFAULTS)
+
+        self.assertEqual(result.source, SOURCE_DEFAULTS)
+
+    def test_a_role_neither_store_knows_resolves_to_nothing(self):
+        result = resolve("Astronaut", MID_LEVEL, {}, DEFAULTS)
+
+        self.assertEqual(result.source, SOURCE_NONE)
+        self.assertEqual(result.skills, [])
+
+    def test_the_level_delta_applies_on_top_of_a_database_baseline(self):
+        """The property the whole design exists for."""
+        database = {"Widget Engineer": ["python", "git", "docker", "sql", "rust"]}
+
+        junior = resolve("Widget Engineer", JUNIOR, database, DEFAULTS)
+        senior = resolve("Widget Engineer", SENIOR, database, DEFAULTS)
+
+        self.assertEqual(junior.skills, ["python", "git", "rust"])
+        self.assertEqual(senior.skills, ["python", "git", "docker", "sql", "rust", "leadership"])
+
+    def test_a_database_only_role_is_not_level_adjusted(self):
+        result = resolve("Astronaut", SENIOR, {"Astronaut": ["orbit"]}, DEFAULTS)
+
+        self.assertEqual(result.skills, ["orbit"])
+        self.assertFalse(result.level_adjusted)
+
+    def test_the_requested_level_is_reported_alongside_the_one_used(self):
+        result = resolve("Widget Engineer", "Wizard", {}, DEFAULTS)
+
+        self.assertEqual(result.level, DEFAULT_LEVEL)
+        self.assertEqual(result.level_as_requested, "Wizard")
+        self.assertFalse(result.level_recognised)
+
+    def test_role_casing_is_matched_across_the_two_stores(self):
+        result = resolve("widget engineer", MID_LEVEL, {"Widget Engineer": ["rust"]}, DEFAULTS)
+
+        self.assertEqual(result.role, "Widget Engineer")
+        self.assertEqual(result.source, SOURCE_DATABASE)
+
+    def test_the_dict_form_carries_everything_a_response_needs(self):
+        payload = resolve("Widget Engineer", "Principal", {}, DEFAULTS).as_dict()
+
+        self.assertEqual(payload["level"], SENIOR)
+        self.assertEqual(payload["level_as_requested"], "Principal")
+        self.assertEqual(payload["source"], SOURCE_DEFAULTS)
+
+
+class KnownRolesTests(TestCase):
+    def test_both_stores_contribute(self):
+        names = known_roles({"Astronaut": ["orbit"]}, DEFAULTS)
+
+        self.assertIn("Astronaut", names)
+        self.assertIn("Widget Engineer", names)
+
+    def test_a_role_in_both_appears_once_with_the_database_casing(self):
+        names = known_roles({"widget engineer": ["rust"]}, DEFAULTS)
+
+        self.assertEqual(names, ["widget engineer"])
+
+    def test_an_unseeded_database_still_lists_the_packaged_roles(self):
+        """An empty Role table used to produce an empty track-comparison table."""
+        self.assertEqual(known_roles({}, DEFAULTS), ["Widget Engineer"])
+
+
+class UntouchedInstallTests(RoleSkillTestCase):
+    """Nothing may move for a deployment nobody has edited.
+
+    `0012` seeded `Role` with the Mid-Level lists, so this is the case a naive
+    database-first resolver silently breaks — and it is the case every existing
+    deployment is in.
+    """
+
+    def test_every_packaged_level_resolves_to_its_packaged_list(self):
+        database = get_role_skills()
+
+        for level, roles in EXPERIENCE_LEVEL_SKILLS.items():
+            for role, expected in roles.items():
+                with self.subTest(level=level, role=role):
+                    # Compared as sets: the database read is sorted while the
+                    # packaged lists are in their written order, and the score
+                    # is a ratio over the set. `test_resolution_is_stable`
+                    # covers the property that order does need to hold.
+                    self.assertEqual(
+                        set(resolve(role, level, database, EXPERIENCE_LEVEL_SKILLS).skills),
+                        set(normalise_skills(expected)),
+                    )
+
+    def test_resolution_is_stable_across_calls(self):
+        """An unstable order would make two runs of one resume read differently."""
+        first = resolve_role_skills("Backend Developer", SENIOR).skills
+        second = resolve_role_skills("Backend Developer", SENIOR).skills
+
+        self.assertEqual(first, second)
+
+    def test_no_skill_is_required_twice(self):
+        skills = resolve_role_skills("Backend Developer", SENIOR).skills
+
+        self.assertEqual(len(skills), len(set(skills)))
+
+    def test_the_seeded_database_supplies_the_baseline(self):
+        result = resolve_role_skills("Backend Developer", MID_LEVEL)
+
+        self.assertEqual(result.source, SOURCE_DATABASE)
+
+    def test_junior_still_expects_less_than_senior(self):
+        junior = resolve_role_skills("Backend Developer", JUNIOR).skills
+        senior = resolve_role_skills("Backend Developer", SENIOR).skills
+
+        self.assertLess(len(junior), len(senior))
+
+
+class DatabaseEditsTakeEffectTests(RoleSkillTestCase):
+    """The reported bug.
+
+    Before this change, every assertion in this class failed: the m2m signal
+    cleared the cache, `get_role_skills()` re-read the table, and the result was
+    discarded one line later.
+    """
+
+    def setUp(self):
+        from analyzer.models import Role, Skill
+
+        self.role = Role.objects.get(name="Backend Developer")
+        self.rust, _ = Skill.objects.get_or_create(name="rust")
+
+    def test_an_added_skill_becomes_a_requirement(self):
+        self.role.skills.add(self.rust)
+
+        self.assertIn("rust", resolve_role_skills("Backend Developer", MID_LEVEL).skills)
+
+    def test_an_added_skill_applies_at_every_level(self):
+        self.role.skills.add(self.rust)
+
+        for level in (JUNIOR, MID_LEVEL, SENIOR):
+            with self.subTest(level=level):
+                self.assertIn("rust", resolve_role_skills("Backend Developer", level).skills)
+
+    def test_a_removed_skill_stops_being_a_requirement(self):
+        from analyzer.models import Skill
+
+        self.role.skills.remove(Skill.objects.get(name="django"))
+
+        self.assertNotIn("django", resolve_role_skills("Backend Developer", MID_LEVEL).skills)
+
+    def test_a_new_role_is_scored_from_the_database_alone(self):
+        from analyzer.models import Role
+
+        role = Role.objects.create(name="Platform Engineer")
+        role.skills.add(self.rust)
+
+        result = resolve_role_skills("Platform Engineer", SENIOR)
+
+        self.assertEqual(result.source, SOURCE_DATABASE)
+        self.assertEqual(result.skills, ["rust"])
+
+    def test_a_new_role_joins_the_known_set(self):
+        from analyzer.models import Role
+        from analyzer.services import get_known_roles
+
+        Role.objects.create(name="Platform Engineer")
+
+        self.assertIn("Platform Engineer", get_known_roles())
+
+
+class AnalysisReportsItsSourceTests(RoleSkillTestCase):
+    """The resolved requirements reach the response, not just the score."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="jane", password="password123")
+
+    def _analyse(self, level="Senior", job_description=None):
+        from unittest.mock import patch
+
+        from analyzer.services import analyze_resume
+        from analyzer.tests import _fake_pdf
+
+        with patch("analyzer.services.pdfplumber.open") as mock_open:
+            mock_open.return_value = _fake_pdf("Python, Django, SQL, Docker, Git.")
+            return analyze_resume(
+                "dummy.pdf",
+                "Backend Developer",
+                experience_level=level,
+                job_description=job_description,
+            )
+
+    def test_the_response_says_which_store_answered(self):
+        result = self._analyse()
+
+        self.assertEqual(result["role_skills"]["source"], SOURCE_DATABASE)
+
+    def test_the_response_says_which_level_was_actually_used(self):
+        result = self._analyse(level="Principal")
+
+        self.assertEqual(result["role_skills"]["level"], SENIOR)
+        self.assertEqual(result["role_skills"]["level_as_requested"], "Principal")
+        self.assertTrue(result["role_skills"]["level_recognised"])
+
+    def test_an_unrecognised_level_is_flagged_rather_than_hidden(self):
+        result = self._analyse(level="Wizard")
+
+        self.assertEqual(result["role_skills"]["level"], MID_LEVEL)
+        self.assertFalse(result["role_skills"]["level_recognised"])
+
+    def test_a_job_description_is_named_as_the_source(self):
+        result = self._analyse(job_description="We need Python, Django and Kubernetes.")
+
+        self.assertEqual(result["role_skills"]["source"], "job-description")
+
+    def test_every_track_comparison_row_names_its_source(self):
+        result = self._analyse()
+
+        self.assertTrue(result["track_comparisons"])
+        for role, row in result["track_comparisons"].items():
+            with self.subTest(role=role):
+                self.assertIn(row["skills_source"], (SOURCE_DATABASE, SOURCE_DEFAULTS))
+
+    def test_track_comparisons_cover_every_known_role(self):
+        result = self._analyse()
+
+        self.assertEqual(
+            set(result["track_comparisons"]),
+            set(role_skills.known_roles(get_role_skills(), EXPERIENCE_LEVEL_SKILLS)),
+        )

--- a/docs/CAREER_TRACKS.md
+++ b/docs/CAREER_TRACKS.md
@@ -1,0 +1,96 @@
+# Career tracks and their skills
+
+A resume is scored against a list of required skills. Where that list comes from
+depends on the request, and there are three possible answers.
+
+## 1. A pasted job description
+
+If the analysis carries a job description, the required skills are extracted
+from it and neither store below is consulted. The response reports
+`role_skills.source` as `"job-description"`.
+
+This is the highest-precedence source and always has been. It is stated here
+because it used to be inferred from an absent field.
+
+## 2. The `Role` table
+
+Otherwise the requirements come from the `Role` / `Skill` tables, editable in
+the Django admin under **Analyzer → Roles**. Adding a skill to a role makes it a
+requirement; removing one stops it being a requirement.
+
+**Until #708 this had no effect.** A dictionary in `services.py` was checked
+first and matched every role the product ships, so the database was read,
+cached, invalidated correctly — and then discarded. If you edited a role before
+that fix and saw nothing change, that is why.
+
+## 3. The packaged defaults
+
+`services.EXPERIENCE_LEVEL_SKILLS` covers Frontend Developer, Backend Developer
+and Data Analyst. It answers for any role the `Role` table does not have, so a
+fresh install with no rows still works.
+
+## Experience levels
+
+The `Role` table holds **one skill list per role**, with no level column. The
+packaged defaults hold three lists per role, one per level. Levels are therefore
+applied as a *delta* on top of whichever store supplied the baseline:
+
+```
+added   = defaults[level][role] − defaults["Mid-Level"][role]
+removed = defaults["Mid-Level"][role] − defaults[level][role]
+
+required = (baseline − removed) + added
+```
+
+Two things follow.
+
+**On an untouched install nothing moves.** Migration `0012` seeded `Role` with
+the Mid-Level lists, so the baseline *is* the Mid-Level list and every level
+resolves to exactly the packaged list it always did.
+
+**An edit applies at every level.** Add `rust` to Backend Developer and it is
+required at Junior, Mid and Senior, because it appears in no level's `removed`
+set. Remove `webpack` from Frontend Developer and it is gone at all three.
+
+### What you cannot express yet
+
+"Docker, but only from Senior upwards" needs a level dimension on `Role`, which
+is a schema change. It belongs with the admin UI work in #545/#546. The delta
+machinery above is a way of not losing the existing tiers while fixing the bug —
+not the intended end state.
+
+A role that exists **only** in the database has no packaged tiers, so it is used
+as-is at every level. The response reports `role_skills.level_adjusted: false`
+for those, rather than implying a tier was applied.
+
+## Levels the analyzer recognises
+
+| You send | Scored as |
+| --- | --- |
+| `Junior`, `Entry level`, `Intern`, `Graduate`, `Trainee`, `Associate` | Junior |
+| `Mid-Level`, `Intermediate`, `Regular` | Mid-Level |
+| `Senior`, `Lead`, `Staff`, `Principal`, `Architect`, `Head of …`, `Director` | Senior |
+| anything else | Mid-Level, with `level_recognised: false` |
+
+`Principal` used to score as Mid-Level while the response echoed `"Principal"`
+straight back. The response now reports both `level_as_requested` and the
+`level` actually used, so a client can tell "we read Principal as Senior" from
+"Principal is a level we know".
+
+## Reading it back
+
+```json
+"role_skills": {
+  "role": "Backend Developer",
+  "level": "Senior",
+  "level_as_requested": "Principal",
+  "level_recognised": true,
+  "level_adjusted": true,
+  "source": "database",
+  "skills": ["python", "django", "..."]
+}
+```
+
+Every row of `track_comparisons` carries a `skills_source` for the same reason:
+two rows in one table can come from different stores, and a score whose
+provenance is invisible is one nobody can debug.


### PR DESCRIPTION
## 📝 Description

```python
def get_role_skills_for_level(target_role, experience_level="Mid-Level"):
    ...
    level_dict = EXPERIENCE_LEVEL_SKILLS.get(norm_level, {})
    if target_role in level_dict:
        return level_dict[target_role]          # <- database never consulted
    return get_role_skills().get(target_role, [])
```

`EXPERIENCE_LEVEL_SKILLS` covers Frontend Developer, Backend Developer and Data Analyst — every role a user can pick — so the database branch was dead code. Editing a `Role`'s skills changed nothing. The m2m signal in `models.py` cleared the cache correctly, `get_role_skills()` re-read the table correctly, and the result was thrown away one line later.

That matters now rather than in the abstract: **#545 and #546 both propose an admin UI over exactly those tables.** Built on this resolver, that UI would be a no-op — you would edit rows, the cache would invalidate, and no score would move.

### The obvious fix is wrong, and the existing tests say so

My first attempt was "read the database first, fall back to the packaged defaults". That loses experience levels entirely.

`Role` holds **one skill list per role** — no level column — and migration `0012` seeded it with the **Mid-Level** lists. So a database-first resolver answers the Mid-Level set at every level, and a Junior resume is suddenly measured against Senior requirements. `ExperienceLevelTests` went red, which is how I found it. Worth stating because the fix looks over-engineered until you know that.

### What actually holds

The two stores answer different questions, and neither is redundant:

- the **database** says *which skills this role needs* — the thing an operator edits, and the thing being ignored;
- the packaged **level tiers** say *how requirements move with seniority* — expressed nowhere in the schema, and not something an operator can currently state.

So a level is a **delta from Mid-Level**, derived from the packaged data rather than hand-maintained:

```
added    = defaults[level][role] − defaults["Mid-Level"][role]
removed  = defaults["Mid-Level"][role] − defaults[level][role]

required = (baseline − removed) + added
```

where `baseline` is the database's list when it has the role, and the packaged Mid-Level list otherwise. Deriving the deltas rather than writing them out means the tiers cannot drift away from the lists they describe.

Two properties fall out, and both are tested:

1. **On an untouched install nothing moves.** The seeded baseline *is* the Mid-Level list, so every level resolves to exactly the packaged list it always did.
2. **An edit applies at every level.** Add `rust` to Backend Developer and it is required at Junior, Mid and Senior, because it is in no level's `removed` set. Remove `webpack` and it is gone at all three.

### What this deliberately does not do

An operator still cannot say *"Docker, but only from Senior upwards"*. That needs a level dimension on `Role` — a schema change that belongs with the admin UI work in #545/#546, not with a bug fix. The module docstring and `docs/CAREER_TRACKS.md` both say so, so the delta machinery is not mistaken for the intended end state.

### Levels that silently were not levels

```python
if "junior" in el_lower or "entry" in el_lower: norm_level = "Junior"
elif "senior" in el_lower or "lead" in el_lower or "staff" in el_lower: norm_level = "Senior"
else: norm_level = "Mid-Level"
```

Anything unrecognised became Mid-Level with no signal — and the response echoed back whatever the caller sent. So **`"Principal"` was scored as Mid-Level while the client was told "Principal"**. `normalise_level` now returns `(level, recognised)`, the response carries `level`, `level_as_requested` and `level_recognised`, and the keyword list gained the phrasings people actually send: Principal, Architect, Director, Head of, Intern, Graduate, Trainee, Associate, Intermediate.

### Three smaller things in the same area

**`track_comparisons` iterated the database's roles and resolved each through the dictionary.** So an unseeded `Role` table produced an *empty* comparison table while the requested role scored perfectly well from the defaults — two different answers to "which roles exist" in one response. It now iterates every role either store knows, and each row carries a `skills_source`, because two rows in one table can genuinely come from different stores.

**`get_role_skills()` did not sort.** The m2m read has no ordering of its own, so two calls could return the same skills in a different order — and the list is shown to the user, with each entry worth 1/len of the score. Sorted in Python rather than with `order_by()`, which would defeat the `prefetch_related` above it.

**`Role` and `Skill` had no admin.** They have been in the model layer since `0011` with no way to reach them short of a shell, which is part of why nobody noticed the resolver ignored them. Registered now that the table is authoritative.

## 🔗 Related Issue

Closes #708

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

**48 new tests** in `analyzer/tests_role_skills.py`. Most need no database — `resolve()` takes both stores as arguments precisely so it can be exercised as a function — and they use a miniature pair of stores rather than reading the real dictionary, so an unrelated edit to it cannot break them.

The two classes that carry the argument are the two claims pulling against each other:

- **`UntouchedInstallTests`** — every packaged (level, role) pair resolves to its packaged list against the seeded database. This is the case a naive database-first resolver silently breaks, and it is the case every existing deployment is in. Plus: the seeded database supplies the baseline, Junior still expects less than Senior, resolution is stable across calls, and no skill is required twice.
- **`DatabaseEditsTakeEffectTests`** — every assertion here failed before the change. An added skill becomes a requirement; it applies at all three levels; a removed skill stops being one; a brand-new role is scored from the database alone and joins the known set.

Also covered: level normalisation including `Principal` (the concrete regression) and the "unrecognised" flag; skill normalisation; case-insensitive role matching with unknown roles returned *unchanged* rather than rewritten to one that exists; deltas that both add and remove (`Backend Developer` at Junior really does add `javascript` while dropping `django`); an **empty** database list treated as a half-finished edit rather than an intent to blank the role; a database-only role reporting `level_adjusted: false`; and the response-shape tests — source reported, level reported, a job description named as `"job-description"`, every `track_comparisons` row naming its source, and the comparison covering every known role.

One thing the tests forced out that is worth flagging for review: **`get_role_skills()` memoises the `Role` table in the process cache for a day, and `TestCase` rolls the database back between tests but not the cache.** So a test that edits a role and reads it leaves the edited list cached for whatever runs next, and the failure lands in the innocent test. `RoleSkillTestCase` clears the key on both sides of each test. This is a pre-existing hazard for anything that touches roles, not something this PR introduced.

```
Ran 391 tests in 11.6s
FAILED (failures=8)
```

The 8 are the pre-existing `tests_device_alerts` / `tests_login_errors` failures, identical to the baseline on `main` (343 tests, same 8). 391 − 343 = 48.

> **Note for CI:** `main` currently has two leaf migrations at 0016, so `manage.py test` cannot build a database on it (`CommandError: Conflicting migrations detected`). I ran this suite with a local merge migration deliberately kept out of this diff. #710 carries the merge; #672 also resolves it. This branch adds no migration of its own and needs no rebase when either lands.

- [ ] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

No frontend changes in this PR.

Manually, in the admin: added `rust` to Backend Developer, re-ran a resume, and watched it appear in the missing-skills list at Junior, Mid and Senior — which is the thing that did nothing before. Then submitted `experience_level: "Principal"` and confirmed the response reports `level: "Senior"` alongside `level_as_requested: "Principal"` instead of quietly scoring it as Mid-Level.

`services.py` is stored with CRLF line endings; I kept them, so the diff there is 75 added / 27 removed rather than a whole-file rewrite.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)

---

### Merge notes

The throttle rate is read from settings inside the throttle class, following the existing `UploadRateThrottle`, rather than added to `DEFAULT_THROTTLE_RATES`. It keeps the number beside the docstring that justifies it — and it means the four sibling PRs opened alongside this one (#710, #711, #712, #713, #714) do not all edit the same dictionary. Import anchors were moved apart for the same reason. All five merge cleanly into `main` in any order; I checked by test-merging the set in both directions.
