### PR TITLE
test: add unit tests for ATS score display component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Unit tests for AtsScore component covering low (20%), medium (60%), and high (95%) score ranges and readability labels (#4).
 - Granular consent toggles in Account Settings and initial banner for optional data collection (analytics and AI resume roast mode), strictly opt-in and off by default (#536).
 - Auto-save Job Description text as a debounced draft in local storage to prevent accidental data loss upon page refresh or navigation (#533).
 - Opt-in playful "Resume Roast" alternate feedback tone switch in suggestions section with humorously constructive feedback while remaining constructive (#497).

--- a/frontend/src/AtsScore.test.tsx
+++ b/frontend/src/AtsScore.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { AtsScore } from './AtsScore'
+
+describe('AtsScore component', () => {
+  it('renders correctly with low score (e.g. 20)', () => {
+    render(<AtsScore score={20} readabilityLabel="hard" />)
+
+    // Check score text
+    expect(screen.getByText('20%')).toBeInTheDocument()
+
+    // Check accessibility meter
+    const meter = screen.getByRole('meter', { name: /ATS Match Score/i })
+    expect(meter).toHaveAttribute('aria-valuenow', '20')
+    expect(meter).toHaveAttribute('aria-valuemin', '0')
+    expect(meter).toHaveAttribute('aria-valuemax', '100')
+
+    // Check region and heading
+    expect(screen.getByRole('region', { name: /ATS Resume Score Summary/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /ATS Resume Score/i })).toBeInTheDocument()
+
+    // Check readability label
+    expect(screen.getByText(/Readability:/i)).toBeInTheDocument()
+    expect(screen.getByText('hard')).toBeInTheDocument()
+  })
+
+  it('renders correctly with medium score (e.g. 60)', () => {
+    render(<AtsScore score={60} readabilityLabel="medium" />)
+
+    expect(screen.getByText('60%')).toBeInTheDocument()
+    const meter = screen.getByRole('meter', { name: /ATS Match Score/i })
+    expect(meter).toHaveAttribute('aria-valuenow', '60')
+    expect(screen.getByText('medium')).toBeInTheDocument()
+  })
+
+  it('renders correctly with high score (e.g. 95)', () => {
+    render(<AtsScore score={95} readabilityLabel="easy" />)
+
+    expect(screen.getByText('95%')).toBeInTheDocument()
+    const meter = screen.getByRole('meter', { name: /ATS Match Score/i })
+    expect(meter).toHaveAttribute('aria-valuenow', '95')
+    expect(screen.getByText('easy')).toBeInTheDocument()
+  })
+
+  it('renders without readability label when not provided', () => {
+    render(<AtsScore score={85} />)
+
+    expect(screen.getByText('85%')).toBeInTheDocument()
+    expect(screen.queryByText(/Readability:/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Description
Adds unit tests for the `AtsScore` component (`AtsScore.tsx`) which renders the ATS percentage score (0–100) and readability indicator.

### Closes
Closes #4

### Changes Made
- Added `frontend/src/AtsScore.test.tsx` testing low (20%), medium (60%), and high (95%) score ranges.
- Verified accessibility attributes (`aria-valuenow`, `aria-valuemin`, `aria-valuemax`) on the meter element.
- Verified conditional rendering for optional `readabilityLabel`.
- Added changelog entry in `CHANGELOG.md`.

### Verification
- Ran Vitest suite: `npm test AtsScore.test.tsx` (4 passed).
