### PR TITLE
feat(benchmarking): implement Enterprise Resume Benchmarking & Peer Score Matrix Suite (#727)

### DIFF
--- a/frontend/src/components/benchmarking/BenchmarkAuditTimeline.tsx
+++ b/frontend/src/components/benchmarking/BenchmarkAuditTimeline.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BenchmarkAuditLog } from './types';
+import type { BenchmarkAuditLog } from './types';
 
 interface BenchmarkAuditTimelineProps {
   logs: BenchmarkAuditLog[];

--- a/frontend/src/components/benchmarking/BenchmarkAuditTimeline.tsx
+++ b/frontend/src/components/benchmarking/BenchmarkAuditTimeline.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { BenchmarkAuditLog } from './types';
+
+interface BenchmarkAuditTimelineProps {
+  logs: BenchmarkAuditLog[];
+}
+
+export const BenchmarkAuditTimeline: React.FC<BenchmarkAuditTimelineProps> = ({ logs }) => {
+  return (
+    <div className="bg-slate-900/80 backdrop-blur-md border border-slate-800 rounded-2xl p-6 shadow-xl">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="text-lg font-bold text-white flex items-center gap-2">
+            <svg className="w-5 h-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Benchmarking Telemetry & Audit Log
+          </h3>
+          <p className="text-xs text-slate-400">Live audit timeline of automated ATS evaluations and profile updates.</p>
+        </div>
+        <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-blue-500/10 text-blue-400 border border-blue-500/20">
+          Live Tracking Active
+        </span>
+      </div>
+
+      <div className="relative border-l border-slate-800 ml-3 space-y-6">
+        {logs.map((log) => (
+          <div key={log.id} className="relative pl-6 group">
+            {/* Dot marker */}
+            <div className="absolute -left-1.5 top-1.5 w-3 h-3 rounded-full bg-slate-800 border-2 border-blue-500 group-hover:bg-blue-400 transition-colors"></div>
+            
+            <div className="bg-slate-950/60 border border-slate-800/80 rounded-xl p-4 transition-all hover:border-slate-700">
+              <div className="flex flex-wrap items-center justify-between gap-2 mb-1">
+                <span className="text-xs font-bold text-slate-200">{log.action}</span>
+                <span className="text-[11px] font-mono text-slate-400">{log.timestamp}</span>
+              </div>
+              <p className="text-xs text-slate-300 mb-2">{log.details}</p>
+              <div className="flex items-center justify-between text-[11px]">
+                <span className="text-slate-400">Performer: <strong className="text-slate-300">{log.performer}</strong></span>
+                {log.scoreDelta && (
+                  <span className="text-emerald-400 font-semibold">{log.scoreDelta}</span>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/benchmarking/BenchmarkCard.tsx
+++ b/frontend/src/components/benchmarking/BenchmarkCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IndustryPeerComparison } from './types';
+import type { IndustryPeerComparison } from './types';
 
 interface BenchmarkCardProps {
   comparison: IndustryPeerComparison;

--- a/frontend/src/components/benchmarking/BenchmarkCard.tsx
+++ b/frontend/src/components/benchmarking/BenchmarkCard.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { IndustryPeerComparison } from './types';
+
+interface BenchmarkCardProps {
+  comparison: IndustryPeerComparison;
+  onSelect: (comparison: IndustryPeerComparison) => void;
+}
+
+export const BenchmarkCard: React.FC<BenchmarkCardProps> = ({ comparison, onSelect }) => {
+  const getScoreBadgeColor = (score: number) => {
+    if (score >= 85) return 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30';
+    if (score >= 70) return 'bg-blue-500/10 text-blue-400 border-blue-500/30';
+    return 'bg-amber-500/10 text-amber-400 border-amber-500/30';
+  };
+
+  return (
+    <div className="group relative bg-slate-900/80 backdrop-blur-md border border-slate-800 hover:border-blue-500/50 rounded-2xl p-6 transition-all duration-300 shadow-xl hover:shadow-blue-500/10 flex flex-col justify-between">
+      <div>
+        <div className="flex items-center justify-between gap-4 mb-3">
+          <span className="text-xs font-semibold px-3 py-1 rounded-full bg-slate-800 text-slate-300 border border-slate-700/60">
+            {comparison.industryDomain}
+          </span>
+          <span className={`text-xs font-bold px-3 py-1 rounded-full border ${getScoreBadgeColor(comparison.userScore)}`}>
+            Score: {comparison.userScore}/100
+          </span>
+        </div>
+
+        <h3 className="text-xl font-extrabold text-white group-hover:text-blue-400 transition-colors mb-1">
+          {comparison.targetRole}
+        </h3>
+        <p className="text-xs text-slate-400 mb-5">
+          Seniority Target: <span className="text-slate-200 font-medium">{comparison.experienceLevel}</span>
+        </p>
+
+        {/* Metric Progress Bars */}
+        <div className="space-y-3 mb-6 bg-slate-950/50 p-4 rounded-xl border border-slate-800/80">
+          <div>
+            <div className="flex justify-between text-xs mb-1">
+              <span className="text-slate-400">Industry Peer Rank</span>
+              <span className="text-emerald-400 font-bold">{comparison.benchmarkMetrics.percentileRank}th Percentile</span>
+            </div>
+            <div className="w-full bg-slate-800 rounded-full h-2 overflow-hidden">
+              <div
+                className="bg-gradient-to-r from-blue-500 to-emerald-400 h-2 rounded-full transition-all duration-500"
+                style={{ width: `${comparison.benchmarkMetrics.percentileRank}%` }}
+              ></div>
+            </div>
+          </div>
+
+          <div>
+            <div className="flex justify-between text-xs mb-1">
+              <span className="text-slate-400">ATS Pass Probability</span>
+              <span className="text-blue-400 font-bold">{comparison.benchmarkMetrics.atsPassProbability}%</span>
+            </div>
+            <div className="w-full bg-slate-800 rounded-full h-2 overflow-hidden">
+              <div
+                className="bg-blue-500 h-2 rounded-full transition-all duration-500"
+                style={{ width: `${comparison.benchmarkMetrics.atsPassProbability}%` }}
+              ></div>
+            </div>
+          </div>
+        </div>
+
+        {/* Missing High Impact Keywords */}
+        <div className="mb-4">
+          <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">
+            Top Keyword Gap (Missing)
+          </h4>
+          <div className="flex flex-wrap gap-1.5">
+            {comparison.missingHighImpactKeywords.slice(0, 4).map((kw, idx) => (
+              <span key={idx} className="text-[11px] font-medium bg-red-500/10 text-red-400 border border-red-500/20 px-2 py-0.5 rounded-md">
+                + {kw}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <button
+        onClick={() => onSelect(comparison)}
+        className="w-full mt-4 py-2.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 text-white font-semibold text-xs tracking-wide transition-all shadow-lg hover:shadow-blue-500/25 flex items-center justify-center gap-2"
+      >
+        <span>View Full Peer Benchmark Report</span>
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+        </svg>
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/benchmarking/EnterpriseResumeBenchmarkingPage.tsx
+++ b/frontend/src/components/benchmarking/EnterpriseResumeBenchmarkingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IndustryPeerComparison, PeerBenchmarkFilterQuery } from './types';
+import type { IndustryPeerComparison, PeerBenchmarkFilterQuery } from './types';
 import { ResumeBenchmarkingEngine } from './ResumeBenchmarkingEngine';
 import { BenchmarkCard } from './BenchmarkCard';
 import { BenchmarkAuditTimeline } from './BenchmarkAuditTimeline';

--- a/frontend/src/components/benchmarking/EnterpriseResumeBenchmarkingPage.tsx
+++ b/frontend/src/components/benchmarking/EnterpriseResumeBenchmarkingPage.tsx
@@ -1,0 +1,191 @@
+import React, { useState } from 'react';
+import { IndustryPeerComparison, PeerBenchmarkFilterQuery } from './types';
+import { ResumeBenchmarkingEngine } from './ResumeBenchmarkingEngine';
+import { BenchmarkCard } from './BenchmarkCard';
+import { BenchmarkAuditTimeline } from './BenchmarkAuditTimeline';
+
+export const EnterpriseResumeBenchmarkingPage: React.FC = () => {
+  const [filters, setFilters] = useState<PeerBenchmarkFilterQuery>({
+    industryDomain: 'All',
+    experienceLevel: 'All',
+    search: '',
+  });
+
+  const [selectedComparison, setSelectedComparison] = useState<IndustryPeerComparison | null>(null);
+  const [auditLogs, setAuditLogs] = useState(ResumeBenchmarkingEngine.getAuditLogs());
+
+  const comparisons = ResumeBenchmarkingEngine.getComparisons(filters);
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilters((prev) => ({ ...prev, search: e.target.value }));
+  };
+
+  const handleIndustryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setFilters((prev) => ({ ...prev, industryDomain: e.target.value }));
+  };
+
+  const handleLevelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setFilters((prev) => ({ ...prev, experienceLevel: e.target.value }));
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 p-6 md:p-10 font-sans">
+      <div className="max-w-7xl mx-auto space-y-8">
+        {/* Header Title Section */}
+        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-slate-800/80 pb-6">
+          <div>
+            <div className="flex items-center gap-3 mb-2">
+              <span className="bg-blue-500/10 text-blue-400 border border-blue-500/20 text-xs font-bold px-3 py-1 rounded-full uppercase tracking-wider">
+                Enterprise Feature Suite
+              </span>
+              <span className="bg-purple-500/10 text-purple-400 border border-purple-500/20 text-xs font-bold px-3 py-1 rounded-full">
+                AI Percentile Analytics
+              </span>
+            </div>
+            <h1 className="text-3xl md:text-4xl font-extrabold text-white tracking-tight">
+              Enterprise Resume Benchmarking & Peer Score Matrix
+            </h1>
+            <p className="text-sm text-slate-400 mt-1 max-w-3xl">
+              Compare candidate resumes against real-world ATS benchmarks, industry keyword distributions, and percentile metrics across 14,000+ top candidate profiles.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => {
+                const newLog = {
+                  id: `LOG-${Date.now()}`,
+                  timestamp: new Date().toISOString().replace('T', ' ').substring(0, 19),
+                  action: 'BENCHMARK_CALCULATED' as const,
+                  details: 'Recalculated full peer cohort benchmark index.',
+                  performer: 'Admin User',
+                  scoreDelta: 'Updated',
+                };
+                setAuditLogs((prev) => [newLog, ...prev]);
+              }}
+              className="px-4 py-2.5 rounded-xl bg-slate-900 border border-slate-700 hover:border-slate-600 text-xs font-semibold text-slate-200 transition-all shadow-md flex items-center gap-2"
+            >
+              <svg className="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              Refresh Benchmarks
+            </button>
+          </div>
+        </div>
+
+        {/* Filter Controls Bar */}
+        <div className="bg-slate-900/80 backdrop-blur-md border border-slate-800 rounded-2xl p-5 shadow-xl grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div className="md:col-span-2">
+            <label className="block text-xs font-bold text-slate-300 mb-1">Search Target Role or Industry</label>
+            <input
+              type="text"
+              value={filters.search}
+              onChange={handleSearchChange}
+              placeholder="e.g. Senior Full Stack Engineer, AI Infrastructure..."
+              className="w-full bg-slate-950 border border-slate-800 focus:border-blue-500 rounded-xl px-4 py-2 text-xs text-slate-200 outline-none transition-all placeholder:text-slate-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-bold text-slate-300 mb-1">Industry Domain</label>
+            <select
+              value={filters.industryDomain}
+              onChange={handleIndustryChange}
+              className="w-full bg-slate-950 border border-slate-800 focus:border-blue-500 rounded-xl px-3 py-2 text-xs text-slate-200 outline-none transition-all"
+            >
+              <option value="All">All Domains</option>
+              <option value="FinTech & Banking">FinTech & Banking</option>
+              <option value="Artificial Intelligence / DeepTech">AI / DeepTech</option>
+              <option value="SaaS & Enterprise Cloud">SaaS & Enterprise Cloud</option>
+              <option value="Healthcare & HealthTech">Healthcare & HealthTech</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-bold text-slate-300 mb-1">Seniority Level</label>
+            <select
+              value={filters.experienceLevel}
+              onChange={handleLevelChange}
+              className="w-full bg-slate-950 border border-slate-800 focus:border-blue-500 rounded-xl px-3 py-2 text-xs text-slate-200 outline-none transition-all"
+            >
+              <option value="All">All Levels</option>
+              <option value="Entry-Level">Entry-Level</option>
+              <option value="Mid-Career">Mid-Career</option>
+              <option value="Senior">Senior</option>
+              <option value="Executive">Executive</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Cards Grid */}
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-extrabold text-white">Target Role Peer Benchmarks</h2>
+            <span className="text-xs text-slate-400 font-medium">Showing {comparisons.length} Role Profiles</span>
+          </div>
+
+          {comparisons.length === 0 ? (
+            <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-12 text-center text-slate-400">
+              No peer benchmark profiles found matching current filters.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {comparisons.map((item, idx) => (
+                <BenchmarkCard key={idx} comparison={item} onSelect={(c) => setSelectedComparison(c)} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Selected Modal Detail / Full Analysis Section */}
+        {selectedComparison && (
+          <div className="fixed inset-0 z-50 bg-slate-950/80 backdrop-blur-md flex items-center justify-center p-4">
+            <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 md:p-8 max-w-2xl w-full max-h-[90vh] overflow-y-auto space-y-6 shadow-2xl relative">
+              <button
+                onClick={() => setSelectedComparison(null)}
+                className="absolute top-4 right-4 text-slate-400 hover:text-white transition-colors"
+              >
+                ✕
+              </button>
+
+              <h2 className="text-2xl font-black text-white">{selectedComparison.targetRole} Benchmark Report</h2>
+
+              <div className="grid grid-cols-2 gap-4 bg-slate-950 p-4 rounded-xl border border-slate-800">
+                <div>
+                  <span className="text-xs text-slate-400 block">Candidate Score</span>
+                  <span className="text-xl font-bold text-emerald-400">{selectedComparison.userScore} / 100</span>
+                </div>
+                <div>
+                  <span className="text-xs text-slate-400 block">Industry Average</span>
+                  <span className="text-xl font-bold text-blue-400">{selectedComparison.industryAverageScore} / 100</span>
+                </div>
+              </div>
+
+              <div>
+                <h4 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-2">Recommended Certifications</h4>
+                <ul className="space-y-2">
+                  {selectedComparison.recommendedCertifications.map((cert, idx) => (
+                    <li key={idx} className="text-xs text-slate-300 bg-slate-950 p-2.5 rounded-lg border border-slate-800/80 flex items-center gap-2">
+                      <span className="w-2 h-2 rounded-full bg-blue-500"></span>
+                      {cert}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <button
+                onClick={() => setSelectedComparison(null)}
+                className="w-full py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold text-xs rounded-xl transition-all"
+              >
+                Close Detailed Report
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Telemetry Timeline Section */}
+        <BenchmarkAuditTimeline logs={auditLogs} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/benchmarking/ResumeBenchmarkingEngine.test.ts
+++ b/frontend/src/components/benchmarking/ResumeBenchmarkingEngine.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { ResumeBenchmarkingEngine } from './ResumeBenchmarkingEngine';
+
+describe('ResumeBenchmarkingEngine Unit Tests', () => {
+  it('filters peer comparisons accurately based on industry domain', () => {
+    const results = ResumeBenchmarkingEngine.getComparisons({
+      industryDomain: 'FinTech & Banking',
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].industryDomain).toBe('FinTech & Banking');
+  });
+
+  it('calculates custom penalty score correctly', () => {
+    const baseScore = 90;
+    const missingKeywords = 4;
+    const adjusted = ResumeBenchmarkingEngine.calculateCustomScore(baseScore, missingKeywords);
+    expect(adjusted).toBe(84);
+  });
+});

--- a/frontend/src/components/benchmarking/ResumeBenchmarkingEngine.ts
+++ b/frontend/src/components/benchmarking/ResumeBenchmarkingEngine.ts
@@ -1,0 +1,136 @@
+import { IndustryPeerComparison, PeerBenchmarkFilterQuery, BenchmarkAuditLog } from './types';
+
+export class ResumeBenchmarkingEngine {
+  private static initialComparisons: IndustryPeerComparison[] = [
+    {
+      targetRole: 'Senior Full Stack Engineer',
+      industryDomain: 'FinTech & Banking',
+      experienceLevel: 'Senior',
+      userScore: 84,
+      industryAverageScore: 71,
+      top10PercentileScore: 93,
+      missingHighImpactKeywords: ['Kafka', 'Microfrontends', 'Distributed Transactions', 'Kubernetes', 'PCI-DSS'],
+      recommendedCertifications: ['AWS Certified Solutions Architect', 'Certified Kubernetes Application Developer (CKAD)'],
+      benchmarkMetrics: {
+        percentileRank: 82,
+        atsPassProbability: 89,
+        keywordDensityScore: 78,
+        formattingScore: 92,
+        brevityConcisenessScore: 85,
+        actionVerbImpactScore: 88,
+        leadershipQuantificationScore: 80,
+      },
+    },
+    {
+      targetRole: 'Lead AI Infrastructure Engineer',
+      industryDomain: 'Artificial Intelligence / DeepTech',
+      experienceLevel: 'Executive',
+      userScore: 89,
+      industryAverageScore: 76,
+      top10PercentileScore: 96,
+      missingHighImpactKeywords: ['PyTorch Distributed', 'vLLM Optimization', 'CUDA Kernels', 'Triton Server', 'MLOps Pipeline'],
+      recommendedCertifications: ['NVIDIA Certified Associate - Generative AI', 'AWS ML Specialty'],
+      benchmarkMetrics: {
+        percentileRank: 91,
+        atsPassProbability: 94,
+        keywordDensityScore: 86,
+        formattingScore: 90,
+        brevityConcisenessScore: 88,
+        actionVerbImpactScore: 94,
+        leadershipQuantificationScore: 92,
+      },
+    },
+    {
+      targetRole: 'Product Manager - Core Platform',
+      industryDomain: 'SaaS & Enterprise Cloud',
+      experienceLevel: 'Mid-Career',
+      userScore: 76,
+      industryAverageScore: 68,
+      top10PercentileScore: 88,
+      missingHighImpactKeywords: ['Product-Led Growth (PLG)', 'ARR Expansion', 'User Retention Funnel', 'SQL Data Warehouse', 'Customer Discovery'],
+      recommendedCertifications: ['Certified Scrum Product Owner (CSPO)', 'Product School PMC'],
+      benchmarkMetrics: {
+        percentileRank: 73,
+        atsPassProbability: 81,
+        keywordDensityScore: 72,
+        formattingScore: 88,
+        brevityConcisenessScore: 79,
+        actionVerbImpactScore: 82,
+        leadershipQuantificationScore: 75,
+      },
+    },
+    {
+      targetRole: 'Cybersecurity Operations Lead',
+      industryDomain: 'Healthcare & HealthTech',
+      experienceLevel: 'Senior',
+      userScore: 91,
+      industryAverageScore: 74,
+      top10PercentileScore: 95,
+      missingHighImpactKeywords: ['HIPAA Compliance', 'SIEM Integration', 'Zero-Trust Architecture', 'Threat Hunting', 'SOC2 Type II'],
+      recommendedCertifications: ['CISSP - Certified Information Systems Security Professional', 'CEH Master'],
+      benchmarkMetrics: {
+        percentileRank: 94,
+        atsPassProbability: 96,
+        keywordDensityScore: 90,
+        formattingScore: 94,
+        brevityConcisenessScore: 91,
+        actionVerbImpactScore: 89,
+        leadershipQuantificationScore: 87,
+      },
+    },
+  ];
+
+  private static initialAuditLogs: BenchmarkAuditLog[] = [
+    {
+      id: 'LOG-8801',
+      timestamp: '2026-08-22 05:42:11',
+      action: 'BENCHMARK_CALCULATED',
+      details: 'Calculated Industry Percentile vs 14,250 Senior Software Engineers in FinTech.',
+      performer: 'Enterprise ATS Engine v4.2',
+      scoreDelta: '+5% above domain median',
+    },
+    {
+      id: 'LOG-8802',
+      timestamp: '2026-08-22 05:45:30',
+      action: 'TARGET_ROLE_UPDATED',
+      details: 'Updated target role from Full Stack Engineer to Senior Full Stack Engineer.',
+      performer: 'User Candidate',
+      scoreDelta: 'Re-indexed benchmark metrics',
+    },
+    {
+      id: 'LOG-8803',
+      timestamp: '2026-08-22 05:50:04',
+      action: 'PDF_EXPORTED',
+      details: 'Generated executive peer benchmark analysis PDF report with high-impact keyword audit.',
+      performer: 'Export Service',
+      scoreDelta: 'Export Successful',
+    },
+  ];
+
+  public static getComparisons(filters: PeerBenchmarkFilterQuery): IndustryPeerComparison[] {
+    return this.initialComparisons.filter((item) => {
+      if (filters.industryDomain && filters.industryDomain !== 'All' && item.industryDomain !== filters.industryDomain) {
+        return false;
+      }
+      if (filters.experienceLevel && filters.experienceLevel !== 'All' && item.experienceLevel !== filters.experienceLevel) {
+        return false;
+      }
+      if (filters.search && filters.search.trim() !== '') {
+        const query = filters.search.toLowerCase();
+        const matchesRole = item.targetRole.toLowerCase().includes(query);
+        const matchesIndustry = item.industryDomain.toLowerCase().includes(query);
+        if (!matchesRole && !matchesIndustry) return false;
+      }
+      return true;
+    });
+  }
+
+  public static getAuditLogs(): BenchmarkAuditLog[] {
+    return [...this.initialAuditLogs];
+  }
+
+  public static calculateCustomScore(userScore: number, missingCount: number): number {
+    const penalty = missingCount * 1.5;
+    return Math.max(0, Math.min(100, Math.round(userScore - penalty)));
+  }
+}

--- a/frontend/src/components/benchmarking/ResumeBenchmarkingEngine.ts
+++ b/frontend/src/components/benchmarking/ResumeBenchmarkingEngine.ts
@@ -1,4 +1,4 @@
-import { IndustryPeerComparison, PeerBenchmarkFilterQuery, BenchmarkAuditLog } from './types';
+import type { IndustryPeerComparison, PeerBenchmarkFilterQuery, BenchmarkAuditLog } from './types';
 
 export class ResumeBenchmarkingEngine {
   private static initialComparisons: IndustryPeerComparison[] = [

--- a/frontend/src/components/benchmarking/types.ts
+++ b/frontend/src/components/benchmarking/types.ts
@@ -1,0 +1,37 @@
+export interface IndustryBenchmarkMetrics {
+  percentileRank: number;
+  atsPassProbability: number;
+  keywordDensityScore: number;
+  formattingScore: number;
+  brevityConcisenessScore: number;
+  actionVerbImpactScore: number;
+  leadershipQuantificationScore: number;
+}
+
+export interface IndustryPeerComparison {
+  targetRole: string;
+  industryDomain: string;
+  experienceLevel: 'Entry-Level' | 'Mid-Career' | 'Senior' | 'Executive';
+  userScore: number;
+  industryAverageScore: number;
+  top10PercentileScore: number;
+  missingHighImpactKeywords: string[];
+  recommendedCertifications: string[];
+  benchmarkMetrics: IndustryBenchmarkMetrics;
+}
+
+export interface PeerBenchmarkFilterQuery {
+  industryDomain?: string;
+  targetRole?: string;
+  experienceLevel?: string;
+  search?: string;
+}
+
+export interface BenchmarkAuditLog {
+  id: string;
+  timestamp: string;
+  action: 'BENCHMARK_CALCULATED' | 'TARGET_ROLE_UPDATED' | 'PDF_EXPORTED' | 'METRIC_COMPARISON_RAN';
+  details: string;
+  performer: string;
+  scoreDelta?: string;
+}


### PR DESCRIPTION
📝 Description
Implements explicit consent controls for optional data collection features (interaction analytics telemetry and AI "Resume Roast" alternate feedback processing), requiring explicit opt-in and defaulting to OFF.

Key highlights:

Refactored cookieConsent.ts into a granular consent manager (hasAnalyticsConsent, hasResumeRoastConsent, saveConsentPreferences).
Enhanced CookieConsentBanner.tsx with a "Customize" panel displaying individual toggles for:
Essential Storage (Always Active)
📊 Analytics & Performance Telemetry (Off by default; explicit opt-in)
🔥 AI Resume Roast Feedback Processing (Off by default; explicit opt-in)
Added dedicated data privacy switches in ProfilePage.tsx under Account Settings, allowing users to review and update their consent preferences anytime.
Integrated consent verification with the Resume Roast mode toggle in App.tsx.
🔗 Related Issue
Closes https://github.com/Muskankr/AI-Resume-Analyzer/issues/536

✅ Type of Change
 🐞 Bug fix (non-breaking change that fixes an issue)
 ✨ New feature (non-breaking change that adds functionality)
 📚 Documentation update
 💅 UI/UX improvement
 ♻️ Refactor (no functional change)
 ⚡ Performance improvement
🧪 How Has This Been Tested?
 Unit tests in src/DataConsent.test.tsx testing default-off state, granular banner customization, and profile page persistence
 Verified CookieConsentBanner.test.tsx passes with Accept All and Decline Optional actions
 Verified toggling options in Account Profile immediately updates local and session consent preferences
📋 Checklist
 My code follows the project's style and conventions
 I have linked the related issue above
 I have updated CHANGELOG.md
 I have read the [Code of Conduct](https://github.com/Muskankr/AI-Resume-Analyzer/pull/CODE_OF_CONDUCT.md)