### PR TITLE
feat: add outside click and Escape dismissal for history sidebar

### DIFF
--- a/frontend/src/HistorySidebar.test.tsx
+++ b/frontend/src/HistorySidebar.test.tsx
@@ -145,4 +145,114 @@ describe('HistorySidebar component (#246)', () => {
     const newBadges = screen.getAllByText('NEW')
     expect(newBadges).toHaveLength(1)
   })
+
+  describe('dismissal behaviors (#413)', () => {
+    it('renders a backdrop when open and clicking it calls onToggle', () => {
+      const handleToggle = vi.fn()
+      render(
+        <HistorySidebar
+          entries={mockEntries}
+          isOpen={true}
+          onToggle={handleToggle}
+          onSelect={() => {}}
+          onDelete={() => {}}
+          onClear={() => {}}
+        />
+      )
+
+      const backdrop = screen.getByTestId('history-sidebar-overlay')
+      expect(backdrop).toBeInTheDocument()
+
+      fireEvent.click(backdrop)
+      expect(handleToggle).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onToggle when clicking inside the panel', () => {
+      const handleToggle = vi.fn()
+      render(
+        <HistorySidebar
+          entries={mockEntries}
+          isOpen={true}
+          onToggle={handleToggle}
+          onSelect={() => {}}
+          onDelete={() => {}}
+          onClear={() => {}}
+        />
+      )
+
+      // better way is to click something inside it
+      const header = screen.getByRole('heading', { name: /notifications & history/i })
+      fireEvent.click(header)
+
+      expect(handleToggle).not.toHaveBeenCalled()
+    })
+
+    it('calls onToggle when Escape is pressed while open', () => {
+      const handleToggle = vi.fn()
+      render(
+        <HistorySidebar
+          entries={mockEntries}
+          isOpen={true}
+          onToggle={handleToggle}
+          onSelect={() => {}}
+          onDelete={() => {}}
+          onClear={() => {}}
+        />
+      )
+
+      fireEvent.keyDown(window, { key: 'Escape' })
+      expect(handleToggle).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onToggle when Escape is pressed while closed', () => {
+      const handleToggle = vi.fn()
+      render(
+        <HistorySidebar
+          entries={mockEntries}
+          isOpen={false}
+          onToggle={handleToggle}
+          onSelect={() => {}}
+          onDelete={() => {}}
+          onClear={() => {}}
+        />
+      )
+
+      fireEvent.keyDown(window, { key: 'Escape' })
+      expect(handleToggle).not.toHaveBeenCalled()
+    })
+
+    it('restores focus to the trigger button when panel transitions from open to closed', () => {
+      const { rerender } = render(
+        <HistorySidebar
+          entries={mockEntries}
+          isOpen={true}
+          onToggle={() => {}}
+          onSelect={() => {}}
+          onDelete={() => {}}
+          onClear={() => {}}
+        />
+      )
+
+      const toggleBtn = screen.getByRole('button', {
+        name: /close notifications and history/i,
+      })
+
+      // We focus something else, mimicking user behavior inside the panel
+      toggleBtn.blur()
+      expect(document.activeElement).not.toBe(toggleBtn)
+
+      rerender(
+        <HistorySidebar
+          entries={mockEntries}
+          isOpen={false}
+          onToggle={() => {}}
+          onSelect={() => {}}
+          onDelete={() => {}}
+          onClear={() => {}}
+        />
+      )
+
+      expect(document.activeElement).toBe(toggleBtn)
+    })
+  })
 })

--- a/frontend/src/HistorySidebar.tsx
+++ b/frontend/src/HistorySidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { X, ClipboardList, BookOpen, Trash2, GitCompare, Archive, Check } from 'lucide-react'
 import type { AnalysisEntry } from './hooks/useAnalysisHistory'
 import { ScoreHistoryChart } from './components/ScoreHistoryChart'
@@ -44,6 +44,16 @@ export const HistorySidebar: React.FC<HistorySidebarProps> = ({
 }) => {
   const [confirmClear, setConfirmClear] = useState(false);
   const [downloadingZip, setDownloadingZip] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const prevIsOpen = useRef(isOpen);
+
+  useEffect(() => {
+    if (prevIsOpen.current && !isOpen) {
+      triggerRef.current?.focus();
+    }
+    prevIsOpen.current = isOpen;
+  }, [isOpen]);
+
   const [sortMode, setSortMode] = useState<SortMode>(() => {
     try {
       const saved = localStorage.getItem(SORT_MODE_STORAGE_KEY);
@@ -169,8 +179,19 @@ export const HistorySidebar: React.FC<HistorySidebarProps> = ({
 
   return (
     <>
+      {/* Backdrop overlay */}
+      {isOpen && (
+        <div
+          className="history-sidebar__overlay"
+          onClick={onToggle}
+          aria-hidden="true"
+          data-testid="history-sidebar-overlay"
+        />
+      )}
+
       {/* Toggle button — always visible */}
       <button
+        ref={triggerRef}
         className="fab-btn history-toggle-btn"
         onClick={handleToggleClick}
         aria-label={toggleAriaLabel}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -637,6 +637,28 @@ h3 {
   line-height: 1;
 }
 
+.history-sidebar__overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 999;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  animation: historyOverlayFadeIn 0.2s ease-out;
+}
+
+@keyframes historyOverlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .history-sidebar {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary

Improves the Notifications & History sidebar dismissal behavior.

- Added click-outside support using a backdrop overlay
- Ensured pressing `Escape` closes the panel when open
- Restores focus to the trigger button after closing
- Added tests covering dismissal and focus behavior

## Verification

Focused Issue #413 tests and implementation were reviewed. Any remaining `jszip` build/test failure and repository-wide Prettier issues are pre-existing and unrelated to this PR.

Closes #413