### PR TITLE
feat: analyse the employment timeline — gaps, overlaps, undated roles (#709)

### DIFF
--- a/backend/analyzer/services.py
+++ b/backend/analyzer/services.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from .models import ResumeAnalysis
 from .skill_matcher import extract_skills, match_skills_with_partial
 from .scoring import compute_score_breakdown
+from .timeline import analyse as analyse_timeline
 from resume_analyzer.quantify_checker import flag_unquantified_bullets
 
 User = get_user_model()
@@ -516,6 +517,12 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
 
     quantify_nudges = flag_unquantified_bullets(raw_text.split('\n'))
 
+    # Employment timeline. Deliberately kept out of `score` for the same reason
+    # `score_breakdown` is: that number is persisted on ResumeAnalysis and read
+    # by the leaderboard, version comparison and the digest, so changing what it
+    # means would change every historical row. See #709.
+    resume_timeline = analyse_timeline(raw_text, experience_level=experience_level)
+
     # Multi-factor view of the same resume. `score` above stays the keyword
     # ratio — it is persisted on ResumeAnalysis and read by the leaderboard,
     # version comparison and digest, so redefining it would change the meaning
@@ -540,6 +547,7 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
         "skills_found": detected,
         "suggestions": suggestions,
         "quantify_nudges": quantify_nudges,
+        "timeline": resume_timeline.as_dict(),
         "matched_skills": matched,
         "partial_skills": partial,
         "missing_skills": missing,

--- a/backend/analyzer/tests_timeline.py
+++ b/backend/analyzer/tests_timeline.py
@@ -1,0 +1,457 @@
+"""Tests for employment-timeline analysis (#709).
+
+Two things are being tested, and the second matters more than the first.
+
+The parser has to read the date formats resumes actually use. That is the easy
+half and most of `ExtractRangesTests`.
+
+The analysis has to **stay quiet when it is not sure**. Resume text arrives with
+its layout stripped, so a false "you forgot your dates" on a resume that has
+them sends the user hunting for a problem that does not exist — worse than
+missing a real one. `FalsePositiveTests` is the class that pins that, and the
+undated-role proximity rule exists entirely because of it.
+
+`today` is injected everywhere, so "current role" and "future date" are tested
+without freezing the clock globally.
+"""
+
+from datetime import date
+
+from django.test import TestCase
+
+from analyzer.timeline import (
+    GAP_THRESHOLD_MONTHS,
+    SEVERITY_HIGH,
+    SEVERITY_INFO,
+    SEVERITY_LOW,
+    SEVERITY_MEDIUM,
+    analyse,
+    extract_ranges,
+    merged_months,
+)
+
+TODAY = date(2026, 8, 20)
+
+
+def codes(timeline):
+    return [finding.code for finding in timeline.findings]
+
+
+class ExtractRangesTests(TestCase):
+    """The formats a resume is actually written in."""
+
+    def test_month_name_range(self):
+        (found,) = extract_ranges("Jan 2020 - Mar 2022")
+
+        self.assertEqual((found.start_year, found.start_month), (2020, 1))
+        self.assertEqual((found.end_year, found.end_month), (2022, 3))
+        self.assertEqual(found.start_format, "month-name")
+
+    def test_full_month_names_and_a_trailing_dot(self):
+        self.assertEqual(len(extract_ranges("January 2020 – March 2022")), 1)
+        self.assertEqual(len(extract_ranges("Sept. 2019 - Dec. 2021")), 1)
+
+    def test_numeric_range(self):
+        (found,) = extract_ranges("03/2017 - 06/2019")
+
+        self.assertEqual((found.start_year, found.start_month), (2017, 3))
+        self.assertEqual(found.start_format, "numeric")
+
+    def test_iso_range(self):
+        (found,) = extract_ranges("2020-01 to 2021-11")
+
+        self.assertEqual((found.start_year, found.start_month), (2020, 1))
+        self.assertEqual(found.start_format, "iso")
+
+    def test_year_only_range(self):
+        (found,) = extract_ranges("2015 - 2016")
+
+        self.assertIsNone(found.start_month)
+        self.assertEqual(found.start_format, "year-only")
+
+    def test_present_in_its_several_spellings(self):
+        for word in ("Present", "current", "Now", "ongoing", "today"):
+            with self.subTest(word=word):
+                (found,) = extract_ranges(f"Jan 2020 - {word}")
+                self.assertTrue(found.is_current)
+
+    def test_en_and_em_dashes_and_word_separators(self):
+        for separator in ("-", "–", "—", "to", "until", "through"):
+            with self.subTest(separator=separator):
+                self.assertEqual(len(extract_ranges(f"Jan 2020 {separator} Mar 2022")), 1)
+
+    def test_several_ranges_across_several_lines(self):
+        text = "Acme\nJan 2020 - Present\nGlobex\nMar 2017 - Jun 2019\n"
+
+        self.assertEqual(len(extract_ranges(text)), 2)
+
+    def test_a_range_is_not_assembled_across_a_line_break(self):
+        """Two-column resumes flatten to text in ways that invite exactly this."""
+        self.assertEqual(extract_ranges("Jan 2020 -\nMar 2022"), [])
+
+    def test_implausible_years_are_not_dates(self):
+        self.assertEqual(extract_ranges("Reduced errors from 1200 - 340"), [])
+
+    def test_version_numbers_are_not_dates(self):
+        self.assertEqual(extract_ranges("Migrated from Python 3.9 to 3.12"), [])
+
+    def test_the_matched_text_is_kept_for_quoting_back(self):
+        (found,) = extract_ranges("Senior Engineer   Jan 2020 - Mar 2022")
+
+        self.assertIn("Jan 2020", found.text)
+        self.assertIn("Senior Engineer", found.line)
+
+
+class DurationTests(TestCase):
+    def test_a_range_is_inclusive_of_both_ends(self):
+        (found,) = extract_ranges("Jan 2020 - Mar 2020")
+
+        self.assertEqual(found.months(TODAY), 3)
+
+    def test_a_year_only_end_runs_to_december(self):
+        """`2019 - 2021` is work through 2021, not work ending that January."""
+        (found,) = extract_ranges("2019 - 2021")
+
+        self.assertEqual(found.months(TODAY), 36)
+
+    def test_a_current_role_runs_to_today(self):
+        (found,) = extract_ranges("Jan 2026 - Present")
+
+        self.assertEqual(found.months(TODAY), 8)
+
+
+class MergedMonthsTests(TestCase):
+    """Total experience, with overlaps counted once."""
+
+    def test_two_separate_roles_add_up(self):
+        ranges = extract_ranges("Jan 2018 - Dec 2018\nJan 2020 - Dec 2020")
+
+        self.assertEqual(merged_months(ranges, TODAY), 24)
+
+    def test_concurrent_roles_are_not_counted_twice(self):
+        """A promotion written as two entries would otherwise inflate the total."""
+        ranges = extract_ranges("Jan 2020 - Dec 2021\nJun 2020 - Dec 2021")
+
+        self.assertEqual(merged_months(ranges, TODAY), 24)
+
+    def test_adjacent_roles_merge_into_one_span(self):
+        ranges = extract_ranges("Jan 2020 - Jun 2020\nJul 2020 - Dec 2020")
+
+        self.assertEqual(merged_months(ranges, TODAY), 12)
+
+    def test_no_ranges_is_zero_not_an_error(self):
+        self.assertEqual(merged_months([], TODAY), 0)
+
+
+class GapTests(TestCase):
+    def test_a_long_gap_is_reported(self):
+        timeline = analyse("Jan 2018 - Dec 2018\nJan 2020 - Dec 2020", today=TODAY)
+
+        self.assertIn("employment_gap", codes(timeline))
+        self.assertEqual(timeline.largest_gap_months, 12)
+
+    def test_a_short_gap_is_not_worth_mentioning(self):
+        """A notice period plus a job search is not a finding."""
+        timeline = analyse("Jan 2018 - Dec 2018\nFeb 2019 - Dec 2019", today=TODAY)
+
+        self.assertNotIn("employment_gap", codes(timeline))
+
+    def test_the_threshold_is_exactly_where_it_says_it_is(self):
+        """A gap of exactly the threshold counts; one month less does not."""
+        self.assertEqual(GAP_THRESHOLD_MONTHS, 4)
+
+        at_threshold = analyse("Jan 2018 - Jan 2018\nJun 2018 - Dec 2018", today=TODAY)
+        below_threshold = analyse("Jan 2018 - Jan 2018\nMay 2018 - Dec 2018", today=TODAY)
+
+        self.assertIn("employment_gap", codes(at_threshold))
+        self.assertNotIn("employment_gap", codes(below_threshold))
+
+    def test_a_gap_over_a_year_is_more_serious_than_a_short_one(self):
+        short = analyse("Jan 2018 - Dec 2018\nAug 2019 - Dec 2019", today=TODAY)
+        long = analyse("Jan 2018 - Dec 2018\nJan 2021 - Dec 2021", today=TODAY)
+
+        short_gap = next(f for f in short.findings if f.code == "employment_gap")
+        long_gap = next(f for f in long.findings if f.code == "employment_gap")
+
+        self.assertEqual(short_gap.severity, SEVERITY_MEDIUM)
+        self.assertEqual(long_gap.severity, SEVERITY_HIGH)
+
+    def test_a_gap_is_measured_from_the_furthest_end_not_the_previous_row(self):
+        """A long role that spans a short one must not create a phantom gap."""
+        timeline = analyse(
+            "Jan 2015 - Dec 2022\nJan 2016 - Dec 2016\nJan 2023 - Dec 2023",
+            today=TODAY,
+        )
+
+        self.assertNotIn("employment_gap", codes(timeline))
+
+    def test_a_gap_names_both_sides(self):
+        timeline = analyse("Jan 2018 - Dec 2018\nJan 2020 - Dec 2020", today=TODAY)
+        gap = next(f for f in timeline.findings if f.code == "employment_gap")
+
+        self.assertIn("Jan 2018", gap.evidence)
+        self.assertIn("Jan 2020", gap.evidence)
+
+
+class OverlapTests(TestCase):
+    def test_concurrent_roles_are_flagged_gently(self):
+        timeline = analyse("Jan 2020 - Dec 2021\nJan 2021 - Dec 2022", today=TODAY)
+        overlap = next(f for f in timeline.findings if f.code == "overlapping_roles")
+
+        self.assertEqual(overlap.severity, SEVERITY_LOW)
+        self.assertIn("contract work", overlap.message)
+
+    def test_a_handover_month_is_not_an_overlap(self):
+        """Leaving one job for another, written to the month, looks like this."""
+        timeline = analyse("Jan 2020 - Mar 2021\nMar 2021 - Dec 2022", today=TODAY)
+
+        self.assertNotIn("overlapping_roles", codes(timeline))
+
+
+class ImpossibleDateTests(TestCase):
+    def test_a_reversed_range_is_reported(self):
+        timeline = analyse("Mar 2022 - Jan 2020", today=TODAY)
+        finding = next(f for f in timeline.findings if f.code == "reversed_range")
+
+        self.assertEqual(finding.severity, SEVERITY_HIGH)
+
+    def test_a_reversed_range_does_not_poison_the_totals(self):
+        """It is dropped, or the gap arithmetic downstream is nonsense."""
+        timeline = analyse("Mar 2022 - Jan 2020\nJan 2024 - Dec 2024", today=TODAY)
+
+        self.assertEqual(timeline.total_months, 12)
+
+    def test_a_far_future_start_is_reported(self):
+        timeline = analyse("Jan 2030 - Present", today=TODAY)
+
+        self.assertIn("future_date", codes(timeline))
+
+    def test_a_start_a_month_or_two_out_is_left_alone(self):
+        """Offers do get signed ahead of time."""
+        timeline = analyse("Oct 2026 - Present", today=TODAY)
+
+        self.assertNotIn("future_date", codes(timeline))
+
+
+class FormatConsistencyTests(TestCase):
+    def test_mixed_formats_are_reported(self):
+        timeline = analyse("Jan 2020 - Mar 2021\n04/2018 - 06/2019", today=TODAY)
+
+        self.assertIn("mixed_date_formats", codes(timeline))
+
+    def test_one_format_throughout_is_not_a_finding(self):
+        timeline = analyse("Jan 2020 - Mar 2021\nApr 2018 - Jun 2019", today=TODAY)
+
+        self.assertNotIn("mixed_date_formats", codes(timeline))
+
+    def test_present_does_not_count_as_a_competing_format(self):
+        """It is the only way to write an open end, not a stylistic choice."""
+        timeline = analyse("Jan 2020 - Present\nMar 2017 - Jun 2019", today=TODAY)
+
+        self.assertNotIn("mixed_date_formats", codes(timeline))
+
+    def test_year_only_ranges_are_flagged_as_ambiguous(self):
+        timeline = analyse("2021 - 2022", today=TODAY)
+        finding = next(f for f in timeline.findings if f.code == "year_only_dates")
+
+        self.assertEqual(finding.severity, SEVERITY_LOW)
+        self.assertIn("two months or twenty-three", finding.message)
+
+
+class UndatedRoleTests(TestCase):
+    def test_a_role_with_no_dates_anywhere_near_it_is_flagged(self):
+        text = (
+            "Senior Engineer, Acme\n"
+            "Jan 2020 - Present\n"
+            "Built the billing pipeline.\n"
+            "Shipped twelve releases.\n"
+            "Contract Developer, Initech\n"
+            "Delivered a thing.\n"
+        )
+        timeline = analyse(text, today=TODAY)
+        finding = next(f for f in timeline.findings if f.code == "undated_role")
+
+        self.assertEqual(finding.severity, SEVERITY_HIGH)
+        self.assertIn("Initech", finding.evidence)
+
+
+class FalsePositiveTests(TestCase):
+    """The failures that would make this feature worse than not having it.
+
+    Every case here is a resume that is *fine*. Any finding is a bug.
+    """
+
+    def test_dates_on_the_line_below_the_title(self):
+        text = (
+            "Senior Backend Engineer, Acme Corp\n"
+            "Jan 2020 - Present\n"
+            "Built the billing pipeline.\n"
+        )
+
+        self.assertNotIn("undated_role", codes(analyse(text, today=TODAY)))
+
+    def test_title_then_company_then_dates(self):
+        text = "Senior Engineer\nAcme Corp\nJan 2020 - Present\nBuilt things.\n"
+
+        self.assertNotIn("undated_role", codes(analyse(text, today=TODAY)))
+
+    def test_dates_on_the_line_above_the_title(self):
+        """A right-aligned date column flattens this way."""
+        text = "Jan 2020 - Present\nSenior Engineer, Acme\nBuilt things.\n"
+
+        self.assertNotIn("undated_role", codes(analyse(text, today=TODAY)))
+
+    def test_dates_on_the_same_line_as_the_title(self):
+        text = "Senior Engineer, Acme        Jan 2020 - Present\nBuilt things.\n"
+
+        self.assertNotIn("undated_role", codes(analyse(text, today=TODAY)))
+
+    def test_a_resume_we_could_not_parse_produces_silence(self):
+        """Not a page of warnings. This is the whole design in one test."""
+        timeline = analyse(
+            "Senior Engineer at Acme\nBuilt the billing pipeline.\nManager at Globex\n",
+            today=TODAY,
+        )
+
+        self.assertFalse(timeline.parsed)
+        self.assertEqual(codes(timeline), ["no_dates_found"])
+        self.assertEqual(timeline.findings[0].severity, SEVERITY_INFO)
+
+    def test_metrics_in_bullets_are_not_read_as_dates(self):
+        timeline = analyse(
+            "Jan 2020 - Present\n"
+            "Reduced p99 latency from 1200 ms to 340 ms.\n"
+            "Cut costs by 40% across 3 services.\n"
+            "Scaled from 100 to 5000 requests per second.\n",
+            today=TODAY,
+        )
+
+        self.assertEqual(len(timeline.ranges), 1)
+
+    def test_a_clean_recent_resume_has_nothing_to_say(self):
+        text = (
+            "Senior Backend Engineer, Acme Corp\n"
+            "Jan 2022 - Present\n"
+            "Built the billing pipeline.\n"
+            "Backend Engineer, Globex\n"
+            "Feb 2019 - Dec 2021\n"
+            "Maintained services.\n"
+        )
+
+        self.assertEqual(codes(analyse(text, today=TODAY)), [])
+
+
+class SeniorityCrossCheckTests(TestCase):
+    SHORT_HISTORY = "Jan 2025 - Present\n"
+
+    def test_senior_with_eighteen_months_is_flagged(self):
+        timeline = analyse(self.SHORT_HISTORY, experience_level="Senior", today=TODAY)
+        finding = next(f for f in timeline.findings if f.code == "seniority_mismatch")
+
+        self.assertEqual(finding.severity, SEVERITY_MEDIUM)
+        self.assertIn("Senior", finding.message)
+
+    def test_senior_with_a_long_history_is_not_flagged(self):
+        timeline = analyse("Jan 2010 - Present", experience_level="Senior", today=TODAY)
+
+        self.assertNotIn("seniority_mismatch", codes(timeline))
+
+    def test_junior_is_never_flagged(self):
+        """There is no floor to fail on the way in."""
+        timeline = analyse(self.SHORT_HISTORY, experience_level="Junior", today=TODAY)
+
+        self.assertNotIn("seniority_mismatch", codes(timeline))
+
+    def test_an_unrecognised_level_skips_the_check_rather_than_guessing(self):
+        timeline = analyse(self.SHORT_HISTORY, experience_level="Wizard", today=TODAY)
+
+        self.assertNotIn("seniority_mismatch", codes(timeline))
+
+    def test_the_check_reads_common_senior_phrasings(self):
+        for level in ("Senior Engineer", "Tech Lead", "Staff", "Principal"):
+            with self.subTest(level=level):
+                timeline = analyse(self.SHORT_HISTORY, experience_level=level, today=TODAY)
+                self.assertIn("seniority_mismatch", codes(timeline))
+
+
+class TimelineShapeTests(TestCase):
+    def test_findings_are_ordered_by_severity(self):
+        text = (
+            "Senior Engineer, Acme\n"
+            "2015 - 2016\n"
+            "Built things.\n"
+            "More bullets here.\n"
+            "Consultant, Initech\n"
+            "Did consulting.\n"
+            "04/2020 - 06/2021\n"
+        )
+        timeline = analyse(text, today=TODAY)
+        severities = [f.severity for f in timeline.findings]
+
+        order = {SEVERITY_HIGH: 0, SEVERITY_MEDIUM: 1, SEVERITY_LOW: 2, SEVERITY_INFO: 3}
+        self.assertEqual(severities, sorted(severities, key=lambda s: order[s]))
+
+    def test_total_years_is_rounded_for_display(self):
+        timeline = analyse("Jan 2020 - Jun 2021", today=TODAY)
+
+        self.assertEqual(timeline.total_months, 18)
+        self.assertEqual(timeline.total_years, 1.5)
+
+    def test_a_current_role_is_reported(self):
+        self.assertTrue(analyse("Jan 2020 - Present", today=TODAY).has_current_role)
+        self.assertFalse(analyse("Jan 2020 - Dec 2021", today=TODAY).has_current_role)
+
+    def test_ranges_come_back_in_chronological_order(self):
+        timeline = analyse("Jan 2020 - Dec 2021\nJan 2015 - Dec 2016", today=TODAY)
+
+        self.assertEqual([r.start_year for r in timeline.ranges], [2015, 2020])
+
+    def test_empty_and_none_input(self):
+        for text in ("", None, "   \n\n  "):
+            with self.subTest(text=text):
+                timeline = analyse(text, today=TODAY)
+                self.assertFalse(timeline.parsed)
+                self.assertEqual(timeline.total_months, 0)
+
+    def test_the_dict_form_is_json_serialisable(self):
+        import json
+
+        payload = analyse("Jan 2020 - Present", experience_level="Senior", today=TODAY).as_dict()
+
+        json.dumps(payload)
+        self.assertIn("findings", payload)
+        self.assertIn("total_months", payload)
+        self.assertTrue(payload["parsed"])
+
+
+class AnalysisIntegrationTests(TestCase):
+    """The timeline reaches the response, and does not disturb the score."""
+
+    def _analyse(self, text, level="Senior"):
+        from unittest.mock import patch
+
+        from analyzer.services import analyze_resume
+        from analyzer.tests import _fake_pdf
+
+        with patch("analyzer.services.pdfplumber.open") as mock_open:
+            mock_open.return_value = _fake_pdf(text)
+            return analyze_resume("dummy.pdf", "Backend Developer", experience_level=level)
+
+    def test_the_timeline_is_in_the_result(self):
+        result = self._analyse("Python, Django.\nJan 2020 - Present\n")
+
+        self.assertIn("timeline", result)
+        self.assertTrue(result["timeline"]["parsed"])
+
+    def test_the_headline_score_is_untouched(self):
+        """It is persisted and read by the leaderboard, digest and charts."""
+        without = self._analyse("Python, Django, SQL, Docker.")
+        with_dates = self._analyse("Python, Django, SQL, Docker.\nJan 2020 - Present\n")
+
+        self.assertEqual(without["score"], with_dates["score"])
+
+    def test_a_resume_with_no_dates_still_analyses(self):
+        result = self._analyse("Python, Django, SQL.")
+
+        self.assertFalse(result["timeline"]["parsed"])
+        self.assertIsInstance(result["score"], int)

--- a/backend/analyzer/timeline.py
+++ b/backend/analyzer/timeline.py
@@ -1,0 +1,698 @@
+"""Reading the employment timeline out of a resume.
+
+Everything the analyzer produces today is about *what* a resume says — skills,
+keyword coverage, readability, whether bullets carry numbers. Nothing looks at
+*when*. A resume can score 90 here and still be filtered on its dates, because
+recruiters read the dates before the bullets and ATS platforms parse them into
+structured employment records.
+
+This module finds date ranges in the extracted text, sorts them, and reports
+what a person reading the timeline would notice: undated roles, gaps, overlaps,
+reversed ranges, dates in the future, and inconsistent formats. It also derives
+total experience as the *union* of the ranges, so two concurrent roles are not
+counted twice, and compares that against the experience level the user selected.
+
+Being conservative is the design
+--------------------------------
+The layout is gone by the time we see this text. ``pdfplumber`` gives a stream
+of lines with no idea which line is a job title and which is a bullet, so this
+cannot know that "Acme Corp" and "Jan 2020 – Mar 2022" belong together — only
+that they are near each other.
+
+So the rule throughout is: **report what is confident, say nothing where it is
+not.** In particular, an undated entry is only ever flagged when the resume has
+*some* dated entries to compare against. A resume we simply failed to parse must
+produce silence, not a page of warnings — a false "you forgot your dates" on a
+resume that has them is worse than missing a real one, because it sends the user
+looking for a problem that does not exist.
+
+The findings are deliberately **not** folded into the headline ``score``. That
+number is persisted on ``ResumeAnalysis`` and read by the leaderboard, version
+comparison and the weekly digest, so changing what it means would change every
+historical row — the same reasoning ``scoring.compute_score_breakdown`` already
+gives for staying out of it.
+"""
+
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import date
+from typing import Dict, List, Optional, Sequence, Tuple
+
+#: Gap, in months, before it is worth mentioning. Under a quarter is a normal
+#: notice period plus a job search and nobody asks about it.
+GAP_THRESHOLD_MONTHS = 4
+
+#: Overlap, in months, before two roles read as concurrent rather than as a
+#: handover. A few weeks of overlap is what leaving one job for another looks
+#: like when both are written to the month.
+OVERLAP_THRESHOLD_MONTHS = 2
+
+#: How far ahead a date may be before it is treated as a typo rather than a
+#: planned start. Offers do get signed a couple of months out.
+FUTURE_TOLERANCE_MONTHS = 3
+
+#: Severity levels, in the order a UI should sort them.
+SEVERITY_HIGH = "high"
+SEVERITY_MEDIUM = "medium"
+SEVERITY_LOW = "low"
+SEVERITY_INFO = "info"
+
+_SEVERITY_ORDER = {
+    SEVERITY_HIGH: 0,
+    SEVERITY_MEDIUM: 1,
+    SEVERITY_LOW: 2,
+    SEVERITY_INFO: 3,
+}
+
+MONTHS = {
+    "jan": 1, "january": 1,
+    "feb": 2, "february": 2,
+    "mar": 3, "march": 3,
+    "apr": 4, "april": 4,
+    "may": 5,
+    "jun": 6, "june": 6,
+    "jul": 7, "july": 7,
+    "aug": 8, "august": 8,
+    "sep": 9, "sept": 9, "september": 9,
+    "oct": 10, "october": 10,
+    "nov": 11, "november": 11,
+    "dec": 12, "december": 12,
+}
+
+#: Words that mean "still there". ``to date`` is included because it is common
+#: and is otherwise parsed as a stray preposition.
+PRESENT_WORDS = ("present", "current", "currently", "now", "ongoing", "to date", "today")
+
+#: Separators between the two ends of a range: hyphen, en dash, em dash,
+#: "to", "until", "through". Written out rather than as a character class so the
+#: word forms can carry their own spacing rules.
+_SEPARATOR = r"(?:\s*(?:-{1,2}|–|—|~|to|until|through|till)\s*)"
+
+#: Years we will accept. Below this is almost always a version number, a
+#: quantity or a page reference rather than a date somebody worked.
+MIN_YEAR = 1950
+MAX_YEAR = 2100
+
+#: Plausible year, written as four digits. Kept separate from `MIN_YEAR` so the
+#: regex and the validation cannot drift apart.
+_YEAR = r"(?:19\d{2}|20\d{2}|21\d{2})"
+
+_MONTH_NAMES = "|".join(sorted(MONTHS, key=len, reverse=True))
+
+def _endpoint(prefix):
+    """Return an alternation matching one end of a range, with named groups.
+
+    Built as an f-string rather than a ``.format()`` template because the
+    patterns contain regex quantifiers like ``\\d{4}``, which ``str.format``
+    reads as replacement fields.
+
+    Ordered most specific first: ``2020-03`` has to be tried before the bare
+    year, or the year alone matches and the month is left dangling.
+    """
+    iso = (
+        rf"(?P<{prefix}iso_year>{_YEAR})[/.-]"
+        rf"(?P<{prefix}iso_month>0?[1-9]|1[0-2])(?!\d)"
+    )
+    month_year = (
+        rf"(?P<{prefix}month_name>{_MONTH_NAMES})\.?,?\s+"
+        rf"(?P<{prefix}my_year>{_YEAR})"
+    )
+    numeric = (
+        rf"(?P<{prefix}num_month>0?[1-9]|1[0-2])[/.-]"
+        rf"(?P<{prefix}nm_year>{_YEAR})"
+    )
+    bare = rf"(?P<{prefix}bare_year>{_YEAR})"
+
+    return "(?:" + "|".join((iso, month_year, numeric, bare)) + ")"
+
+
+_PRESENT = r"(?P<present>" + "|".join(PRESENT_WORDS) + r")"
+
+RANGE_PATTERN = re.compile(
+    r"(?<![\w/])"
+    + _endpoint("start_")
+    + _SEPARATOR
+    + r"(?:" + _PRESENT + r"|" + _endpoint("end_") + r")"
+    + r"(?![\w/])",
+    re.IGNORECASE,
+)
+
+#: A line that names a job but carries no range. Only used once at least one
+#: range has been found — see the module docstring.
+ROLE_HINT_PATTERN = re.compile(
+    r"\b(engineer|developer|analyst|manager|designer|consultant|scientist|"
+    r"architect|administrator|specialist|coordinator|director|intern|"
+    r"associate|lead|officer|technician)\b",
+    re.IGNORECASE,
+)
+
+#: How each recognised format is named back to the user. The keys are what
+#: :func:`_parse_endpoint` returns, so a new format cannot be added without
+#: giving it a name here.
+FORMAT_LABELS = {
+    "month-name": "Jan 2020",
+    "numeric": "01/2020",
+    "iso": "2020-01",
+    "year-only": "2020",
+    "present": "Present",
+}
+
+
+@dataclass
+class DateRange:
+    """One parsed employment range.
+
+    Attributes:
+        start_year / start_month: ``start_month`` is ``None`` for a year-only
+            date. Kept rather than defaulted to January, because "2020" and
+            "Jan 2020" carry different amounts of information and the gap
+            arithmetic has to know which it has.
+        end_year / end_month: ``None`` on both when the range runs to today.
+        is_current: The range ended in "Present" or similar.
+        start_format / end_format: Keys into :data:`FORMAT_LABELS`.
+        text: The matched substring, so a finding can quote the resume back.
+        line: The full line it came from, for context in the UI.
+        line_number: Index of that line in the extracted text. Used to decide
+            whether a nearby heading is really undated — see
+            :func:`_undated_role_lines`.
+    """
+
+    start_year: int
+    start_month: Optional[int]
+    end_year: Optional[int]
+    end_month: Optional[int]
+    is_current: bool
+    start_format: str
+    end_format: str
+    text: str
+    line: str = ""
+    line_number: int = -1
+
+    def start_index(self) -> int:
+        """Months since year zero, for arithmetic. Unknown month reads as January."""
+        return self.start_year * 12 + ((self.start_month or 1) - 1)
+
+    def end_index(self, today: date) -> int:
+        """Months since year zero for the end.
+
+        A current role ends today. A year-only end reads as **December** of that
+        year, not January: "2019 – 2021" describes work through 2021, and
+        treating it as ending in January would invent an eleven-month gap.
+        """
+        if self.is_current or self.end_year is None:
+            return today.year * 12 + (today.month - 1)
+        if self.end_month is None:
+            return self.end_year * 12 + 11
+        return self.end_year * 12 + (self.end_month - 1)
+
+    def months(self, today: date) -> int:
+        """Length in months, inclusive of both endpoints, never negative."""
+        return max(0, self.end_index(today) - self.start_index() + 1)
+
+    def label(self) -> str:
+        return self.text.strip()
+
+    def as_dict(self) -> Dict:
+        return asdict(self)
+
+
+@dataclass
+class Finding:
+    """Something a reader would notice about the timeline.
+
+    ``message`` is written for the person being scored and is meant to be
+    rendered as-is, in the style of ``scoring.FactorScore.detail``.
+    """
+
+    code: str
+    severity: str
+    message: str
+    #: Text from the resume the finding refers to, so a user can locate it.
+    evidence: str = ""
+
+    def as_dict(self) -> Dict:
+        return asdict(self)
+
+
+@dataclass
+class Timeline:
+    """The parsed timeline and everything derived from it."""
+
+    ranges: List[DateRange] = field(default_factory=list)
+    findings: List[Finding] = field(default_factory=list)
+    #: Union of the ranges, so concurrent roles are not counted twice.
+    total_months: int = 0
+    #: ``total_months`` as years, to one decimal, for display.
+    total_years: float = 0.0
+    #: Largest gap found, in months. 0 when there is none.
+    largest_gap_months: int = 0
+    #: True when at least one range runs to "Present".
+    has_current_role: bool = False
+    #: Distinct date formats seen, as display labels.
+    formats_seen: List[str] = field(default_factory=list)
+    #: False when nothing parseable was found — the UI should say "we could not
+    #: read your dates", not "your resume has no dates".
+    parsed: bool = False
+
+    def as_dict(self) -> Dict:
+        return {
+            "parsed": self.parsed,
+            "ranges": [r.as_dict() for r in self.ranges],
+            "findings": [f.as_dict() for f in self.findings],
+            "total_months": self.total_months,
+            "total_years": self.total_years,
+            "largest_gap_months": self.largest_gap_months,
+            "has_current_role": self.has_current_role,
+            "formats_seen": list(self.formats_seen),
+        }
+
+
+def _parse_endpoint(match, prefix) -> Optional[Tuple[int, Optional[int], str]]:
+    """Return ``(year, month_or_None, format_key)`` for one end of a range."""
+    groups = match.groupdict()
+
+    iso_year = groups.get(f"{prefix}iso_year")
+    if iso_year:
+        return int(iso_year), int(groups[f"{prefix}iso_month"]), "iso"
+
+    month_name = groups.get(f"{prefix}month_name")
+    if month_name:
+        return int(groups[f"{prefix}my_year"]), MONTHS[month_name.lower()], "month-name"
+
+    num_month = groups.get(f"{prefix}num_month")
+    if num_month:
+        return int(groups[f"{prefix}nm_year"]), int(num_month), "numeric"
+
+    bare = groups.get(f"{prefix}bare_year")
+    if bare:
+        return int(bare), None, "year-only"
+
+    return None
+
+
+def extract_ranges(text: str) -> List[DateRange]:
+    """Find every date range in ``text``, in the order they appear.
+
+    Scanned line by line rather than over the whole document, so a range cannot
+    be assembled from the end of one line and the start of the next — which
+    happens constantly in two-column resumes flattened to text.
+    """
+    ranges = []
+
+    for line_number, line in enumerate((text or "").splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        for match in RANGE_PATTERN.finditer(stripped):
+            start = _parse_endpoint(match, "start_")
+            if start is None:
+                continue
+
+            start_year, start_month, start_format = start
+            if not MIN_YEAR <= start_year <= MAX_YEAR:
+                continue
+
+            if match.groupdict().get("present"):
+                ranges.append(
+                    DateRange(
+                        start_year=start_year,
+                        start_month=start_month,
+                        end_year=None,
+                        end_month=None,
+                        is_current=True,
+                        start_format=start_format,
+                        end_format="present",
+                        text=match.group(0),
+                        line=stripped,
+                        line_number=line_number,
+                    )
+                )
+                continue
+
+            end = _parse_endpoint(match, "end_")
+            if end is None:
+                continue
+
+            end_year, end_month, end_format = end
+            if not MIN_YEAR <= end_year <= MAX_YEAR:
+                continue
+
+            ranges.append(
+                DateRange(
+                    start_year=start_year,
+                    start_month=start_month,
+                    end_year=end_year,
+                    end_month=end_month,
+                    is_current=False,
+                    start_format=start_format,
+                    end_format=end_format,
+                    text=match.group(0),
+                    line=stripped,
+                    line_number=line_number,
+                )
+            )
+
+    return ranges
+
+
+def _describe_months(months: int) -> str:
+    """Render a month count the way a person would say it."""
+    if months < 12:
+        return f"{months} month{'s' if months != 1 else ''}"
+
+    years, remainder = divmod(months, 12)
+    if remainder == 0:
+        return f"{years} year{'s' if years != 1 else ''}"
+    return f"{years} year{'s' if years != 1 else ''} {remainder} month{'s' if remainder != 1 else ''}"
+
+
+def merged_months(ranges: Sequence[DateRange], today: date) -> int:
+    """Total months covered by ``ranges``, counting overlaps once.
+
+    A promotion written as two entries, or a contract held alongside a staff
+    job, would otherwise inflate total experience — which is the number this
+    module compares against the selected seniority, so double-counting there
+    would produce exactly the wrong advice.
+    """
+    if not ranges:
+        return 0
+
+    spans = sorted(
+        (r.start_index(), r.end_index(today)) for r in ranges if r.end_index(today) >= r.start_index()
+    )
+    if not spans:
+        return 0
+
+    total = 0
+    current_start, current_end = spans[0]
+
+    for start, end in spans[1:]:
+        if start <= current_end + 1:
+            current_end = max(current_end, end)
+        else:
+            total += current_end - current_start + 1
+            current_start, current_end = start, end
+
+    total += current_end - current_start + 1
+    return total
+
+
+#: How far *after* a heading a date range may sit and still belong to it. Two,
+#: because the common layouts are ``Title / Dates`` and
+#: ``Title / Company / Dates``.
+DATE_LINES_AFTER = 2
+
+#: How far *before*. Only one: a right-aligned date column flattens to the line
+#: above its heading, but nothing puts the dates two lines early. Asymmetric
+#: rather than a symmetric window, because widening it backwards is what makes a
+#: genuinely undated role three lines below a dated one look dated.
+DATE_LINES_BEFORE = 1
+
+
+def _undated_role_lines(text: str, ranges: Sequence[DateRange]) -> List[str]:
+    """Lines that look like a job title with no date range anywhere near them.
+
+    The proximity check is the whole difficulty. ``pdfplumber`` gives a stream of
+    lines with no idea which is a heading and which is a bullet, so a resume
+    written as
+
+    .. code-block:: text
+
+        Senior Backend Engineer, Acme Corp
+        Jan 2020 – Present
+
+    has its title and its dates on *different lines*, and a naive same-line check
+    reports every properly dated role as undated. That is the worst failure this
+    module can have — it sends the user hunting for a problem that is not there —
+    so a heading counts as dated when a range appears from
+    :data:`DATE_LINES_BEFORE` above it to :data:`DATE_LINES_AFTER` below.
+
+    Only meaningful once ``ranges`` is non-empty; the caller enforces that. A
+    line containing any year is also skipped, because a date we failed to *pair
+    into a range* is still a date.
+    """
+    dated_lines = {r.line_number for r in ranges if r.line_number >= 0}
+    if not dated_lines:
+        return []
+
+    # Built from the heading's point of view: a range on line N vouches for a
+    # heading anywhere from N - DATE_LINES_AFTER to N + DATE_LINES_BEFORE.
+    near_a_date = set()
+    for number in dated_lines:
+        for offset in range(-DATE_LINES_AFTER, DATE_LINES_BEFORE + 1):
+            near_a_date.add(number + offset)
+
+    year_re = re.compile(_YEAR)
+    undated = []
+
+    for number, line in enumerate(text.splitlines()):
+        stripped = line.strip()
+        if not stripped or number in near_a_date:
+            continue
+        if len(stripped) > 120:
+            # Long lines are prose, not headings.
+            continue
+        if year_re.search(stripped):
+            continue
+        if ROLE_HINT_PATTERN.search(stripped):
+            undated.append(stripped)
+
+    return undated
+
+
+def _seniority_expectation(level: str) -> Optional[Tuple[int, str]]:
+    """Return ``(minimum_months, label)`` for a level, or ``None``.
+
+    Only a floor, and a lenient one. The point is to catch the resume that
+    claims Senior and shows eighteen months, not to police the boundary between
+    four and five years.
+    """
+    if not isinstance(level, str):
+        return None
+
+    text = level.strip().lower()
+    if "senior" in text or "lead" in text or "staff" in text or "principal" in text:
+        return 60, "Senior"
+    if "mid" in text or "intermediate" in text:
+        return 24, "Mid-Level"
+    return None
+
+
+def analyse(text, experience_level="", today=None) -> Timeline:
+    """Parse ``text`` and report on the timeline it describes.
+
+    Args:
+        text: The extracted resume text.
+        experience_level: What the user selected, used only for the seniority
+            cross-check. Anything unrecognised skips that check rather than
+            guessing.
+        today: Clock override. Injected rather than read from the module, so
+            "current role" and "future date" are testable without freezing time
+            globally.
+
+    Returns:
+        A :class:`Timeline`. ``parsed`` is ``False`` when nothing was found, and
+        in that case ``findings`` carries one informational entry and nothing
+        else — see the module docstring on why silence is the right failure.
+    """
+    today = today or date.today()
+    ranges = extract_ranges(text or "")
+
+    if not ranges:
+        return Timeline(
+            parsed=False,
+            findings=[
+                Finding(
+                    code="no_dates_found",
+                    severity=SEVERITY_INFO,
+                    message=(
+                        "We could not read any employment dates from this resume. "
+                        "If your roles do have dates, they may be in a layout an ATS "
+                        "cannot parse either — a plain line like "
+                        "\"Jan 2020 – Mar 2022\" beside each role is the safest format."
+                    ),
+                )
+            ],
+        )
+
+    findings: List[Finding] = []
+
+    # --- Impossible and implausible dates ---------------------------------
+    #
+    # Checked first, and the offending ranges are dropped, because a reversed or
+    # far-future range would poison the gap and total-experience arithmetic that
+    # follows.
+    usable = []
+    future_cutoff = today.year * 12 + (today.month - 1) + FUTURE_TOLERANCE_MONTHS
+
+    for r in ranges:
+        if not r.is_current and r.end_index(today) < r.start_index():
+            findings.append(
+                Finding(
+                    code="reversed_range",
+                    severity=SEVERITY_HIGH,
+                    message=(
+                        f"\"{r.label()}\" ends before it starts. An ATS that parses this "
+                        "into an employment record will either drop the role or record "
+                        "it with a negative duration."
+                    ),
+                    evidence=r.line or r.label(),
+                )
+            )
+            continue
+
+        if r.start_index() > future_cutoff:
+            findings.append(
+                Finding(
+                    code="future_date",
+                    severity=SEVERITY_MEDIUM,
+                    message=(
+                        f"\"{r.label()}\" starts in the future. If that is not a planned "
+                        "start date, it is likely a typo in the year."
+                    ),
+                    evidence=r.line or r.label(),
+                )
+            )
+            continue
+
+        usable.append(r)
+
+    ordered = sorted(usable, key=lambda r: (r.start_index(), r.end_index(today)))
+
+    # --- Gaps and overlaps ------------------------------------------------
+    largest_gap = 0
+    if len(ordered) > 1:
+        furthest_end = ordered[0].end_index(today)
+        previous = ordered[0]
+
+        for current in ordered[1:]:
+            gap = current.start_index() - furthest_end - 1
+            if gap >= GAP_THRESHOLD_MONTHS:
+                largest_gap = max(largest_gap, gap)
+                findings.append(
+                    Finding(
+                        code="employment_gap",
+                        severity=SEVERITY_MEDIUM if gap < 12 else SEVERITY_HIGH,
+                        message=(
+                            f"There is a gap of {_describe_months(gap)} between "
+                            f"\"{previous.label()}\" and \"{current.label()}\". A gap is not a "
+                            "problem, but an unexplained one is a question — a single line "
+                            "naming what you were doing usually settles it."
+                        ),
+                        evidence=f"{previous.label()} → {current.label()}",
+                    )
+                )
+
+            overlap = furthest_end - current.start_index() + 1
+            if overlap >= OVERLAP_THRESHOLD_MONTHS:
+                findings.append(
+                    Finding(
+                        code="overlapping_roles",
+                        severity=SEVERITY_LOW,
+                        message=(
+                            f"\"{previous.label()}\" and \"{current.label()}\" overlap by "
+                            f"{_describe_months(overlap)}. That is normal for contract work, "
+                            "a promotion or a side project — but say which it is, or it reads "
+                            "as a mistake."
+                        ),
+                        evidence=f"{previous.label()} / {current.label()}",
+                    )
+                )
+
+            if current.end_index(today) > furthest_end:
+                furthest_end = current.end_index(today)
+                previous = current
+
+    # --- Format consistency -----------------------------------------------
+    formats = []
+    for r in ordered:
+        for key in (r.start_format, r.end_format):
+            label = FORMAT_LABELS.get(key)
+            if label and label not in formats:
+                formats.append(label)
+
+    # "Present" is not a competing format — it is the only way to write an open
+    # end — so it does not count towards inconsistency.
+    competing = [f for f in formats if f != FORMAT_LABELS["present"]]
+    if len(competing) > 1:
+        findings.append(
+            Finding(
+                code="mixed_date_formats",
+                severity=SEVERITY_LOW,
+                message=(
+                    "Your dates are written in more than one format ("
+                    + ", ".join(competing)
+                    + "). Parsers usually lock on to the first one they see and drop the "
+                    "rest, so picking one and using it throughout is worth a minute."
+                ),
+            )
+        )
+
+    # --- Year-only ranges -------------------------------------------------
+    year_only = [r for r in ordered if r.start_month is None]
+    if year_only:
+        findings.append(
+            Finding(
+                code="year_only_dates",
+                severity=SEVERITY_LOW,
+                message=(
+                    f"{len(year_only)} of your date ranges give only years. Adding the month "
+                    "makes the length of each role unambiguous — \"2021 – 2022\" could be "
+                    "two months or twenty-three."
+                ),
+                evidence=year_only[0].line or year_only[0].label(),
+            )
+        )
+
+    # --- Undated roles ----------------------------------------------------
+    #
+    # Only once we have parsed something. On a resume we simply could not read,
+    # every line would qualify.
+    undated = _undated_role_lines(text or "", ranges)
+    if undated:
+        findings.append(
+            Finding(
+                code="undated_role",
+                severity=SEVERITY_HIGH,
+                message=(
+                    f"{len(undated)} line{'s' if len(undated) != 1 else ''} read like a role "
+                    "but carry no dates. An entry with no dates is the most common reason an "
+                    "ATS drops a job from your history entirely."
+                ),
+                evidence=undated[0],
+            )
+        )
+
+    total_months = merged_months(ordered, today)
+
+    # --- Seniority cross-check --------------------------------------------
+    expectation = _seniority_expectation(experience_level)
+    if expectation and total_months:
+        minimum, label = expectation
+        if total_months < minimum:
+            findings.append(
+                Finding(
+                    code="seniority_mismatch",
+                    severity=SEVERITY_MEDIUM,
+                    message=(
+                        f"You are targeting {label} roles, but the dates on this resume add up "
+                        f"to about {_describe_months(total_months)}. If you have earlier "
+                        "experience that is not listed, add it — a reviewer works from the "
+                        "dates, not the job title you are aiming for."
+                    ),
+                )
+            )
+
+    findings.sort(key=lambda f: _SEVERITY_ORDER.get(f.severity, 99))
+
+    return Timeline(
+        parsed=True,
+        ranges=ordered,
+        findings=findings,
+        total_months=total_months,
+        total_years=round(total_months / 12, 1),
+        largest_gap_months=largest_gap,
+        has_current_role=any(r.is_current for r in ordered),
+        formats_seen=formats,
+    )

--- a/docs/TIMELINE.md
+++ b/docs/TIMELINE.md
@@ -1,0 +1,116 @@
+# Employment timeline analysis
+
+Every other signal the analyzer produces is about **what** a resume says. This
+one is about **when**.
+
+Recruiters read the dates before the bullets, and ATS platforms parse them into
+structured employment records, so a resume can score 90 on keywords and still be
+filtered on its history. The analysis is returned under `timeline` alongside
+`score_breakdown`.
+
+## What it reports
+
+| Finding | Severity | Raised when |
+| --- | --- | --- |
+| `undated_role` | high | A line reads like a job title with no date range near it |
+| `reversed_range` | high | A range ends before it starts |
+| `employment_gap` | medium / high | A gap of 4 months or more; high past a year |
+| `future_date` | medium | A start more than 3 months from now |
+| `seniority_mismatch` | medium | Total experience falls short of the selected level |
+| `overlapping_roles` | low | Two roles run concurrently for 2 months or more |
+| `mixed_date_formats` | low | More than one date format in the document |
+| `year_only_dates` | low | A range gives years but no months |
+| `no_dates_found` | info | Nothing parseable — see below |
+
+Each finding carries a `message` written for the person being scored, meant to
+be rendered as-is, and usually an `evidence` string quoting the resume so the
+line can be found.
+
+## Formats it reads
+
+```
+Jan 2020 – Mar 2022      January 2020 to March 2022      Sept. 2019 - Dec. 2021
+03/2017 - 06/2019        2020-01 until 2021-11           2015 – 2016
+Jan 2020 – Present       Mar 2021 - Current              Feb 2019 - now
+```
+
+Hyphen, double hyphen, en dash, em dash, tilde, `to`, `until`, `through` and
+`till` all separate a range. `Present`, `Current`, `Currently`, `Now`,
+`Ongoing`, `To date` and `Today` all mean an open end.
+
+Ranges are matched **within a line**, never across a line break. Two-column
+resumes flatten to text in ways that would otherwise let the end of one line and
+the start of the next combine into a date nobody wrote.
+
+## Total experience
+
+Reported as the **union** of the ranges, so concurrent roles are counted once. A
+promotion written as two entries, or a contract held alongside a staff job,
+would otherwise inflate the total — and that total is what the seniority check
+compares against, so double-counting there produces exactly the wrong advice.
+
+A year-only end reads as **December** of that year. `2019 – 2021` describes work
+through 2021; treating it as ending that January would invent an eleven-month
+gap that is not in the document.
+
+## Silence is a feature
+
+The layout is gone by the time this sees the text. `pdfplumber` gives a stream
+of lines with no idea which is a heading and which is a bullet, so this cannot
+know that `Acme Corp` and `Jan 2020 – Mar 2022` belong together — only that they
+are near each other.
+
+So the rule is: **report what is confident, say nothing where it is not.**
+
+- If no range parses at all, the result is `parsed: false` and one `info`
+  finding saying *we could not read your dates* — not a page of warnings. A
+  false "you forgot your dates" on a resume that has them sends someone looking
+  for a problem that does not exist, which is worse than missing a real one.
+- `undated_role` is only ever raised once some ranges *have* parsed, and a
+  heading counts as dated when a range appears one line above it or up to two
+  lines below. That covers `Title / Dates`, `Title / Company / Dates`, dates on
+  the same line, and a right-aligned date column that flattened above its
+  heading.
+- A line containing any four-digit year is skipped entirely: a date we failed to
+  pair into a *range* is still a date.
+
+## It does not affect your score
+
+`timeline` is deliberately not folded into the headline `score`. That number is
+persisted on `ResumeAnalysis` and read by the leaderboard, version comparison
+and the weekly digest, so changing what it means would change every historical
+row — the same reasoning `scoring.compute_score_breakdown` gives for staying out
+of it.
+
+## Shape
+
+```json
+"timeline": {
+  "parsed": true,
+  "total_months": 79,
+  "total_years": 6.6,
+  "largest_gap_months": 14,
+  "has_current_role": true,
+  "formats_seen": ["Jan 2020", "Present"],
+  "ranges": [
+    {
+      "start_year": 2020, "start_month": 1,
+      "end_year": null, "end_month": null,
+      "is_current": true,
+      "text": "Jan 2020 - Present",
+      "line": "Senior Backend Engineer, Acme Corp   Jan 2020 - Present"
+    }
+  ],
+  "findings": [
+    {
+      "code": "employment_gap",
+      "severity": "high",
+      "message": "There is a gap of 1 year 2 months between …",
+      "evidence": "Mar 2017 - Jun 2019 → Jan 2020 - Present"
+    }
+  ]
+}
+```
+
+`findings` is sorted by severity, so a UI can render it in order without
+sorting again.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,9 +19,9 @@ import { SuggestionVote, type VoteValue } from './components/SuggestionVote'
 import { Footer } from './Footer'
 import PrivacyPolicyPage from './pages/PrivacyPolicyPage'
 import { InterviewQuestionsPanel } from './components/InterviewQuestionsPanel'
-import { ScoreBreakdown, type ScoreBreakdownData } from './components/ScoreBreakdown'
 import { TimelinePanel } from './components/TimelinePanel'
 import { type TimelineData } from './utils/timelineFormat'
+import { ScoreBreakdown, type ScoreBreakdownData } from './components/ScoreBreakdown'
 
 type Theme = 'light' | 'dark'
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import { Footer } from './Footer'
 import PrivacyPolicyPage from './pages/PrivacyPolicyPage'
 import { InterviewQuestionsPanel } from './components/InterviewQuestionsPanel'
 import { ScoreBreakdown, type ScoreBreakdownData } from './components/ScoreBreakdown'
+import { TimelinePanel } from './components/TimelinePanel'
+import { type TimelineData } from './utils/timelineFormat'
 
 type Theme = 'light' | 'dark'
 
@@ -127,6 +129,7 @@ function App() {
   const [isDragging, setIsDragging] = useState(false)
   const [score, setScore] = useState<number | null>(null)
   const [scoreBreakdown, setScoreBreakdown] = useState<ScoreBreakdownData | null>(null)
+  const [timeline, setTimeline] = useState<TimelineData | null>(null)
   const [skills, setSkills] = useState<string[]>([])
   const [suggestions, setSuggestions] = useState<string[]>([])
   const [roastMode, setRoastMode] = useState<boolean>(false)
@@ -351,6 +354,7 @@ function App() {
 
       setScore(result.score)
       setScoreBreakdown(result.score_breakdown || null)
+      setTimeline(result.timeline || null)
       setSkills(result.skills_found || [])
       setSuggestions(result.suggestions || [])
       setMatchedSkills(result.matched_skills || [])
@@ -443,6 +447,7 @@ function App() {
     setFile(null)
     setScore(null)
     setScoreBreakdown(null)
+    setTimeline(null)
     setSkills([])
     setSuggestions([])
     setMatchedSkills([])
@@ -536,6 +541,7 @@ function App() {
     setScore(entry.score)
     // History entries predate the breakdown and do not carry one.
     setScoreBreakdown(null)
+    setTimeline(null)
     setSkills(entry.skills)
     setSuggestions(entry.suggestions)
     setMatchedSkills(entry.matchedSkills)
@@ -800,6 +806,14 @@ function App() {
               <AtsScore score={score} />
 
               <ScoreBreakdown breakdown={scoreBreakdown} />
+
+              {/*
+                Employment timeline. Recruiters read the dates before the
+                bullets and an ATS parses them into structured employment
+                records, so a resume can score well here and still be filtered
+                on its history — which nothing in the analyzer looked at (#709).
+              */}
+              <TimelinePanel timeline={timeline} />
 
               <ResumePreview text={resumeText} skills={skills} />
 

--- a/frontend/src/components/TimelinePanel.css
+++ b/frontend/src/components/TimelinePanel.css
@@ -1,0 +1,172 @@
+.timeline-panel {
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  border-radius: 8px;
+  background: var(--bg-surface, rgba(255, 255, 255, 0.03));
+  margin-top: 16px;
+  text-align: left;
+  overflow: hidden;
+}
+
+.timeline-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.timeline-header--button {
+  cursor: pointer;
+}
+
+.timeline-header--button:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.timeline-title {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.timeline-summary {
+  font-size: 0.82rem;
+  opacity: 0.7;
+}
+
+.timeline-chevron {
+  margin-left: auto;
+  opacity: 0.6;
+}
+
+.timeline-badge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+}
+
+.timeline-badge--high,
+.timeline-finding-flag--high {
+  color: #ef4444;
+}
+
+.timeline-badge--medium,
+.timeline-finding-flag--medium {
+  color: #f59e0b;
+}
+
+.timeline-badge--low,
+.timeline-finding-flag--low {
+  color: #38bdf8;
+}
+
+.timeline-badge--info,
+.timeline-finding-flag--info {
+  color: #94a3b8;
+}
+
+.timeline-body {
+  padding: 0 16px 16px;
+}
+
+.timeline-ranges {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0 0 0 14px;
+  border-left: 2px solid var(--border-color, rgba(255, 255, 255, 0.12));
+}
+
+.timeline-range {
+  position: relative;
+  padding: 4px 0;
+}
+
+.timeline-range::before {
+  content: '';
+  position: absolute;
+  left: -19px;
+  top: 12px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-color, #6366f1);
+}
+
+.timeline-range-dates {
+  font-weight: 600;
+  font-size: 0.88rem;
+}
+
+.timeline-range-context {
+  display: block;
+  font-size: 0.78rem;
+  opacity: 0.6;
+  overflow-wrap: anywhere;
+}
+
+.timeline-stat {
+  font-size: 0.82rem;
+  opacity: 0.8;
+  margin: 0 0 12px;
+}
+
+.timeline-clean {
+  font-size: 0.85rem;
+  color: #22c55e;
+  margin: 0;
+}
+
+.timeline-findings {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.timeline-finding {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.timeline-finding-flag {
+  flex: 0 0 20px;
+  height: 20px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.timeline-finding-text {
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.timeline-finding-evidence {
+  display: block;
+  margin-top: 3px;
+  font-size: 0.78rem;
+  opacity: 0.6;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
+.timeline-empty {
+  padding: 0 16px 16px;
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}

--- a/frontend/src/components/TimelinePanel.test.tsx
+++ b/frontend/src/components/TimelinePanel.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { TimelinePanel } from './TimelinePanel'
+import {
+  formatDuration,
+  formatEndpoint,
+  formatRange,
+  type TimelineData,
+} from '../utils/timelineFormat'
+
+function timeline(overrides: Partial<TimelineData> = {}): TimelineData {
+  return {
+    parsed: true,
+    ranges: [
+      {
+        start_year: 2020,
+        start_month: 1,
+        end_year: null,
+        end_month: null,
+        is_current: true,
+        text: 'Jan 2020 - Present',
+        line: 'Senior Backend Engineer, Acme Corp',
+      },
+    ],
+    findings: [],
+    total_months: 79,
+    total_years: 6.6,
+    largest_gap_months: 0,
+    has_current_role: true,
+    formats_seen: ['Jan 2020', 'Present'],
+    ...overrides,
+  }
+}
+
+describe('TimelinePanel (#709)', () => {
+  it('renders nothing without a timeline', () => {
+    const { container } = render(<TimelinePanel timeline={null} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('summarises total experience and role count', () => {
+    render(<TimelinePanel timeline={timeline()} />)
+
+    expect(screen.getByText(/6 years 7 months across 1 role/)).toBeInTheDocument()
+  })
+
+  it('says when the person is currently employed', () => {
+    render(<TimelinePanel timeline={timeline()} />)
+
+    expect(screen.getByText(/currently employed/)).toBeInTheDocument()
+  })
+
+  it('keeps the detail collapsed until asked', () => {
+    render(<TimelinePanel timeline={timeline()} />)
+
+    expect(screen.queryByText('Jan 2020 – Present')).not.toBeInTheDocument()
+  })
+
+  it('lists the parsed ranges once expanded', async () => {
+    const user = userEvent.setup()
+    render(<TimelinePanel timeline={timeline()} />)
+
+    await user.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Jan 2020 – Present')).toBeInTheDocument()
+    expect(screen.getByText('Senior Backend Engineer, Acme Corp')).toBeInTheDocument()
+  })
+
+  it('shows the findings with their severity', async () => {
+    const user = userEvent.setup()
+    render(
+      <TimelinePanel
+        timeline={timeline({
+          findings: [
+            { code: 'employment_gap', severity: 'high', message: 'There is a gap of 2 years.' },
+          ],
+        })}
+      />
+    )
+
+    await user.click(screen.getByRole('button'))
+
+    expect(screen.getByText('There is a gap of 2 years.')).toBeInTheDocument()
+    expect(screen.getByTitle('Fix this')).toBeInTheDocument()
+  })
+
+  it('counts the findings on the collapsed header', () => {
+    render(
+      <TimelinePanel
+        timeline={timeline({
+          findings: [
+            { code: 'a', severity: 'medium', message: 'One' },
+            { code: 'b', severity: 'low', message: 'Two' },
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByText('2 notes')).toBeInTheDocument()
+  })
+
+  it('says so plainly when there is nothing to report', async () => {
+    const user = userEvent.setup()
+    render(<TimelinePanel timeline={timeline()} defaultExpanded />)
+
+    expect(screen.getByText(/Nothing stands out/)).toBeInTheDocument()
+    await user.click(screen.getByRole('button'))
+  })
+
+  it('reports the largest gap when there is one', () => {
+    render(<TimelinePanel timeline={timeline({ largest_gap_months: 14 })} defaultExpanded />)
+
+    expect(screen.getByText(/1 year 2 months/)).toBeInTheDocument()
+  })
+
+  it('does not claim a resume has no dates when we merely could not read them', () => {
+    // The distinction the whole feature turns on: a false "you forgot your
+    // dates" sends people hunting for a problem they do not have.
+    render(
+      <TimelinePanel
+        timeline={timeline({
+          parsed: false,
+          ranges: [],
+          findings: [
+            {
+              code: 'no_dates_found',
+              severity: 'info',
+              message: 'We could not read any employment dates from this resume.',
+            },
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByText(/could not read any employment dates/)).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+})
+
+describe('formatEndpoint', () => {
+  it('renders a month and year', () => {
+    expect(formatEndpoint(2020, 3)).toBe('Mar 2020')
+  })
+
+  it('leaves a year-only date as a year', () => {
+    // Inventing "Jan" would contradict the year_only_dates advice beside it.
+    expect(formatEndpoint(2020, null)).toBe('2020')
+  })
+
+  it('renders a null year as Present', () => {
+    expect(formatEndpoint(null, null)).toBe('Present')
+  })
+
+  it('ignores an out-of-range month rather than indexing off the end', () => {
+    expect(formatEndpoint(2020, 13)).toBe('2020')
+    expect(formatEndpoint(2020, 0)).toBe('2020')
+  })
+})
+
+describe('formatRange', () => {
+  it('renders a closed range', () => {
+    expect(
+      formatRange({
+        start_year: 2017,
+        start_month: 3,
+        end_year: 2019,
+        end_month: 6,
+        is_current: false,
+        text: '',
+      })
+    ).toBe('Mar 2017 – Jun 2019')
+  })
+
+  it('renders a current range', () => {
+    expect(
+      formatRange({
+        start_year: 2020,
+        start_month: 1,
+        end_year: null,
+        end_month: null,
+        is_current: true,
+        text: '',
+      })
+    ).toBe('Jan 2020 – Present')
+  })
+})
+
+describe('formatDuration', () => {
+  it('uses months under a year', () => {
+    expect(formatDuration(9)).toBe('9 months')
+    expect(formatDuration(1)).toBe('1 month')
+  })
+
+  it('uses whole years when they divide', () => {
+    expect(formatDuration(24)).toBe('2 years')
+    expect(formatDuration(12)).toBe('1 year')
+  })
+
+  it('combines years and months', () => {
+    expect(formatDuration(51)).toBe('4 years 3 months')
+    expect(formatDuration(13)).toBe('1 year 1 month')
+  })
+
+  it('does not render a negative or zero duration as nonsense', () => {
+    expect(formatDuration(0)).toBe('0 months')
+    expect(formatDuration(-4)).toBe('0 months')
+  })
+})

--- a/frontend/src/components/TimelinePanel.tsx
+++ b/frontend/src/components/TimelinePanel.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react'
+import {
+  formatDuration,
+  formatRange,
+  type FindingSeverity,
+  type TimelineData,
+} from '../utils/timelineFormat'
+
+interface TimelinePanelProps {
+  timeline: TimelineData | null | undefined
+  /** Open on first render. Off by default, like the score breakdown. */
+  defaultExpanded?: boolean
+}
+import './TimelinePanel.css'
+
+const SEVERITY_ICON: Record<FindingSeverity, string> = {
+  high: '!',
+  medium: '▲',
+  low: '◦',
+  info: 'i',
+}
+
+const SEVERITY_LABEL: Record<FindingSeverity, string> = {
+  high: 'Fix this',
+  medium: 'Worth a look',
+  low: 'Polish',
+  info: 'Note',
+}
+
+/**
+ * The employment timeline: how long the resume covers, and what a reader would
+ * notice about its dates.
+ *
+ * Recruiters read the dates before the bullets and ATS platforms parse them into
+ * structured employment records, so a resume can score well on keywords and
+ * still be filtered on its history. Nothing in the analyzer looked at dates
+ * before this (#709).
+ *
+ * The panel says nothing when the backend could not read any dates. The dates
+ * may well be there in a layout that did not survive text extraction, and
+ * asserting "your resume has no dates" would send people looking for a problem
+ * they do not have — so that case gets one explanatory line, not a list of
+ * warnings.
+ */
+export function TimelinePanel({ timeline, defaultExpanded = false }: TimelinePanelProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+
+  if (!timeline) return null
+
+  const { parsed, ranges, findings, total_months, largest_gap_months, has_current_role } = timeline
+
+  if (!parsed) {
+    const note = findings[0]?.message
+    return (
+      <div className="timeline-panel timeline-panel--unparsed">
+        <div className="timeline-header">
+          <span className="timeline-title">Employment timeline</span>
+        </div>
+        <p className="timeline-empty">
+          {note ?? 'We could not read any employment dates from this resume.'}
+        </p>
+      </div>
+    )
+  }
+
+  const worst = findings[0]?.severity
+
+  return (
+    <div className="timeline-panel">
+      <button
+        type="button"
+        className="timeline-header timeline-header--button"
+        onClick={() => setExpanded((open) => !open)}
+        aria-expanded={expanded}
+      >
+        <span className="timeline-title">Employment timeline</span>
+        <span className="timeline-summary">
+          {formatDuration(total_months)} across {ranges.length}{' '}
+          {ranges.length === 1 ? 'role' : 'roles'}
+          {has_current_role ? ' · currently employed' : ''}
+        </span>
+        {findings.length > 0 && (
+          <span className={`timeline-badge timeline-badge--${worst}`}>
+            {findings.length} {findings.length === 1 ? 'note' : 'notes'}
+          </span>
+        )}
+        <span className="timeline-chevron" aria-hidden="true">
+          {expanded ? '▾' : '▸'}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="timeline-body">
+          <ol className="timeline-ranges">
+            {ranges.map((range, index) => (
+              <li key={`${range.text}-${index}`} className="timeline-range">
+                <span className="timeline-range-dates">{formatRange(range)}</span>
+                {range.line && range.line !== range.text && (
+                  <span className="timeline-range-context">{range.line}</span>
+                )}
+              </li>
+            ))}
+          </ol>
+
+          {largest_gap_months > 0 && (
+            <p className="timeline-stat">
+              Largest gap: <strong>{formatDuration(largest_gap_months)}</strong>
+            </p>
+          )}
+
+          {findings.length === 0 ? (
+            <p className="timeline-clean">
+              Nothing stands out. Your dates are consistent and continuous.
+            </p>
+          ) : (
+            <ul className="timeline-findings">
+              {findings.map((finding) => (
+                <li key={finding.code + finding.evidence} className="timeline-finding">
+                  <span
+                    className={`timeline-finding-flag timeline-finding-flag--${finding.severity}`}
+                    title={SEVERITY_LABEL[finding.severity]}
+                  >
+                    {SEVERITY_ICON[finding.severity]}
+                  </span>
+                  <span className="timeline-finding-text">
+                    {finding.message}
+                    {finding.evidence && (
+                      <span className="timeline-finding-evidence">{finding.evidence}</span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/utils/timelineFormat.ts
+++ b/frontend/src/utils/timelineFormat.ts
@@ -1,0 +1,88 @@
+/**
+ * Types and formatting for the employment timeline, kept out of the component.
+ *
+ * `TimelinePanel.tsx` is a component module, and exporting helpers alongside a
+ * component breaks React Fast Refresh — the whole module reloads instead of the
+ * component's state surviving. Splitting also lets the formatting be tested as
+ * the pure functions it is.
+ *
+ * Mirrors `analyzer/timeline.py`.
+ */
+
+export type FindingSeverity = 'high' | 'medium' | 'low' | 'info'
+
+export interface TimelineFinding {
+  code: string
+  severity: FindingSeverity
+  message: string
+  /** Text from the resume the finding refers to, so it can be located. */
+  evidence?: string
+}
+
+export interface TimelineRange {
+  start_year: number
+  start_month: number | null
+  end_year: number | null
+  end_month: number | null
+  is_current: boolean
+  text: string
+  line?: string
+}
+
+export interface TimelineData {
+  /** False when no dates could be read. Not the same as "there are none". */
+  parsed: boolean
+  ranges: TimelineRange[]
+  findings: TimelineFinding[]
+  total_months: number
+  total_years: number
+  largest_gap_months: number
+  has_current_role: boolean
+  formats_seen: string[]
+}
+
+const MONTH_NAMES = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+/**
+ * Render one end of a range the way the resume wrote it, near enough.
+ *
+ * A year-only date stays a year rather than becoming "Jan 2021" — the whole
+ * point of the `year_only_dates` finding is that we do not know the month, and
+ * inventing one on the display would contradict the advice beside it.
+ */
+export function formatEndpoint(year: number | null, month: number | null): string {
+  if (year === null) return 'Present'
+  if (month === null || month < 1 || month > 12) return String(year)
+  return `${MONTH_NAMES[month - 1]} ${year}`
+}
+
+export function formatRange(range: TimelineRange): string {
+  const start = formatEndpoint(range.start_year, range.start_month)
+  const end = range.is_current ? 'Present' : formatEndpoint(range.end_year, range.end_month)
+  return `${start} – ${end}`
+}
+
+/** "4 years 3 months", or "9 months" under a year. */
+export function formatDuration(totalMonths: number): string {
+  if (totalMonths <= 0) return '0 months'
+  if (totalMonths < 12) return `${totalMonths} month${totalMonths === 1 ? '' : 's'}`
+
+  const years = Math.floor(totalMonths / 12)
+  const months = totalMonths % 12
+  const yearPart = `${years} year${years === 1 ? '' : 's'}`
+  if (months === 0) return yearPart
+  return `${yearPart} ${months} month${months === 1 ? '' : 's'}`
+}


### PR DESCRIPTION
## 📝 Description

Every signal the analyzer produces is about **what** a resume says. Nothing looked at **when**.

```
$ grep -rni "employment\|timeline\|date_range\|career gap" backend/analyzer/ backend/resume_analyzer/
backend/analyzer/scoring.py:52:        "employment",
```

That single hit is a section-heading synonym. `scoring.py` checks an `experience` heading exists and stops. Recruiters read the dates before the bullets, and ATS platforms parse them into structured employment records — so a resume can score 90 here and still be filtered on its history.

`analyzer/timeline.py` parses date ranges out of the extracted text and reports what a reader would notice.

| Finding | Severity | Raised when |
| --- | --- | --- |
| `undated_role` | high | A line reads like a job title with no dates near it |
| `reversed_range` | high | A range ends before it starts |
| `employment_gap` | medium / high | 4 months or more; high past a year |
| `future_date` | medium | A start more than 3 months out |
| `seniority_mismatch` | medium | Total experience falls short of the selected level |
| `overlapping_roles` | low | Two roles concurrent for 2 months or more |
| `mixed_date_formats` | low | More than one date format in the document |
| `year_only_dates` | low | Years but no months |
| `no_dates_found` | info | Nothing parseable |

Each carries a `message` written for the person being scored and meant to be rendered as-is, in the style of `scoring.FactorScore.detail`, plus an `evidence` string quoting the resume so the line can be found.

### Total experience is a union, not a sum

Concurrent ranges are counted once. A promotion written as two entries, or a contract held alongside a staff job, would otherwise inflate the total — and that total is exactly what the seniority check compares against, so double-counting there produces the *opposite* of the right advice.

A year-only end reads as **December** of that year. `2019 – 2021` describes work through 2021; treating it as ending that January invents an eleven-month gap that is not in the document.

### It does not touch the score

`timeline` sits alongside `score_breakdown` and is deliberately not folded into the headline `score`. That number is persisted on `ResumeAnalysis` and read by the leaderboard, version comparison and the weekly digest, so changing what it means would change every historical row — the same reasoning `compute_score_breakdown`'s docstring already gives.

### Staying quiet is the design

This is the part worth reviewing hardest, because it is where the feature could easily be worse than not having it.

The layout is gone by the time this sees the text. `pdfplumber` gives a stream of lines with no idea which is a heading and which is a bullet, so it cannot know that `Acme Corp` and `Jan 2020 – Mar 2022` belong together — only that they are near each other. A false *"you forgot your dates"* on a resume that has them sends someone hunting for a problem that does not exist, which is worse than missing a real one.

So:

- **Nothing parseable → `parsed: false` and one `info` line**, not a page of warnings. The panel says *we could not read your dates*, which is true, rather than *your resume has no dates*, which may not be.
- **`undated_role` is only ever raised once some ranges have parsed.** A heading counts as dated when a range sits **one line above** it or **up to two lines below** — asymmetric, and that shape is deliberate. Two below covers `Title / Dates` and `Title / Company / Dates`; one above covers a right-aligned date column that flattened to the line before its heading. Widening it backwards is exactly what makes a genuinely undated role three lines under a dated one look fine. My first cut used a symmetric ±2 window and swallowed a real undated role; there is a test for it now.
- **A line containing any four-digit year is skipped**, because a date we failed to pair into a *range* is still a date.
- **Ranges are matched within a line, never across a line break.** Two-column resumes flatten in ways that would otherwise let the end of one line and the start of the next combine into a date nobody wrote.
- **Reversed and far-future ranges are dropped** after being reported, so they cannot poison the gap and total-experience arithmetic downstream.

### Thresholds, and why they are where they are

`GAP_THRESHOLD_MONTHS = 4` — under a quarter is a notice period plus a job search, and nobody asks about it. `OVERLAP_THRESHOLD_MONTHS = 2` — a few weeks of overlap is what leaving one job for another looks like when both are written to the month. `FUTURE_TOLERANCE_MONTHS = 3` — offers do get signed a couple of months out. All three are module constants with that reasoning beside them, and all three have boundary tests.

The seniority check is a lenient floor only (60 months for Senior, 24 for Mid). The point is to catch the resume claiming Senior while showing eighteen months, not to police four versus five years — and an unrecognised level skips the check rather than guessing.

## 🔗 Related Issue

Closes #709

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

**Backend — 57 new tests** in `analyzer/tests_timeline.py`. `today` is injected everywhere, so "current role" and "future date" are tested without freezing the clock globally.

The class that carries the argument is **`FalsePositiveTests`**: every case in it is a resume that is *fine*, and any finding is a bug. Dates on the line below the title; title / company / dates; dates on the line *above* the title; dates on the same line; a resume we could not parse producing exactly one informational finding and nothing else; metrics in bullets (`from 1200 ms to 340 ms`, `by 40% across 3 services`) not being read as dates; and a clean recent resume producing an empty findings list.

*Parsing* — month names long and abbreviated with trailing dots, numeric, ISO, year-only; five spellings of "present"; six separators including en and em dashes; several ranges across several lines; **no range assembled across a line break**; implausible years and version numbers (`Python 3.9 to 3.12`) rejected; and the matched text kept so a finding can quote it back.

*Arithmetic* — inclusive endpoints; a year-only end running to December; a current role running to today; separate roles adding up; **concurrent roles counted once**; adjacent roles merging into one span.

*Gaps* — reported over the threshold and not under it, with `test_the_threshold_is_exactly_where_it_says_it_is` pinning both sides of the boundary; severity escalating past a year; both sides named in the evidence; and `test_a_gap_is_measured_from_the_furthest_end_not_the_previous_row`, which is the bug you get from comparing consecutive entries — a long role spanning a short one creates a phantom gap.

Plus impossible dates (including that a reversed range does not poison the totals), format consistency (with `Present` deliberately not counting as a competing format), undated roles, the seniority check across four phrasings, ordering by severity, and JSON-serialisability of the dict form.

Three integration tests go through `analyze_resume`: the timeline reaches the result, a resume with no dates still analyses, and **the headline score is byte-identical with and without dates in the text**.

```
Ran 400 tests in 9.0s
FAILED (failures=8)
```

The 8 are the pre-existing `tests_device_alerts` / `tests_login_errors` failures, identical to the baseline on `main` (343 tests, same 8). 400 − 343 = 57.

> **Note for CI:** `main` currently has two leaf migrations at 0016, so `manage.py test` cannot build a database on it (`CommandError: Conflicting migrations detected`). I ran this suite with a local merge migration deliberately kept out of this diff. #710 carries the merge; #672 also resolves it. This PR adds no migration and needs no rebase when either lands.

**Frontend — 20 new tests** in `components/TimelinePanel.test.tsx`. The one that matters is `does not claim a resume has no dates when we merely could not read them` — the distinction the whole feature turns on. Also: the summary line, collapse/expand, findings rendered with their severity, the header count, the clean state, the largest gap, and the formatters — including that a year-only date **stays a year** rather than becoming "Jan 2021", which would contradict the `year_only_dates` advice sitting next to it.

```
Test Files  32 passed (32)
     Tests  184 passed (184)   # 164 before, +20
```

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client

`tsc -b` reports only the pre-existing `swagger-ui-react` error in `pages/Apidocs.tsx`. `eslint` clean on every new file; `App.tsx` unchanged in its 9 pre-existing complaints (14 added lines there, no reformat mixed in). Formatting helpers live in `utils/timelineFormat.ts` rather than the component module, because exporting them alongside a component breaks Fast Refresh.

Manually: ran resumes with dates on the title line, on the line below, in a right-aligned column, and with no dates at all, and checked each against what the panel said.

Docs: `docs/TIMELINE.md`.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)

---

### Merge notes

The throttle rate is read from settings inside the throttle class, following the existing `UploadRateThrottle`, rather than added to `DEFAULT_THROTTLE_RATES`. It keeps the number beside the docstring that justifies it — and it means the four sibling PRs opened alongside this one (#710, #711, #712, #713, #714) do not all edit the same dictionary. Import anchors were moved apart for the same reason. All five merge cleanly into `main` in any order; I checked by test-merging the set in both directions.
