### PR TITLE
fix: add quality warning for short job descriptions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -792,6 +792,30 @@ function App() {
                 boxSizing: 'border-box',
               }}
             />
+            {(() => {
+              const wordCount = jobDescription.trim() ? jobDescription.trim().split(/\s+/).length : 0;
+              if (wordCount > 0 && wordCount < 50) {
+                return (
+                  <div
+                    style={{
+                      marginTop: '8px',
+                      padding: '8px 12px',
+                      backgroundColor: 'rgba(234, 179, 8, 0.1)',
+                      border: '1px solid rgba(234, 179, 8, 0.3)',
+                      borderRadius: '6px',
+                      fontSize: '0.8rem',
+                      color: '#facc15',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                    }}
+                  >
+                    ⚠️ <span>Friendly tip: Very short job descriptions might yield less accurate analysis. Consider pasting the full description!</span>
+                  </div>
+                );
+              }
+              return null;
+            })()}
             {jobDescription && (
               <div
                 style={{

--- a/frontend/src/JobDescriptionDraft.test.tsx
+++ b/frontend/src/JobDescriptionDraft.test.tsx
@@ -71,4 +71,29 @@ describe('Job Description Draft Auto-Save (#533)', () => {
     const textarea = screen.getByPlaceholderText(/Paste job description text here/i) as HTMLTextAreaElement
     expect(textarea.value).toBe('')
   })
+
+  it('shows a quality warning when the job description is less than 50 words', () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    )
+
+    const textarea = screen.getByPlaceholderText(/Paste job description text here/i)
+
+    // Type a short JD (5 words)
+    fireEvent.change(textarea, {
+      target: { value: 'This is a short description' },
+    })
+
+    expect(screen.getByText(/Friendly tip: Very short job descriptions/i)).toBeInTheDocument()
+
+    // Type a longer JD (52 words)
+    const longText = 'word '.repeat(52)
+    fireEvent.change(textarea, {
+      target: { value: longText },
+    })
+
+    expect(screen.queryByText(/Friendly tip: Very short job descriptions/i)).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## 📝 Description

Adds a soft, non-blocking warning banner directly below the job description input box if the pasted description is under 50 words. This alerts users that very short descriptions might result in less accurate resume matching, while still allowing them to proceed.


## 🔗 Related Issue

Closes #755 

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

<!-- Describe the steps you took to verify your change. -->
- [ ] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`)
- [x] Manually tested in the browser / API client
- [x] Added unit tests in `JobDescriptionDraft.test.tsx` to verify the warning displays for short text and hides for longer text.

## 📸 Screenshots (if applicable)
<img width="1905" height="986" alt="Screenshot 2026-08-22 200954" src="https://github.com/user-attachments/assets/8fde400d-5c69-4627-b13e-ffebd0794438" />



## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
