### PR TITLE
feat: add unified notification preferences

### DIFF
--- a/backend/analyzer/migrations/0018_userprofile_notification_preferences.py
+++ b/backend/analyzer/migrations/0018_userprofile_notification_preferences.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("analyzer", "0017_resumeanalysis_share_controls"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userprofile",
+            name="notification_preferences",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text="Per-channel notification preferences. Missing keys use documented defaults.",
+            ),
+        ),
+    ]

--- a/backend/analyzer/models.py
+++ b/backend/analyzer/models.py
@@ -34,31 +34,10 @@ class ResumeAnalysis(models.Model):
     interview_questions = models.JSONField(blank=True, null=True)
 
     # --- Public sharing ---------------------------------------------------
-    #
-    # ``share_id`` is still assigned at creation, because it is the row's stable
-    # public name and generating it lazily would mean a nullable unique column.
-    # What changed is that holding the id is no longer sufficient:
-    # :meth:`is_share_live` is now the question the public endpoint asks, and it
-    # is false until someone turns sharing on.
-
     share_id = models.UUIDField(default=uuid.uuid4, unique=True)
-
-    #: Whether the owner has published this analysis. Off by default — an
-    #: analysis used to be reachable by anyone who learned its id from the
-    #: moment it was created, which is not a decision the owner ever made.
     share_enabled = models.BooleanField(default=False)
-
-    #: When sharing was last turned on or rotated. Shown in the UI so a user
-    #: looking at an old analysis can tell how long a link has been live.
     share_created_at = models.DateTimeField(null=True, blank=True)
-
-    #: When the link stops working. Always set while sharing is on — a link with
-    #: no end is the state this exists to remove.
     share_expires_at = models.DateTimeField(null=True, blank=True)
-
-    #: Rough traffic counter, so "did anyone actually open this?" has an answer
-    #: and an unexpected number is a reason to revoke. Incremented with an F()
-    #: expression, so it is a lower bound under concurrency rather than a lie.
     share_view_count = models.PositiveIntegerField(default=0)
 
     class Meta:
@@ -68,50 +47,18 @@ class ResumeAnalysis(models.Model):
         return f"{self.user.username} — {self.file_name} ({self.score}%)"
 
     def is_share_live(self, at=None):
-        """Return ``True`` when the public endpoint should answer for this row.
-
-        Both halves matter. ``share_enabled`` is the owner's decision;
-        ``share_expires_at`` is the clock. A row that is enabled but past its
-        expiry is not live, and is left alone rather than rewritten — expiry is
-        evaluated on read so a revocation never depends on a cleanup job having
-        run.
-        """
         if not self.share_enabled:
             return False
         if self.share_expires_at is None:
-            # Enabled with no expiry should be unreachable — `enable_sharing` is
-            # the only way to set the flag and it always sets a date. Treated as
-            # not-live rather than trusted, because the failure mode of the
-            # other choice is an immortal link.
             return False
         return self.share_expires_at > (at or timezone.now())
 
     def enable_sharing(self, lifetime_days, rotate=False, at=None):
-        """Publish this analysis for ``lifetime_days``, optionally under a new id.
-
-        Args:
-            lifetime_days: Life of the link from now. The caller is expected to
-                have passed the value through ``sharing.clamp_lifetime_days``.
-            rotate: Issue a fresh ``share_id``, which invalidates every copy of
-                the previous link. This is the "I sent it to the wrong person"
-                button, and it is separate from revoking because the common case
-                is wanting a working link, just not *that* one.
-            at: Clock override, for tests.
-
-        Returns:
-            ``self``, saved.
-        """
         now = at or timezone.now()
-
         if rotate or not self.share_enabled:
-            # A link that is off is being turned on, which is a new publication
-            # even if the id is unchanged; resetting the counter keeps the
-            # number answering "views since I shared it" rather than an
-            # all-time total that spans a revocation.
             self.share_view_count = 0
         if rotate:
             self.share_id = uuid.uuid4()
-
         self.share_enabled = True
         self.share_created_at = now
         self.share_expires_at = now + timedelta(days=lifetime_days)
@@ -127,27 +74,12 @@ class ResumeAnalysis(models.Model):
         return self
 
     def revoke_sharing(self):
-        """Turn the link off and clear its expiry.
-
-        The ``share_id`` is deliberately left in place. Re-enabling later should
-        be a decision about *whether* to share, not a forced rotation, and
-        keeping the id means a user who re-enables does not have to re-send a
-        link they already distributed. :meth:`enable_sharing` with
-        ``rotate=True`` is there for when they do want a clean break.
-        """
         self.share_enabled = False
         self.share_expires_at = None
         self.save(update_fields=["share_enabled", "share_expires_at"])
         return self
 
     def register_share_view(self):
-        """Count one public read, without reading the row back first.
-
-        ``F("share_view_count") + 1`` so two concurrent views cannot both write
-        the same number. The in-memory instance is intentionally *not*
-        refreshed — the view has no use for the new value, and refreshing would
-        cost a second query on the hot path of a public endpoint.
-        """
         type(self).objects.filter(pk=self.pk).update(
             share_view_count=models.F("share_view_count") + 1
         )
@@ -157,6 +89,11 @@ class UserProfile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="profile")
     avatar = models.FileField(upload_to="avatars/", blank=True, null=True)
     weekly_digest_opt_in = models.BooleanField(default=False)
+    notification_preferences = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Per-channel notification preferences. Missing keys use documented defaults.",
+    )
 
     def __str__(self):
         return f"{self.user.username}'s Profile"
@@ -176,48 +113,20 @@ class KnownDevice(models.Model):
 
 
 def generate_webhook_secret():
-    """Return a fresh signing secret for a webhook.
-
-    ``token_hex(32)`` gives 64 hex characters from 256 bits of entropy, which
-    matches the ``max_length`` on the field below.
-    """
     return secrets.token_hex(32)
 
 
 class Webhook(models.Model):
-    """An HTTP endpoint a user has asked us to notify.
-
-    Deliveries are signed. Each webhook carries its own :attr:`secret`, and
-    every request is sent with an HMAC-SHA256 of the exact body it is carrying,
-    so a receiver can tell a genuine delivery from anyone who has learned the
-    URL. Without that the URL itself is the only credential, and URLs leak —
-    into logs, proxies and bug reports.
-
-    The delivery bookkeeping fields exist because a webhook that has quietly
-    stopped working is indistinguishable from one that has had nothing to
-    report. Recording the last outcome lets the API answer "is this working?".
-    """
-
-    #: The one event that exists today. Named rather than free-form so a
-    #: receiver can switch on it, and so adding a second event later does not
-    #: change the shape of the payload for the first.
     EVENT_ANALYSIS_COMPLETED = "resume_analysis.completed"
     EVENT_PING = "ping"
-
-    #: Consecutive failures before the webhook is switched off. An endpoint that
-    #: has been failing this long is almost always gone for good, and retrying
-    #: forever means every future analysis pays for it.
     MAX_CONSECUTIVE_FAILURES = 10
 
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="webhooks")
     url = models.URLField(max_length=500)
-    #: Free-text label so a user with several webhooks can tell them apart.
     description = models.CharField(max_length=120, blank=True, default="")
     secret = models.CharField(max_length=64, default=generate_webhook_secret)
     is_active = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
-
-    #: Outcome of the most recent delivery attempt.
     last_delivery_at = models.DateTimeField(null=True, blank=True)
     last_status_code = models.IntegerField(null=True, blank=True)
     last_error = models.CharField(max_length=255, blank=True, default="")
@@ -226,9 +135,6 @@ class Webhook(models.Model):
     class Meta:
         ordering = ["-created_at"]
         constraints = [
-            # The same endpoint registered twice would just get every event
-            # twice. Scoped to the user: two people may legitimately point at
-            # the same collector.
             models.UniqueConstraint(
                 fields=["user", "url"], name="unique_webhook_url_per_user"
             )
@@ -238,7 +144,6 @@ class Webhook(models.Model):
         return f"{self.user.username} - {self.url}"
 
     def record_success(self, status_code):
-        """Note a delivery that the receiver accepted."""
         self.last_delivery_at = timezone.now()
         self.last_status_code = status_code
         self.last_error = ""
@@ -253,38 +158,23 @@ class Webhook(models.Model):
         )
 
     def record_failure(self, error, status_code=None):
-        """Note a delivery that did not land, disabling the hook if it keeps up."""
         self.last_delivery_at = timezone.now()
         self.last_status_code = status_code
-        # Truncated rather than rejected: the message is diagnostic, and a long
-        # one from a misbehaving server should not fail the write that records
-        # the misbehaviour.
         self.last_error = str(error)[:255]
         self.consecutive_failures += 1
-
         fields = [
             "last_delivery_at",
             "last_status_code",
             "last_error",
             "consecutive_failures",
         ]
-
         if self.consecutive_failures >= self.MAX_CONSECUTIVE_FAILURES:
             self.is_active = False
             fields.append("is_active")
-
         self.save(update_fields=fields)
 
 
 class SuggestionFeedback(models.Model):
-    """A user's up/down vote on one suggestion from one of their analyses.
-
-    Suggestions are generated from a template, so votes are the only signal
-    available for whether the recommendations are worth reading. One row per
-    (user, analysis, suggestion): voting again updates the existing row rather
-    than stacking duplicates.
-    """
-
     UP = "up"
     DOWN = "down"
     VOTE_CHOICES = [(UP, "Helpful"), (DOWN, "Not helpful")]
@@ -296,9 +186,6 @@ class SuggestionFeedback(models.Model):
         ResumeAnalysis, on_delete=models.CASCADE, related_name="suggestion_feedback"
     )
     suggestion_text = models.TextField()
-    #: SHA-256 of the suggestion text. The uniqueness constraint keys on this
-    #: rather than the text itself, because databases limit how many bytes an
-    #: index entry may hold and suggestions have no length bound.
     suggestion_hash = models.CharField(max_length=64, db_index=True)
     vote = models.CharField(max_length=4, choices=VOTE_CHOICES)
     comment = models.TextField(blank=True, default="")
@@ -317,11 +204,9 @@ class SuggestionFeedback(models.Model):
     @staticmethod
     def hash_suggestion(text: str) -> str:
         import hashlib
-
         return hashlib.sha256((text or "").strip().encode("utf-8")).hexdigest()
 
     def save(self, *args, **kwargs):
-        # Keep the hash in step with the text no matter who writes the row.
         self.suggestion_hash = self.hash_suggestion(self.suggestion_text)
         return super().save(*args, **kwargs)
 
@@ -348,10 +233,12 @@ from django.db.models.signals import post_save, post_delete, m2m_changed
 from django.dispatch import receiver
 from django.core.cache import cache
 
+
 @receiver([post_save, post_delete], sender=Role)
 @receiver([post_save, post_delete], sender=Skill)
 def invalidate_role_skills_cache(sender, **kwargs):
     cache.delete("role_skills_dict")
+
 
 @receiver(m2m_changed, sender=Role.skills.through)
 def invalidate_m2m_cache(sender, **kwargs):

--- a/backend/analyzer/models.py
+++ b/backend/analyzer/models.py
@@ -34,10 +34,31 @@ class ResumeAnalysis(models.Model):
     interview_questions = models.JSONField(blank=True, null=True)
 
     # --- Public sharing ---------------------------------------------------
+    #
+    # ``share_id`` is still assigned at creation, because it is the row's stable
+    # public name and generating it lazily would mean a nullable unique column.
+    # What changed is that holding the id is no longer sufficient:
+    # :meth:`is_share_live` is now the question the public endpoint asks, and it
+    # is false until someone turns sharing on.
+
     share_id = models.UUIDField(default=uuid.uuid4, unique=True)
+
+    #: Whether the owner has published this analysis. Off by default — an
+    #: analysis used to be reachable by anyone who learned its id from the
+    #: moment it was created, which is not a decision the owner ever made.
     share_enabled = models.BooleanField(default=False)
+
+    #: When sharing was last turned on or rotated. Shown in the UI so a user
+    #: looking at an old analysis can tell how long a link has been live.
     share_created_at = models.DateTimeField(null=True, blank=True)
+
+    #: When the link stops working. Always set while sharing is on — a link with
+    #: no end is the state this exists to remove.
     share_expires_at = models.DateTimeField(null=True, blank=True)
+
+    #: Rough traffic counter, so "did anyone actually open this?" has an answer
+    #: and an unexpected number is a reason to revoke. Incremented with an F()
+    #: expression, so it is a lower bound under concurrency rather than a lie.
     share_view_count = models.PositiveIntegerField(default=0)
 
     class Meta:
@@ -47,18 +68,50 @@ class ResumeAnalysis(models.Model):
         return f"{self.user.username} — {self.file_name} ({self.score}%)"
 
     def is_share_live(self, at=None):
+        """Return ``True`` when the public endpoint should answer for this row.
+
+        Both halves matter. ``share_enabled`` is the owner's decision;
+        ``share_expires_at`` is the clock. A row that is enabled but past its
+        expiry is not live, and is left alone rather than rewritten — expiry is
+        evaluated on read so a revocation never depends on a cleanup job having
+        run.
+        """
         if not self.share_enabled:
             return False
         if self.share_expires_at is None:
+            # Enabled with no expiry should be unreachable — `enable_sharing` is
+            # the only way to set the flag and it always sets a date. Treated as
+            # not-live rather than trusted, because the failure mode of the
+            # other choice is an immortal link.
             return False
         return self.share_expires_at > (at or timezone.now())
 
     def enable_sharing(self, lifetime_days, rotate=False, at=None):
+        """Publish this analysis for ``lifetime_days``, optionally under a new id.
+
+        Args:
+            lifetime_days: Life of the link from now. The caller is expected to
+                have passed the value through ``sharing.clamp_lifetime_days``.
+            rotate: Issue a fresh ``share_id``, which invalidates every copy of
+                the previous link. This is the "I sent it to the wrong person"
+                button, and it is separate from revoking because the common case
+                is wanting a working link, just not *that* one.
+            at: Clock override, for tests.
+
+        Returns:
+            ``self``, saved.
+        """
         now = at or timezone.now()
+
         if rotate or not self.share_enabled:
+            # A link that is off is being turned on, which is a new publication
+            # even if the id is unchanged; resetting the counter keeps the
+            # number answering "views since I shared it" rather than an
+            # all-time total that spans a revocation.
             self.share_view_count = 0
         if rotate:
             self.share_id = uuid.uuid4()
+
         self.share_enabled = True
         self.share_created_at = now
         self.share_expires_at = now + timedelta(days=lifetime_days)
@@ -74,12 +127,27 @@ class ResumeAnalysis(models.Model):
         return self
 
     def revoke_sharing(self):
+        """Turn the link off and clear its expiry.
+
+        The ``share_id`` is deliberately left in place. Re-enabling later should
+        be a decision about *whether* to share, not a forced rotation, and
+        keeping the id means a user who re-enables does not have to re-send a
+        link they already distributed. :meth:`enable_sharing` with
+        ``rotate=True`` is there for when they do want a clean break.
+        """
         self.share_enabled = False
         self.share_expires_at = None
         self.save(update_fields=["share_enabled", "share_expires_at"])
         return self
 
     def register_share_view(self):
+        """Count one public read, without reading the row back first.
+
+        ``F("share_view_count") + 1`` so two concurrent views cannot both write
+        the same number. The in-memory instance is intentionally *not*
+        refreshed — the view has no use for the new value, and refreshing would
+        cost a second query on the hot path of a public endpoint.
+        """
         type(self).objects.filter(pk=self.pk).update(
             share_view_count=models.F("share_view_count") + 1
         )
@@ -113,20 +181,48 @@ class KnownDevice(models.Model):
 
 
 def generate_webhook_secret():
+    """Return a fresh signing secret for a webhook.
+
+    ``token_hex(32)`` gives 64 hex characters from 256 bits of entropy, which
+    matches the ``max_length`` on the field below.
+    """
     return secrets.token_hex(32)
 
 
 class Webhook(models.Model):
+    """An HTTP endpoint a user has asked us to notify.
+
+    Deliveries are signed. Each webhook carries its own :attr:`secret`, and
+    every request is sent with an HMAC-SHA256 of the exact body it is carrying,
+    so a receiver can tell a genuine delivery from anyone who has learned the
+    URL. Without that the URL itself is the only credential, and URLs leak —
+    into logs, proxies and bug reports.
+
+    The delivery bookkeeping fields exist because a webhook that has quietly
+    stopped working is indistinguishable from one that has had nothing to
+    report. Recording the last outcome lets the API answer "is this working?".
+    """
+
+    #: The one event that exists today. Named rather than free-form so a
+    #: receiver can switch on it, and so adding a second event later does not
+    #: change the shape of the payload for the first.
     EVENT_ANALYSIS_COMPLETED = "resume_analysis.completed"
     EVENT_PING = "ping"
+
+    #: Consecutive failures before the webhook is switched off. An endpoint that
+    #: has been failing this long is almost always gone for good, and retrying
+    #: forever means every future analysis pays for it.
     MAX_CONSECUTIVE_FAILURES = 10
 
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="webhooks")
     url = models.URLField(max_length=500)
+    #: Free-text label so a user with several webhooks can tell them apart.
     description = models.CharField(max_length=120, blank=True, default="")
     secret = models.CharField(max_length=64, default=generate_webhook_secret)
     is_active = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
+
+    #: Outcome of the most recent delivery attempt.
     last_delivery_at = models.DateTimeField(null=True, blank=True)
     last_status_code = models.IntegerField(null=True, blank=True)
     last_error = models.CharField(max_length=255, blank=True, default="")
@@ -144,6 +240,7 @@ class Webhook(models.Model):
         return f"{self.user.username} - {self.url}"
 
     def record_success(self, status_code):
+        """Note a delivery that the receiver accepted."""
         self.last_delivery_at = timezone.now()
         self.last_status_code = status_code
         self.last_error = ""
@@ -158,23 +255,38 @@ class Webhook(models.Model):
         )
 
     def record_failure(self, error, status_code=None):
+        """Note a delivery that did not land, disabling the hook if it keeps up."""
         self.last_delivery_at = timezone.now()
         self.last_status_code = status_code
+        # Truncated rather than rejected: the message is diagnostic, and a long
+        # one from a misbehaving server should not fail the write that records
+        # the misbehaviour.
         self.last_error = str(error)[:255]
         self.consecutive_failures += 1
+
         fields = [
             "last_delivery_at",
             "last_status_code",
             "last_error",
             "consecutive_failures",
         ]
+
         if self.consecutive_failures >= self.MAX_CONSECUTIVE_FAILURES:
             self.is_active = False
             fields.append("is_active")
+
         self.save(update_fields=fields)
 
 
 class SuggestionFeedback(models.Model):
+    """A user's up/down vote on one suggestion from one of their analyses.
+
+    Suggestions are generated from a template, so votes are the only signal
+    available for whether the recommendations are worth reading. One row per
+    (user, analysis, suggestion): voting again updates the existing row rather
+    than stacking duplicates.
+    """
+
     UP = "up"
     DOWN = "down"
     VOTE_CHOICES = [(UP, "Helpful"), (DOWN, "Not helpful")]
@@ -186,6 +298,9 @@ class SuggestionFeedback(models.Model):
         ResumeAnalysis, on_delete=models.CASCADE, related_name="suggestion_feedback"
     )
     suggestion_text = models.TextField()
+    #: SHA-256 of the suggestion text. The uniqueness constraint keys on this
+    #: rather than the text itself, because databases limit how many bytes an
+    #: index entry may hold and suggestions have no length bound.
     suggestion_hash = models.CharField(max_length=64, db_index=True)
     vote = models.CharField(max_length=4, choices=VOTE_CHOICES)
     comment = models.TextField(blank=True, default="")
@@ -204,9 +319,11 @@ class SuggestionFeedback(models.Model):
     @staticmethod
     def hash_suggestion(text: str) -> str:
         import hashlib
+
         return hashlib.sha256((text or "").strip().encode("utf-8")).hexdigest()
 
     def save(self, *args, **kwargs):
+        # Keep the hash in step with the text no matter who writes the row.
         self.suggestion_hash = self.hash_suggestion(self.suggestion_text)
         return super().save(*args, **kwargs)
 
@@ -233,12 +350,10 @@ from django.db.models.signals import post_save, post_delete, m2m_changed
 from django.dispatch import receiver
 from django.core.cache import cache
 
-
 @receiver([post_save, post_delete], sender=Role)
 @receiver([post_save, post_delete], sender=Skill)
 def invalidate_role_skills_cache(sender, **kwargs):
     cache.delete("role_skills_dict")
-
 
 @receiver(m2m_changed, sender=Role.skills.through)
 def invalidate_m2m_cache(sender, **kwargs):

--- a/backend/analyzer/serializers.py
+++ b/backend/analyzer/serializers.py
@@ -22,11 +22,24 @@ class SignupSerializer(serializers.ModelSerializer):
         fields = ("username", "password")
 
     def validate_password(self, value):
+        """Run the project's configured password validators.
+
+        ``AUTH_PASSWORD_VALIDATORS`` is set in settings but nothing was calling
+        it — ``min_length=6`` here was the only rule in force, and
+        ``set_password()`` does not validate. The length, common-password and
+        all-numeric checks the project believes it has were dead config on
+        every path that sets a password. The reset flow now runs the same
+        validators, so the two agree on what is acceptable.
+        """
+        # Passed in so UserAttributeSimilarityValidator can compare the
+        # password against the username being registered.
         candidate = User(username=self.initial_data.get("username") or "")
+
         try:
             validate_password(value, user=candidate)
         except DjangoValidationError as exc:
             raise serializers.ValidationError(list(exc.messages))
+
         return value
 
     def create(self, validated_data):
@@ -46,21 +59,30 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                 raise serializers.ValidationError(
                     {"captcha_token": ["CAPTCHA verification failed. Please complete the security challenge."]}
                 )
+
         username = attrs.get("username")
         password = attrs.get("password")
+
         from django.contrib.auth import authenticate
         from django.contrib.auth.models import User
         from rest_framework.exceptions import AuthenticationFailed
+
         user = User.objects.filter(username=username).first()
         if not user:
+            # Generic message to prevent user enumeration
             raise AuthenticationFailed("No active account found with the given credentials.")
+
         if not user.is_active:
             raise AuthenticationFailed({
                 "detail": "Your account has been locked or deactivated. Please reset your password to unlock it or contact support.",
                 "code": "account_locked"
             })
+
         if not user.check_password(password):
+            # Generic message to prevent user enumeration
             raise AuthenticationFailed("No active account found with the given credentials.")
+
+        # Check if email is verified (forward-compatible with issue 371)
         profile = getattr(user, 'profile', None)
         is_verified = getattr(profile, 'is_verified', True) if profile else True
         if not is_verified:
@@ -69,6 +91,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                 "code": "email_unverified",
                 "email": user.email
             })
+
         data = super().validate(attrs)
         profile, _ = UserProfile.objects.get_or_create(user=self.user)
         if profile.avatar:
@@ -78,21 +101,28 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                 data["avatar_url"] = profile.avatar.url
         else:
             data["avatar_url"] = None
+
         if request:
             from .models import KnownDevice
             from .views import get_client_ip, parse_user_agent, send_new_device_login_alert
+
             ip = get_client_ip(request)
             ua = request.META.get('HTTP_USER_AGENT', '')
             device = parse_user_agent(ua)
+
             known_devices = KnownDevice.objects.filter(user=self.user)
             has_existing = known_devices.exists()
             device_exists = known_devices.filter(ip_address=ip, device_info=device).exists()
+
             if not device_exists:
                 if has_existing:
+                    # Unrecognized login! Send email alert.
                     try:
                         send_new_device_login_alert(self.user, ip, device)
                     except Exception:
                         pass
+
+                # Save as a known device (registers initial silently, or adds new device)
                 try:
                     KnownDevice.objects.get_or_create(
                         user=self.user,
@@ -101,11 +131,13 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                     )
                 except Exception:
                     pass
+
         return data
 
 
 class ResumeAnalysisSerializer(serializers.ModelSerializer):
     """Full record, including the extracted text. Used for a single analysis."""
+
     class Meta:
         model = ResumeAnalysis
         fields = ("id", "share_id", "file_name", "score", "skills_found", "suggestions",
@@ -114,35 +146,90 @@ class ResumeAnalysisSerializer(serializers.ModelSerializer):
 
 
 class ResumeAnalysisListSerializer(serializers.ModelSerializer):
-    """Slim record for history listings."""
+    """Slim record for history listings.
+
+    Drops ``resume_text``, ``cover_letter_text``, ``cover_letter_feedback`` and
+    ``interview_questions`` — several KB per row that the history sidebar
+    fetches and immediately discards. Fetch a single analysis from
+    ``/api/history/<id>/`` when the full text is actually needed.
+    """
+
     class Meta:
         model = ResumeAnalysis
         fields = ("id", "share_id", "file_name", "score", "skills_found", "suggestions",
                   "matched_skills", "partial_skills", "missing_skills", "target_role", "experience_level", "created_at")
 
 class PublicSharedAnalysisSerializer(serializers.ModelSerializer):
+    """What a share link is allowed to return.
+
+    Deliberately not a subset of :class:`ResumeAnalysisSerializer` by way of
+    ``exclude``. An exclude list is a denylist, and a denylist on a model that
+    gains fields over time fails open — the next column added to
+    ``ResumeAnalysis`` would be published by default. ``sharing.PUBLIC_FIELDS``
+    is the allowlist, and adding a field to the public view is a deliberate edit
+    to it.
+
+    On top of the field selection, every string that survives is passed through
+    :func:`~analyzer.sharing.redact_structure`. The fields here are *derived
+    from* the resume — ``skills_found`` is extracted from it, and a suggestion
+    can quote a phrase back — so "we did not serialise ``resume_text``" is not
+    on its own a guarantee that no contact detail is in the response.
+    """
+
+    #: Kept as a plain read-only field rather than the model's UUID, so the
+    #: response carries the string form the frontend puts in a URL.
     share_id = serializers.CharField(read_only=True)
+
+    #: Present so a viewer can see the link will not last forever, which is the
+    #: reassurance that makes sharing reasonable in the first place.
     expires_at = serializers.DateTimeField(source="share_expires_at", read_only=True)
+
     class Meta:
         model = ResumeAnalysis
         fields = sharing.PUBLIC_FIELDS + ("expires_at",)
         read_only_fields = fields
+
     def to_representation(self, instance):
         return sharing.redact_structure(super().to_representation(instance))
 
 
 class ShareStateSerializer(serializers.ModelSerializer):
+    """The owner's view of a link: is it on, until when, and how many opens.
+
+    Returned by the share-management endpoint so the UI never has to infer
+    state from a 200 or a 404. ``share_url`` is assembled here rather than in
+    the frontend because the public path is a backend routing detail, and the
+    frontend has already had that wrong once (#632).
+    """
+
     is_live = serializers.SerializerMethodField()
     share_url = serializers.SerializerMethodField()
+
     class Meta:
         model = ResumeAnalysis
-        fields = ("share_id", "share_enabled", "share_created_at", "share_expires_at", "share_view_count", "is_live", "share_url")
+        fields = (
+            "share_id",
+            "share_enabled",
+            "share_created_at",
+            "share_expires_at",
+            "share_view_count",
+            "is_live",
+            "share_url",
+        )
         read_only_fields = fields
+
     def get_is_live(self, obj) -> bool:
         return obj.is_share_live()
+
     def get_share_url(self, obj):
+        """Return the public URL, or ``None`` when there is nothing to link to.
+
+        ``None`` rather than a dead URL: a UI given a string will render it, and
+        a copyable link that 404s is worse than no link at all.
+        """
         if not obj.is_share_live():
             return None
+
         base = getattr(settings, "FRONTEND_URL", "") or ""
         return f"{base.rstrip('/')}/shared/{obj.share_id}"
 
@@ -230,6 +317,8 @@ class UserProfileSerializer(serializers.ModelSerializer):
 from .models import SuggestionFeedback
 
 class SuggestionFeedbackSerializer(serializers.ModelSerializer):
+    """Read representation of one stored vote."""
+
     class Meta:
         model = SuggestionFeedback
         fields = ("id", "analysis", "suggestion_text", "vote", "comment", "updated_at")
@@ -239,33 +328,74 @@ class SuggestionFeedbackSerializer(serializers.ModelSerializer):
 from .models import Webhook
 from .url_safety import UnsafeURLError, assert_url_is_safe
 
+
 class WebhookSerializer(serializers.ModelSerializer):
+    """Read/write representation of a registered webhook.
+
+    ``secret`` is never in the output. It is returned exactly once, by the
+    create view, in the response to the POST that generated it — the same
+    pattern every webhook provider uses, because a secret that can be re-read
+    from a list endpoint is only as protected as the weakest session that can
+    reach that endpoint.
+    """
+
+    #: Read-only summary of how the last attempt went, so a user can tell a
+    #: healthy webhook from one that has been failing since they set it up.
     status = serializers.SerializerMethodField()
+
     class Meta:
         model = Webhook
-        fields = ("id", "url", "description", "is_active", "created_at", "status")
+        fields = (
+            "id",
+            "url",
+            "description",
+            "is_active",
+            "created_at",
+            "status",
+        )
         read_only_fields = ("id", "created_at", "status")
+
     def get_status(self, obj):
         return {
-            "last_delivery_at": obj.last_delivery_at.isoformat() if obj.last_delivery_at else None,
+            "last_delivery_at": (
+                obj.last_delivery_at.isoformat() if obj.last_delivery_at else None
+            ),
             "last_status_code": obj.last_status_code,
             "last_error": obj.last_error,
             "consecutive_failures": obj.consecutive_failures,
         }
+
     def validate_url(self, value):
+        """Reject anything the fetcher would not be allowed to reach.
+
+        This is the same check the resume-import path runs (#583). Registering
+        the URL is the point at which a user can be told *why* it was refused;
+        by delivery time the request is in a background task with nobody
+        watching, so that check — which also runs, because DNS changes — can
+        only log.
+        """
         try:
             assert_url_is_safe(value)
         except UnsafeURLError as exc:
             raise serializers.ValidationError(
-                "That URL cannot be used as a webhook destination. It must be a public HTTPS or HTTP address on port 80 or 443 — internal, loopback and cloud-metadata addresses are not permitted."
+                "That URL cannot be used as a webhook destination. It must be a "
+                "public HTTPS or HTTP address on port 80 or 443 — internal, "
+                "loopback and cloud-metadata addresses are not permitted."
             ) from exc
         return value
+
     def validate(self, attrs):
+        """Reject a duplicate before the database constraint has to."""
         user = self.context["request"].user
         url = attrs.get("url", getattr(self.instance, "url", None))
+
         duplicates = Webhook.objects.filter(user=user, url=url)
         if self.instance is not None:
             duplicates = duplicates.exclude(pk=self.instance.pk)
+
         if duplicates.exists():
-            raise serializers.ValidationError({"url": "You have already registered a webhook for that URL."})
+            raise serializers.ValidationError(
+                {"url": "You have already registered a webhook for that URL."}
+            )
+
         return attrs

--- a/backend/analyzer/serializers.py
+++ b/backend/analyzer/serializers.py
@@ -22,24 +22,11 @@ class SignupSerializer(serializers.ModelSerializer):
         fields = ("username", "password")
 
     def validate_password(self, value):
-        """Run the project's configured password validators.
-
-        ``AUTH_PASSWORD_VALIDATORS`` is set in settings but nothing was calling
-        it — ``min_length=6`` here was the only rule in force, and
-        ``set_password()`` does not validate. The length, common-password and
-        all-numeric checks the project believes it has were dead config on
-        every path that sets a password. The reset flow now runs the same
-        validators, so the two agree on what is acceptable.
-        """
-        # Passed in so UserAttributeSimilarityValidator can compare the
-        # password against the username being registered.
         candidate = User(username=self.initial_data.get("username") or "")
-
         try:
             validate_password(value, user=candidate)
         except DjangoValidationError as exc:
             raise serializers.ValidationError(list(exc.messages))
-
         return value
 
     def create(self, validated_data):
@@ -59,30 +46,21 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                 raise serializers.ValidationError(
                     {"captcha_token": ["CAPTCHA verification failed. Please complete the security challenge."]}
                 )
-
         username = attrs.get("username")
         password = attrs.get("password")
-
         from django.contrib.auth import authenticate
         from django.contrib.auth.models import User
         from rest_framework.exceptions import AuthenticationFailed
-
         user = User.objects.filter(username=username).first()
         if not user:
-            # Generic message to prevent user enumeration
             raise AuthenticationFailed("No active account found with the given credentials.")
-
         if not user.is_active:
             raise AuthenticationFailed({
                 "detail": "Your account has been locked or deactivated. Please reset your password to unlock it or contact support.",
                 "code": "account_locked"
             })
-
         if not user.check_password(password):
-            # Generic message to prevent user enumeration
             raise AuthenticationFailed("No active account found with the given credentials.")
-
-        # Check if email is verified (forward-compatible with issue 371)
         profile = getattr(user, 'profile', None)
         is_verified = getattr(profile, 'is_verified', True) if profile else True
         if not is_verified:
@@ -91,7 +69,6 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                 "code": "email_unverified",
                 "email": user.email
             })
-
         data = super().validate(attrs)
         profile, _ = UserProfile.objects.get_or_create(user=self.user)
         if profile.avatar:
@@ -101,28 +78,21 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                 data["avatar_url"] = profile.avatar.url
         else:
             data["avatar_url"] = None
-
         if request:
             from .models import KnownDevice
             from .views import get_client_ip, parse_user_agent, send_new_device_login_alert
-
             ip = get_client_ip(request)
             ua = request.META.get('HTTP_USER_AGENT', '')
             device = parse_user_agent(ua)
-
             known_devices = KnownDevice.objects.filter(user=self.user)
             has_existing = known_devices.exists()
             device_exists = known_devices.filter(ip_address=ip, device_info=device).exists()
-
             if not device_exists:
                 if has_existing:
-                    # Unrecognized login! Send email alert.
                     try:
                         send_new_device_login_alert(self.user, ip, device)
                     except Exception:
                         pass
-
-                # Save as a known device (registers initial silently, or adds new device)
                 try:
                     KnownDevice.objects.get_or_create(
                         user=self.user,
@@ -131,13 +101,11 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                     )
                 except Exception:
                     pass
-
         return data
 
 
 class ResumeAnalysisSerializer(serializers.ModelSerializer):
     """Full record, including the extracted text. Used for a single analysis."""
-
     class Meta:
         model = ResumeAnalysis
         fields = ("id", "share_id", "file_name", "score", "skills_found", "suggestions",
@@ -146,90 +114,35 @@ class ResumeAnalysisSerializer(serializers.ModelSerializer):
 
 
 class ResumeAnalysisListSerializer(serializers.ModelSerializer):
-    """Slim record for history listings.
-
-    Drops ``resume_text``, ``cover_letter_text``, ``cover_letter_feedback`` and
-    ``interview_questions`` — several KB per row that the history sidebar
-    fetches and immediately discards. Fetch a single analysis from
-    ``/api/history/<id>/`` when the full text is actually needed.
-    """
-
+    """Slim record for history listings."""
     class Meta:
         model = ResumeAnalysis
         fields = ("id", "share_id", "file_name", "score", "skills_found", "suggestions",
                   "matched_skills", "partial_skills", "missing_skills", "target_role", "experience_level", "created_at")
 
 class PublicSharedAnalysisSerializer(serializers.ModelSerializer):
-    """What a share link is allowed to return.
-
-    Deliberately not a subset of :class:`ResumeAnalysisSerializer` by way of
-    ``exclude``. An exclude list is a denylist, and a denylist on a model that
-    gains fields over time fails open — the next column added to
-    ``ResumeAnalysis`` would be published by default. ``sharing.PUBLIC_FIELDS``
-    is the allowlist, and adding a field to the public view is a deliberate edit
-    to it.
-
-    On top of the field selection, every string that survives is passed through
-    :func:`~analyzer.sharing.redact_structure`. The fields here are *derived
-    from* the resume — ``skills_found`` is extracted from it, and a suggestion
-    can quote a phrase back — so "we did not serialise ``resume_text``" is not
-    on its own a guarantee that no contact detail is in the response.
-    """
-
-    #: Kept as a plain read-only field rather than the model's UUID, so the
-    #: response carries the string form the frontend puts in a URL.
     share_id = serializers.CharField(read_only=True)
-
-    #: Present so a viewer can see the link will not last forever, which is the
-    #: reassurance that makes sharing reasonable in the first place.
     expires_at = serializers.DateTimeField(source="share_expires_at", read_only=True)
-
     class Meta:
         model = ResumeAnalysis
         fields = sharing.PUBLIC_FIELDS + ("expires_at",)
         read_only_fields = fields
-
     def to_representation(self, instance):
         return sharing.redact_structure(super().to_representation(instance))
 
 
 class ShareStateSerializer(serializers.ModelSerializer):
-    """The owner's view of a link: is it on, until when, and how many opens.
-
-    Returned by the share-management endpoint so the UI never has to infer
-    state from a 200 or a 404. ``share_url`` is assembled here rather than in
-    the frontend because the public path is a backend routing detail, and the
-    frontend has already had that wrong once (#632).
-    """
-
     is_live = serializers.SerializerMethodField()
     share_url = serializers.SerializerMethodField()
-
     class Meta:
         model = ResumeAnalysis
-        fields = (
-            "share_id",
-            "share_enabled",
-            "share_created_at",
-            "share_expires_at",
-            "share_view_count",
-            "is_live",
-            "share_url",
-        )
+        fields = ("share_id", "share_enabled", "share_created_at", "share_expires_at", "share_view_count", "is_live", "share_url")
         read_only_fields = fields
-
     def get_is_live(self, obj) -> bool:
         return obj.is_share_live()
-
     def get_share_url(self, obj):
-        """Return the public URL, or ``None`` when there is nothing to link to.
-
-        ``None`` rather than a dead URL: a UI given a string will render it, and
-        a copyable link that 404s is worse than no link at all.
-        """
         if not obj.is_share_live():
             return None
-
         base = getattr(settings, "FRONTEND_URL", "") or ""
         return f"{base.rstrip('/')}/shared/{obj.share_id}"
 
@@ -254,23 +167,40 @@ class VersionComparisonSerializer(serializers.Serializer):
 class UserProfileSerializer(serializers.ModelSerializer):
     email = serializers.EmailField(required=True, allow_blank=False)
     weekly_digest_opt_in = serializers.BooleanField(required=False, default=False)
+    notification_preferences = serializers.JSONField(required=False)
 
     class Meta:
         model = User
-        fields = ("username", "email", "weekly_digest_opt_in")
+        fields = ("username", "email", "weekly_digest_opt_in", "notification_preferences")
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
         profile, _ = UserProfile.objects.get_or_create(user=instance)
+        prefs = profile.notification_preferences or {}
         ret["weekly_digest_opt_in"] = profile.weekly_digest_opt_in
+        ret["notification_preferences"] = {
+            "in_app": prefs.get("in_app", True),
+            "browser": prefs.get("browser", False),
+        }
         return ret
 
     def update(self, instance, validated_data):
         weekly_digest_opt_in = validated_data.pop("weekly_digest_opt_in", None)
+        notification_preferences = validated_data.pop("notification_preferences", None)
         user = super().update(instance, validated_data)
+        profile, _ = UserProfile.objects.get_or_create(user=user)
+        changed = False
         if weekly_digest_opt_in is not None:
-            profile, _ = UserProfile.objects.get_or_create(user=user)
             profile.weekly_digest_opt_in = weekly_digest_opt_in
+            changed = True
+        if notification_preferences is not None:
+            current = profile.notification_preferences or {}
+            profile.notification_preferences = {
+                "in_app": notification_preferences.get("in_app", current.get("in_app", True)),
+                "browser": notification_preferences.get("browser", current.get("browser", False)),
+            }
+            changed = True
+        if changed:
             profile.save()
         return user
 
@@ -300,8 +230,6 @@ class UserProfileSerializer(serializers.ModelSerializer):
 from .models import SuggestionFeedback
 
 class SuggestionFeedbackSerializer(serializers.ModelSerializer):
-    """Read representation of one stored vote."""
-
     class Meta:
         model = SuggestionFeedback
         fields = ("id", "analysis", "suggestion_text", "vote", "comment", "updated_at")
@@ -311,74 +239,33 @@ class SuggestionFeedbackSerializer(serializers.ModelSerializer):
 from .models import Webhook
 from .url_safety import UnsafeURLError, assert_url_is_safe
 
-
 class WebhookSerializer(serializers.ModelSerializer):
-    """Read/write representation of a registered webhook.
-
-    ``secret`` is never in the output. It is returned exactly once, by the
-    create view, in the response to the POST that generated it — the same
-    pattern every webhook provider uses, because a secret that can be re-read
-    from a list endpoint is only as protected as the weakest session that can
-    reach that endpoint.
-    """
-
-    #: Read-only summary of how the last attempt went, so a user can tell a
-    #: healthy webhook from one that has been failing since they set it up.
     status = serializers.SerializerMethodField()
-
     class Meta:
         model = Webhook
-        fields = (
-            "id",
-            "url",
-            "description",
-            "is_active",
-            "created_at",
-            "status",
-        )
+        fields = ("id", "url", "description", "is_active", "created_at", "status")
         read_only_fields = ("id", "created_at", "status")
-
     def get_status(self, obj):
         return {
-            "last_delivery_at": (
-                obj.last_delivery_at.isoformat() if obj.last_delivery_at else None
-            ),
+            "last_delivery_at": obj.last_delivery_at.isoformat() if obj.last_delivery_at else None,
             "last_status_code": obj.last_status_code,
             "last_error": obj.last_error,
             "consecutive_failures": obj.consecutive_failures,
         }
-
     def validate_url(self, value):
-        """Reject anything the fetcher would not be allowed to reach.
-
-        This is the same check the resume-import path runs (#583). Registering
-        the URL is the point at which a user can be told *why* it was refused;
-        by delivery time the request is in a background task with nobody
-        watching, so that check — which also runs, because DNS changes — can
-        only log.
-        """
         try:
             assert_url_is_safe(value)
         except UnsafeURLError as exc:
             raise serializers.ValidationError(
-                "That URL cannot be used as a webhook destination. It must be a "
-                "public HTTPS or HTTP address on port 80 or 443 — internal, "
-                "loopback and cloud-metadata addresses are not permitted."
+                "That URL cannot be used as a webhook destination. It must be a public HTTPS or HTTP address on port 80 or 443 — internal, loopback and cloud-metadata addresses are not permitted."
             ) from exc
         return value
-
     def validate(self, attrs):
-        """Reject a duplicate before the database constraint has to."""
         user = self.context["request"].user
         url = attrs.get("url", getattr(self.instance, "url", None))
-
         duplicates = Webhook.objects.filter(user=user, url=url)
         if self.instance is not None:
             duplicates = duplicates.exclude(pk=self.instance.pk)
-
         if duplicates.exists():
-            raise serializers.ValidationError(
-                {"url": "You have already registered a webhook for that URL."}
-            )
-
+            raise serializers.ValidationError({"url": "You have already registered a webhook for that URL."})
         return attrs

--- a/backend/analyzer/tests_notification_preferences.py
+++ b/backend/analyzer/tests_notification_preferences.py
@@ -1,0 +1,81 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from .models import UserProfile
+
+
+class NotificationPreferenceTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="notification-user",
+            email="notification@example.com",
+            password="test-password-123",
+        )
+        self.profile, _ = UserProfile.objects.get_or_create(user=self.user)
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+    def test_defaults_are_documented_and_persisted(self):
+        self.profile.refresh_from_db()
+        self.assertFalse(self.profile.weekly_digest_opt_in)
+        self.assertEqual(self.profile.notification_preferences, {})
+
+        response = self.client.get("/api/profile/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["weekly_digest_opt_in"], False)
+        self.assertEqual(
+            response.data["notification_preferences"],
+            {"in_app": True, "browser": False},
+        )
+
+    def test_all_notification_preferences_persist(self):
+        response = self.client.put(
+            "/api/profile/",
+            {
+                "username": self.user.username,
+                "email": self.user.email,
+                "weekly_digest_opt_in": True,
+                "notification_preferences": {
+                    "in_app": False,
+                    "browser": True,
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.profile.refresh_from_db()
+        self.assertTrue(self.profile.weekly_digest_opt_in)
+        self.assertEqual(
+            self.profile.notification_preferences,
+            {"in_app": False, "browser": True},
+        )
+
+        response = self.client.get("/api/profile/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["weekly_digest_opt_in"], True)
+        self.assertEqual(
+            response.data["notification_preferences"],
+            {"in_app": False, "browser": True},
+        )
+
+    def test_partial_notification_update_keeps_existing_values(self):
+        self.profile.notification_preferences = {"in_app": False, "browser": True}
+        self.profile.save(update_fields=["notification_preferences"])
+
+        response = self.client.put(
+            "/api/profile/",
+            {
+                "username": self.user.username,
+                "email": self.user.email,
+                "notification_preferences": {"in_app": True},
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.profile.refresh_from_db()
+        self.assertEqual(
+            self.profile.notification_preferences,
+            {"in_app": True, "browser": True},
+        )

--- a/frontend/src/components/ProfilePage.test.tsx
+++ b/frontend/src/components/ProfilePage.test.tsx
@@ -4,93 +4,229 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ProfilePage } from './ProfilePage'
 
+// ProfilePage now talks to the shared `api` instance rather than bare axios,
+// so that the access token is attached from storage and a 401 is retried after
+// a refresh (#633). Mocking the client directly keeps these tests about the
+// page rather than about axios' interceptor plumbing.
 vi.mock('../api/client', () => ({
-  api: { get: vi.fn(), put: vi.fn(), post: vi.fn(), delete: vi.fn() },
+  api: {
+    get: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
   BACKEND_URL: 'http://127.0.0.1:8000',
   onSessionExpired: vi.fn(() => () => {}),
 }))
 
-vi.mock('../hooks/useAuth', () => ({ useAuth: vi.fn() }))
-
-vi.mock('../utils/notification', () => ({
-  requestNotificationPermission: vi.fn().mockResolvedValue('granted'),
-  saveNotificationPreferences: vi.fn(),
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: vi.fn(),
 }))
 
 import { api } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
-import { requestNotificationPermission, saveNotificationPreferences } from '../utils/notification'
 
-const mockedGet = vi.mocked(api.get)
-const mockedPut = vi.mocked(api.put)
+const mockedAxiosGet = vi.mocked(api.get)
+const mockedAxiosPut = vi.mocked(api.put)
 const mockedUseAuth = vi.mocked(useAuth)
 
-describe('ProfilePage notification preferences', () => {
+describe('ProfilePage', () => {
+  const mockUser = {
+    username: 'testuser',
+    token: 'fake-token',
+  }
+
+  const mockUpdateProfileSession = vi.fn()
+
   beforeEach(() => {
     vi.clearAllMocks()
+
     mockedUseAuth.mockReturnValue({
-      user: { username: 'testuser', token: 'fake-token' },
-      signup: vi.fn(), login: vi.fn(), loginWithOAuth: vi.fn(), logout: vi.fn(),
-      sessionExpired: false, dismissSessionExpired: vi.fn(), updateProfileSession: vi.fn(),
-      updateUserAvatar: vi.fn(), exportUserData: vi.fn().mockResolvedValue(undefined),
+      user: mockUser,
+      signup: vi.fn(),
+      login: vi.fn(),
+      loginWithOAuth: vi.fn(),
+      logout: vi.fn(),
+      sessionExpired: false,
+      dismissSessionExpired: vi.fn(),
+      updateProfileSession: mockUpdateProfileSession,
+      updateUserAvatar: vi.fn(),
+      exportUserData: vi.fn(),
     })
-    mockedGet.mockResolvedValue({ data: {
-      username: 'testuser', email: 'test@example.com', weekly_digest_opt_in: false,
-      notification_preferences: { in_app: true, browser: false },
-    } })
   })
 
-  it('shows all notification types with documented defaults', async () => {
-    render(<ProfilePage />)
-    await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
+  it('shows access denied when the user is not authenticated', () => {
+    mockedUseAuth.mockReturnValue({
+      user: null,
+      signup: vi.fn(),
+      login: vi.fn(),
+      loginWithOAuth: vi.fn(),
+      logout: vi.fn(),
+      sessionExpired: false,
+      dismissSessionExpired: vi.fn(),
+      updateProfileSession: vi.fn(),
+      updateUserAvatar: vi.fn(),
+      exportUserData: vi.fn(),
+    })
 
-    expect(screen.getByRole('heading', { name: /notification preferences/i })).toBeInTheDocument()
-    expect(screen.getByRole('switch', { name: /in-app notifications/i })).toBeChecked()
-    expect(screen.getByRole('switch', { name: /browser notifications/i })).not.toBeChecked()
-    expect(screen.getByRole('switch', { name: /weekly resume-tips email digest/i })).not.toBeChecked()
-    expect(screen.getByText('Default: On (opt-out)')).toBeInTheDocument()
-    expect(screen.getAllByText('Default: Off (opt-in)').length).toBeGreaterThanOrEqual(2)
+    render(<ProfilePage />)
+
+    expect(screen.getByText('Access Denied')).toBeInTheDocument()
+    expect(screen.getByText(/Please log in to manage your account details/i)).toBeInTheDocument()
   })
 
-  it('requests browser permission when browser notifications are enabled', async () => {
+  it('fetches and displays the authenticated user profile', async () => {
+    mockedAxiosGet.mockResolvedValueOnce({
+      data: {
+        username: 'testuser',
+        email: 'test@example.com',
+        weekly_digest_opt_in: true,
+      },
+    })
+
     render(<ProfilePage />)
-    await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
+
+    expect(screen.getByText('Fetching profile information...')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+    })
+
+    expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument()
+
+    const digestToggle = screen.getByRole('switch', {
+      name: /weekly resume-tips email digest/i,
+    })
+
+    expect(digestToggle).toBeChecked()
+    expect(mockedAxiosGet).toHaveBeenCalledWith(expect.stringContaining('/api/profile/'))
+  })
+
+  it('enters edit mode when Edit Profile is clicked', async () => {
+    mockedAxiosGet.mockResolvedValueOnce({
+      data: {
+        username: 'testuser',
+        email: 'test@example.com',
+        weekly_digest_opt_in: false,
+      },
+    })
+
+    render(<ProfilePage />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+    })
+
+    const usernameInput = screen.getByLabelText('Username')
+    const emailInput = screen.getByLabelText('Email Address')
+    const digestToggle = screen.getByRole('switch', {
+      name: /weekly resume-tips email digest/i,
+    })
+
+    expect(usernameInput).toBeDisabled()
+    expect(emailInput).toBeDisabled()
+    expect(digestToggle).toBeDisabled()
+
     fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
-    fireEvent.click(screen.getByRole('switch', { name: /browser notifications/i }))
-    await waitFor(() => expect(requestNotificationPermission).toHaveBeenCalled())
-    expect(screen.getByRole('switch', { name: /browser notifications/i })).toBeChecked()
+
+    expect(usernameInput).not.toBeDisabled()
+    expect(emailInput).not.toBeDisabled()
+    expect(digestToggle).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
   })
 
-  it('persists all three notification preferences through the profile API', async () => {
-    mockedPut.mockResolvedValueOnce({ data: {
-      username: 'testuser', email: 'test@example.com', weekly_digest_opt_in: true,
-      notification_preferences: { in_app: false, browser: true },
-    } })
+  it('updates the profile successfully', async () => {
+    mockedAxiosGet.mockResolvedValueOnce({
+      data: {
+        username: 'testuser',
+        email: 'test@example.com',
+        weekly_digest_opt_in: false,
+      },
+    })
+
+    mockedAxiosPut.mockResolvedValueOnce({
+      data: {
+        username: 'updateduser',
+        email: 'updated@example.com',
+        weekly_digest_opt_in: true,
+      },
+    })
 
     render(<ProfilePage />)
-    await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+    })
+
     fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
-    fireEvent.click(screen.getByRole('switch', { name: /in-app notifications/i }))
-    fireEvent.click(screen.getByRole('switch', { name: /browser notifications/i }))
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'updateduser' } })
+    fireEvent.change(screen.getByLabelText('Email Address'), { target: { value: 'updated@example.com' } })
     fireEvent.click(screen.getByRole('switch', { name: /weekly resume-tips email digest/i }))
     fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
 
-    await waitFor(() => expect(mockedPut).toHaveBeenCalled())
-    expect(mockedPut).toHaveBeenCalledWith('/api/profile/', expect.objectContaining({
-      username: 'testuser', email: 'test@example.com', weekly_digest_opt_in: true,
-      notification_preferences: { in_app: false, browser: true },
-    }))
-    expect(saveNotificationPreferences).toHaveBeenCalledWith({ in_app: false, browser: true })
-    expect(await screen.findByText(/profile and notification preferences updated successfully/i)).toBeInTheDocument()
+    await waitFor(() => expect(mockedAxiosPut).toHaveBeenCalled())
+
+    expect(mockedAxiosPut).toHaveBeenCalledWith(expect.stringContaining('/api/profile/'), {
+      username: 'updateduser',
+      email: 'updated@example.com',
+      weekly_digest_opt_in: true,
+    })
+
+    await waitFor(() => expect(screen.getByText('Profile updated successfully!')).toBeInTheDocument())
+    expect(screen.getByDisplayValue('updateduser')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('updated@example.com')).toBeInTheDocument()
+    expect(mockUpdateProfileSession).toHaveBeenCalledWith('updateduser')
+    expect(screen.getByRole('button', { name: /edit profile/i })).toBeInTheDocument()
   })
 
-  it('does not enable browser notifications when permission is denied', async () => {
-    vi.mocked(requestNotificationPermission).mockResolvedValueOnce('denied')
+  it('does not save when username is empty', async () => {
+    mockedAxiosGet.mockResolvedValueOnce({
+      data: { username: 'testuser', email: 'test@example.com', weekly_digest_opt_in: false },
+    })
+
     render(<ProfilePage />)
     await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
-    fireEvent.click(screen.getByRole('switch', { name: /browser notifications/i }))
-    await waitFor(() => expect(screen.getByText(/browser notifications are blocked/i)).toBeInTheDocument())
-    expect(screen.getByRole('switch', { name: /browser notifications/i })).not.toBeChecked()
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+    expect(await screen.findByText('Username cannot be empty.')).toBeInTheDocument()
+    expect(mockedAxiosPut).not.toHaveBeenCalled()
+  })
+
+  it('does not save when the email is invalid', async () => {
+    mockedAxiosGet.mockResolvedValueOnce({
+      data: { username: 'testuser', email: 'test@example.com', weekly_digest_opt_in: false },
+    })
+
+    render(<ProfilePage />)
+    await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
+    fireEvent.change(screen.getByLabelText('Email Address'), { target: { value: 'invalid-email' } })
+
+    const form = screen.getByRole('button', { name: /save changes/i }).closest('form')
+    if (form) fireEvent.submit(form)
+
+    expect(await screen.findByText('Please provide a valid email address.')).toBeInTheDocument()
+    expect(mockedAxiosPut).not.toHaveBeenCalled()
+  })
+
+  it('cancels editing and restores the original values', async () => {
+    mockedAxiosGet.mockResolvedValueOnce({
+      data: { username: 'testuser', email: 'test@example.com', weekly_digest_opt_in: false },
+    })
+
+    render(<ProfilePage />)
+    await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'changeduser' } })
+    fireEvent.change(screen.getByLabelText('Email Address'), { target: { value: 'changed@example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /edit profile/i })).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/ProfilePage.test.tsx
+++ b/frontend/src/components/ProfilePage.test.tsx
@@ -4,296 +4,93 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ProfilePage } from './ProfilePage'
 
-// ProfilePage now talks to the shared `api` instance rather than bare axios,
-// so that the access token is attached from storage and a 401 is retried after
-// a refresh (#633). Mocking the client directly keeps these tests about the
-// page rather than about axios' interceptor plumbing.
 vi.mock('../api/client', () => ({
-  api: {
-    get: vi.fn(),
-    put: vi.fn(),
-    post: vi.fn(),
-    delete: vi.fn(),
-  },
+  api: { get: vi.fn(), put: vi.fn(), post: vi.fn(), delete: vi.fn() },
   BACKEND_URL: 'http://127.0.0.1:8000',
   onSessionExpired: vi.fn(() => () => {}),
 }))
 
-vi.mock('../hooks/useAuth', () => ({
-  useAuth: vi.fn(),
+vi.mock('../hooks/useAuth', () => ({ useAuth: vi.fn() }))
+
+vi.mock('../utils/notification', () => ({
+  requestNotificationPermission: vi.fn().mockResolvedValue('granted'),
+  saveNotificationPreferences: vi.fn(),
 }))
 
 import { api } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
+import { requestNotificationPermission, saveNotificationPreferences } from '../utils/notification'
 
-const mockedAxiosGet = vi.mocked(api.get)
-const mockedAxiosPut = vi.mocked(api.put)
+const mockedGet = vi.mocked(api.get)
+const mockedPut = vi.mocked(api.put)
 const mockedUseAuth = vi.mocked(useAuth)
 
-describe('ProfilePage', () => {
-  const mockUser = {
-    username: 'testuser',
-    token: 'fake-token',
-  }
-
-  const mockUpdateProfileSession = vi.fn()
-
+describe('ProfilePage notification preferences', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-
     mockedUseAuth.mockReturnValue({
-      user: mockUser,
-      signup: vi.fn(),
-      login: vi.fn(),
-      loginWithOAuth: vi.fn(),
-      logout: vi.fn(),
-      sessionExpired: false,
-      dismissSessionExpired: vi.fn(),
-      updateProfileSession: mockUpdateProfileSession,
-      updateUserAvatar: vi.fn(),
-      exportUserData: vi.fn(),
+      user: { username: 'testuser', token: 'fake-token' },
+      signup: vi.fn(), login: vi.fn(), loginWithOAuth: vi.fn(), logout: vi.fn(),
+      sessionExpired: false, dismissSessionExpired: vi.fn(), updateProfileSession: vi.fn(),
+      updateUserAvatar: vi.fn(), exportUserData: vi.fn().mockResolvedValue(undefined),
     })
+    mockedGet.mockResolvedValue({ data: {
+      username: 'testuser', email: 'test@example.com', weekly_digest_opt_in: false,
+      notification_preferences: { in_app: true, browser: false },
+    } })
   })
 
-  it('shows access denied when the user is not authenticated', () => {
-    mockedUseAuth.mockReturnValue({
-      user: null,
-      signup: vi.fn(),
-      login: vi.fn(),
-      loginWithOAuth: vi.fn(),
-      logout: vi.fn(),
-      sessionExpired: false,
-      dismissSessionExpired: vi.fn(),
-      updateProfileSession: vi.fn(),
-      updateUserAvatar: vi.fn(),
-      exportUserData: vi.fn(),
-    })
-
+  it('shows all notification types with documented defaults', async () => {
     render(<ProfilePage />)
+    await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
 
-    expect(screen.getByText('Access Denied')).toBeInTheDocument()
-    expect(screen.getByText(/Please log in to manage your account details/i)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /notification preferences/i })).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: /in-app notifications/i })).toBeChecked()
+    expect(screen.getByRole('switch', { name: /browser notifications/i })).not.toBeChecked()
+    expect(screen.getByRole('switch', { name: /weekly resume-tips email digest/i })).not.toBeChecked()
+    expect(screen.getByText('Default: On (opt-out)')).toBeInTheDocument()
+    expect(screen.getAllByText('Default: Off (opt-in)').length).toBeGreaterThanOrEqual(2)
   })
 
-  it('fetches and displays the authenticated user profile', async () => {
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: {
-        username: 'testuser',
-        email: 'test@example.com',
-        weekly_digest_opt_in: true,
-      },
-    })
-
+  it('requests browser permission when browser notifications are enabled', async () => {
     render(<ProfilePage />)
-
-    expect(screen.getByText('Fetching profile information...')).toBeInTheDocument()
-
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
-    })
-
-    expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument()
-
-    const digestToggle = screen.getByRole('switch', {
-      name: /weekly resume-tips email digest/i,
-    })
-
-    expect(digestToggle).toBeChecked()
-
-    // No Authorization argument any more: the client's request
-    // interceptor attaches the current token, so the page does not build
-    // a header from a value captured on render.
-    expect(mockedAxiosGet).toHaveBeenCalledWith(expect.stringContaining('/api/profile/'))
-  })
-
-  it('enters edit mode when Edit Profile is clicked', async () => {
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: {
-        username: 'testuser',
-        email: 'test@example.com',
-        weekly_digest_opt_in: false,
-      },
-    })
-
-    render(<ProfilePage />)
-
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
-    })
-
-    const usernameInput = screen.getByLabelText('Username')
-    const emailInput = screen.getByLabelText('Email Address')
-    const digestToggle = screen.getByRole('switch', {
-      name: /weekly resume-tips email digest/i,
-    })
-
-    expect(usernameInput).toBeDisabled()
-    expect(emailInput).toBeDisabled()
-    expect(digestToggle).toBeDisabled()
-
+    await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
-
-    expect(usernameInput).not.toBeDisabled()
-    expect(emailInput).not.toBeDisabled()
-    expect(digestToggle).not.toBeDisabled()
-
-    expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument()
-
-    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('switch', { name: /browser notifications/i }))
+    await waitFor(() => expect(requestNotificationPermission).toHaveBeenCalled())
+    expect(screen.getByRole('switch', { name: /browser notifications/i })).toBeChecked()
   })
 
-  it('updates the profile successfully', async () => {
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: {
-        username: 'testuser',
-        email: 'test@example.com',
-        weekly_digest_opt_in: false,
-      },
-    })
-
-    mockedAxiosPut.mockResolvedValueOnce({
-      data: {
-        username: 'updateduser',
-        email: 'updated@example.com',
-        weekly_digest_opt_in: true,
-      },
-    })
+  it('persists all three notification preferences through the profile API', async () => {
+    mockedPut.mockResolvedValueOnce({ data: {
+      username: 'testuser', email: 'test@example.com', weekly_digest_opt_in: true,
+      notification_preferences: { in_app: false, browser: true },
+    } })
 
     render(<ProfilePage />)
-
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
-    })
-
+    await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
-
-    fireEvent.change(screen.getByLabelText('Username'), {
-      target: { value: 'updateduser' },
-    })
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'updated@example.com' },
-    })
-
-    fireEvent.click(
-      screen.getByRole('switch', {
-        name: /weekly resume-tips email digest/i,
-      })
-    )
-
+    fireEvent.click(screen.getByRole('switch', { name: /in-app notifications/i }))
+    fireEvent.click(screen.getByRole('switch', { name: /browser notifications/i }))
+    fireEvent.click(screen.getByRole('switch', { name: /weekly resume-tips email digest/i }))
     fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
 
-    await waitFor(() => {
-      expect(mockedAxiosPut).toHaveBeenCalled()
-    })
-
-    expect(mockedAxiosPut).toHaveBeenCalledWith(expect.stringContaining('/api/profile/'), {
-      username: 'updateduser',
-      email: 'updated@example.com',
-      weekly_digest_opt_in: true,
-    })
-
-    await waitFor(() => {
-      expect(screen.getByText('Profile updated successfully!')).toBeInTheDocument()
-    })
-
-    expect(screen.getByDisplayValue('updateduser')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('updated@example.com')).toBeInTheDocument()
-
-    expect(mockUpdateProfileSession).toHaveBeenCalledWith('updateduser')
-
-    expect(screen.getByRole('button', { name: /edit profile/i })).toBeInTheDocument()
+    await waitFor(() => expect(mockedPut).toHaveBeenCalled())
+    expect(mockedPut).toHaveBeenCalledWith('/api/profile/', expect.objectContaining({
+      username: 'testuser', email: 'test@example.com', weekly_digest_opt_in: true,
+      notification_preferences: { in_app: false, browser: true },
+    }))
+    expect(saveNotificationPreferences).toHaveBeenCalledWith({ in_app: false, browser: true })
+    expect(await screen.findByText(/profile and notification preferences updated successfully/i)).toBeInTheDocument()
   })
 
-  it('does not save when username is empty', async () => {
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: {
-        username: 'testuser',
-        email: 'test@example.com',
-        weekly_digest_opt_in: false,
-      },
-    })
-
+  it('does not enable browser notifications when permission is denied', async () => {
+    vi.mocked(requestNotificationPermission).mockResolvedValueOnce('denied')
     render(<ProfilePage />)
-
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
-    })
-
+    await waitFor(() => expect(screen.getByDisplayValue('testuser')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
-
-    fireEvent.change(screen.getByLabelText('Username'), {
-      target: { value: '' },
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
-
-    expect(await screen.findByText('Username cannot be empty.')).toBeInTheDocument()
-
-    expect(mockedAxiosPut).not.toHaveBeenCalled()
-  })
-
-  it('does not save when the email is invalid', async () => {
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: {
-        username: 'testuser',
-        email: 'test@example.com',
-        weekly_digest_opt_in: false,
-      },
-    })
-
-    render(<ProfilePage />)
-
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'invalid-email' },
-    })
-
-    const form = screen.getByRole('button', { name: /save changes/i }).closest('form')
-    if (form) {
-      fireEvent.submit(form)
-    }
-
-    expect(await screen.findByText('Please provide a valid email address.')).toBeInTheDocument()
-
-    expect(mockedAxiosPut).not.toHaveBeenCalled()
-  })
-
-  it('cancels editing and restores the original values', async () => {
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: {
-        username: 'testuser',
-        email: 'test@example.com',
-        weekly_digest_opt_in: false,
-      },
-    })
-
-    render(<ProfilePage />)
-
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: /edit profile/i }))
-
-    fireEvent.change(screen.getByLabelText('Username'), {
-      target: { value: 'changeduser' },
-    })
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'changed@example.com' },
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
-
-    expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument()
-
-    expect(screen.getByRole('button', { name: /edit profile/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('switch', { name: /browser notifications/i }))
+    await waitFor(() => expect(screen.getByText(/browser notifications are blocked/i)).toBeInTheDocument())
+    expect(screen.getByRole('switch', { name: /browser notifications/i })).not.toBeChecked()
   })
 })

--- a/frontend/src/components/ProfilePage.tsx
+++ b/frontend/src/components/ProfilePage.tsx
@@ -1,23 +1,34 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { api } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { getConsentPreferences, saveConsentPreferences } from '../utils/cookieConsent'
+import { requestNotificationPermission } from '../utils/notification'
+
+type NotificationPreferences = {
+  in_app: boolean
+  browser: boolean
+}
+
+const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  in_app: true,
+  browser: false,
+}
 
 export const ProfilePage: React.FC = () => {
   const { user, updateProfileSession, exportUserData } = useAuth()
   const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
   const [weeklyDigestOptIn, setWeeklyDigestOptIn] = useState(false)
+  const [notificationPreferences, setNotificationPreferences] = useState<NotificationPreferences>(DEFAULT_NOTIFICATION_PREFERENCES)
   const [analyticsConsent, setAnalyticsConsentState] = useState<boolean>(() => getConsentPreferences().analytics)
   const [resumeRoastConsent, setResumeRoastConsentState] = useState<boolean>(() => getConsentPreferences().resumeRoast)
   const [isEditing, setIsEditing] = useState(false)
-
   const [originalUsername, setOriginalUsername] = useState('')
   const [originalEmail, setOriginalEmail] = useState('')
   const [originalOptIn, setOriginalOptIn] = useState(false)
+  const [originalNotificationPreferences, setOriginalNotificationPreferences] = useState<NotificationPreferences>(DEFAULT_NOTIFICATION_PREFERENCES)
   const [originalAnalyticsConsent, setOriginalAnalyticsConsent] = useState<boolean>(() => getConsentPreferences().analytics)
   const [originalResumeRoastConsent, setOriginalResumeRoastConsent] = useState<boolean>(() => getConsentPreferences().resumeRoast)
-
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [exporting, setExporting] = useState(false)
@@ -26,24 +37,24 @@ export const ProfilePage: React.FC = () => {
 
   useEffect(() => {
     if (!user) return
-
     const fetchProfile = async () => {
       try {
         setLoading(true)
         setError(null)
-        // Through `api` so an expired access token is refreshed and the
-        // request retried. Building the header from `user.token` by hand meant
-        // the profile page was blank with "Failed to load profile details"
-        // fifteen minutes after signing in.
         const response = await api.get('/api/profile/')
         const data = response.data
+        const prefs = {
+          in_app: data.notification_preferences?.in_app !== false,
+          browser: data.notification_preferences?.browser === true,
+        }
         setUsername(data.username)
         setEmail(data.email || '')
         setWeeklyDigestOptIn(!!data.weekly_digest_opt_in)
+        setNotificationPreferences(prefs)
         setOriginalUsername(data.username)
         setOriginalEmail(data.email || '')
         setOriginalOptIn(!!data.weekly_digest_opt_in)
-
+        setOriginalNotificationPreferences(prefs)
         const consentPrefs = getConsentPreferences()
         setAnalyticsConsentState(consentPrefs.analytics)
         setResumeRoastConsentState(consentPrefs.resumeRoast)
@@ -55,7 +66,6 @@ export const ProfilePage: React.FC = () => {
         setLoading(false)
       }
     }
-
     fetchProfile()
   }, [user])
 
@@ -63,6 +73,7 @@ export const ProfilePage: React.FC = () => {
     setUsername(originalUsername)
     setEmail(originalEmail)
     setWeeklyDigestOptIn(originalOptIn)
+    setNotificationPreferences(originalNotificationPreferences)
     setAnalyticsConsentState(originalAnalyticsConsent)
     setResumeRoastConsentState(originalResumeRoastConsent)
     setIsEditing(false)
@@ -75,9 +86,7 @@ export const ProfilePage: React.FC = () => {
       setExporting(true)
       setError(null)
       setSuccessMsg(null)
-
       await exportUserData()
-
       setSuccessMsg('Your account data has been downloaded successfully.')
     } catch (err: any) {
       setError(err.response?.data?.error || err.message || 'Failed to export your data.')
@@ -86,12 +95,23 @@ export const ProfilePage: React.FC = () => {
     }
   }
 
+  const updateNotificationPreference = async (channel: keyof NotificationPreferences, enabled: boolean) => {
+    if (channel === 'browser' && enabled) {
+      const permission = await requestNotificationPermission()
+      if (permission !== 'granted') {
+        setError(permission === 'denied'
+          ? 'Browser notifications are blocked by your browser. Allow notifications for this site and try again.'
+          : 'Browser notification permission was not granted.')
+        return
+      }
+      setError(null)
+    }
+    setNotificationPreferences((current) => ({ ...current, [channel]: enabled }))
+  }
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!user) return
-
-    // Client-side validations
     if (!username.trim()) {
       setError('Username cannot be empty.')
       return
@@ -110,44 +130,37 @@ export const ProfilePage: React.FC = () => {
       setSaving(true)
       setError(null)
       setSuccessMsg(null)
-
       const response = await api.put('/api/profile/', {
         username,
         email,
         weekly_digest_opt_in: weeklyDigestOptIn,
+        notification_preferences: notificationPreferences,
       })
-
       const updated = response.data
+      const savedPrefs = {
+        in_app: updated.notification_preferences?.in_app !== false,
+        browser: updated.notification_preferences?.browser === true,
+      }
       setUsername(updated.username)
       setEmail(updated.email)
       setWeeklyDigestOptIn(!!updated.weekly_digest_opt_in)
+      setNotificationPreferences(savedPrefs)
       setOriginalUsername(updated.username)
       setOriginalEmail(updated.email)
       setOriginalOptIn(!!updated.weekly_digest_opt_in)
-
-      // Save client-side data consent preferences (#536)
-      saveConsentPreferences({
-        analytics: analyticsConsent,
-        resumeRoast: resumeRoastConsent,
-      })
+      setOriginalNotificationPreferences(savedPrefs)
+      saveConsentPreferences({ analytics: analyticsConsent, resumeRoast: resumeRoastConsent })
       setOriginalAnalyticsConsent(analyticsConsent)
       setOriginalResumeRoastConsent(resumeRoastConsent)
-
-      // Update global context session
       updateProfileSession(updated.username)
-
-      setSuccessMsg('Profile updated successfully!')
+      setSuccessMsg('Profile and notification preferences updated successfully!')
       setIsEditing(false)
     } catch (err: any) {
       if (err.response?.data) {
         const errors = err.response.data
-        if (errors.username) {
-          setError(Array.isArray(errors.username) ? errors.username[0] : errors.username)
-        } else if (errors.email) {
-          setError(Array.isArray(errors.email) ? errors.email[0] : errors.email)
-        } else {
-          setError(errors.error || 'Failed to update profile details.')
-        }
+        if (errors.username) setError(Array.isArray(errors.username) ? errors.username[0] : errors.username)
+        else if (errors.email) setError(Array.isArray(errors.email) ? errors.email[0] : errors.email)
+        else setError(errors.error || 'Failed to update profile details.')
       } else {
         setError('An unexpected error occurred.')
       }
@@ -156,275 +169,57 @@ export const ProfilePage: React.FC = () => {
     }
   }
 
-  if (!user) {
-    return (
-      <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '60px 20px' }}>
-        <div className="analysis-card text-center" style={{ maxWidth: '400px', width: '100%', padding: '40px' }}>
-          <h2 style={{ color: 'var(--color-danger)', marginBottom: '16px' }}>Access Denied</h2>
-          <p style={{ color: 'var(--muted-text)', marginBottom: '24px' }}>Please log in to manage your account details.</p>
-        </div>
+  const preferenceCard = (
+    id: string,
+    label: string,
+    description: string,
+    defaultText: string,
+    checked: boolean,
+    onChange: (enabled: boolean) => void,
+  ) => (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 16px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: 'rgba(255, 255, 255, 0.02)', gap: '16px' }}>
+      <div>
+        <label htmlFor={id} style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)', display: 'block' }}>{label}</label>
+        <span style={{ fontSize: '0.8rem', color: 'var(--muted-text)', display: 'block', marginTop: '3px' }}>{description}</span>
+        <span style={{ fontSize: '0.75rem', color: 'var(--muted-text)', display: 'block', marginTop: '4px' }}>Default: {defaultText}</span>
       </div>
-    )
+      <div className="form-check form-switch" style={{ margin: 0, paddingLeft: '2.5em', flexShrink: 0 }}>
+        <input id={id} className="form-check-input" type="checkbox" role="switch" checked={checked} onChange={(e) => onChange(e.target.checked)} disabled={!isEditing || saving} style={{ width: '2.2em', height: '1.2em', cursor: isEditing ? 'pointer' : 'not-allowed' }} />
+      </div>
+    </div>
+  )
+
+  if (!user) {
+    return <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '60px 20px' }}><div className="analysis-card text-center" style={{ maxWidth: '400px', width: '100%', padding: '40px' }}><h2 style={{ color: 'var(--color-danger)', marginBottom: '16px' }}>Access Denied</h2><p style={{ color: 'var(--muted-text)', marginBottom: '24px' }}>Please log in to manage your account details.</p></div></div>
   }
 
   return (
     <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '40px 20px' }}>
-      <div className="analysis-card" style={{ maxWidth: '600px', width: '100%', padding: '30px' }}>
+      <div className="analysis-card" style={{ maxWidth: '700px', width: '100%', padding: '30px' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px', borderBottom: '1px solid var(--surface-border)', paddingBottom: '16px' }}>
           <span style={{ fontSize: '2rem' }}>👤</span>
-          <div>
-            <h1 style={{ fontSize: '1.5rem', fontWeight: '700', margin: 0, color: 'var(--heading-text)' }}>Account Profile</h1>
-            <p style={{ fontSize: '0.85rem', color: 'var(--muted-text)', margin: '4px 0 0 0' }}>Manage your account username and contact details</p>
-          </div>
+          <div><h1 style={{ fontSize: '1.5rem', fontWeight: '700', margin: 0, color: 'var(--heading-text)' }}>Account Profile</h1><p style={{ fontSize: '0.85rem', color: 'var(--muted-text)', margin: '4px 0 0' }}>Manage your account and notification preferences</p></div>
         </div>
-
-        {loading ? (
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '40px 0', gap: '12px' }}>
-            <div className="spinner" style={{ borderTopColor: 'var(--color-primary)' }} />
-            <p style={{ color: 'var(--muted-text)' }}>Fetching profile information...</p>
-          </div>
-        ) : (
+        {loading ? <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '40px 0', gap: '12px' }}><div className="spinner" style={{ borderTopColor: 'var(--color-primary)' }} /><p style={{ color: 'var(--muted-text)' }}>Fetching profile information...</p></div> : (
           <form onSubmit={handleSave} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-            {error && (
-              <div style={{
-                background: 'rgba(239, 68, 68, 0.1)',
-                border: '1px solid var(--color-danger)',
-                color: 'var(--color-danger)',
-                padding: '12px 16px',
-                borderRadius: 'var(--radius-md)',
-                fontSize: '0.9rem',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px'
-              }}>
-                <span>⚠️</span>
-                <span>{error}</span>
-              </div>
-            )}
+            {error && <div style={{ background: 'rgba(239, 68, 68, 0.1)', border: '1px solid var(--color-danger)', color: 'var(--color-danger)', padding: '12px 16px', borderRadius: 'var(--radius-md)', fontSize: '0.9rem' }}>⚠️ {error}</div>}
+            {successMsg && <div style={{ background: 'rgba(34, 197, 94, 0.1)', border: '1px solid var(--color-accent)', color: 'var(--color-accent)', padding: '12px 16px', borderRadius: 'var(--radius-md)', fontSize: '0.9rem' }}>✅ {successMsg}</div>}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}><label htmlFor="profile-username" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Username</label><input id="profile-username" name="username" type="text" autoComplete="username" value={username} onChange={(e) => setUsername(e.target.value)} disabled={!isEditing || saving} style={{ padding: '10px 14px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)', color: 'var(--control-text)', fontSize: '0.95rem' }} /></div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}><label htmlFor="profile-email" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Email Address</label><input id="profile-email" name="email" type="email" autoComplete="email" value={email} onChange={(e) => setEmail(e.target.value)} disabled={!isEditing || saving} style={{ padding: '10px 14px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)', color: 'var(--control-text)', fontSize: '0.95rem' }} /></div>
 
-            {successMsg && (
-              <div style={{
-                background: 'rgba(34, 197, 94, 0.1)',
-                border: '1px solid var(--color-accent)',
-                color: 'var(--color-accent)',
-                padding: '12px 16px',
-                borderRadius: 'var(--radius-md)',
-                fontSize: '0.9rem',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px'
-              }}>
-                <span>✅</span>
-                <span>{successMsg}</span>
-              </div>
-            )}
-
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-              <label htmlFor="profile-username" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Username</label>
-              <input
-                id="profile-username"
-                name="username"
-                type="text"
-                autoComplete="username"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                disabled={!isEditing || saving}
-                style={{
-                  padding: '10px 14px',
-                  borderRadius: 'var(--radius-md)',
-                  border: '1px solid var(--control-border)',
-                  background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)',
-                  color: 'var(--control-text)',
-                  fontSize: '0.95rem',
-                  outline: 'none',
-                  transition: 'border-color 0.2s ease',
-                  cursor: isEditing ? 'text' : 'not-allowed'
-                }}
-              />
+            <div style={{ borderTop: '1px solid var(--surface-border)', paddingTop: '20px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div><h2 style={{ fontSize: '1.1rem', margin: 0, color: 'var(--heading-text)' }}>🔔 Notification Preferences</h2><p style={{ fontSize: '0.8rem', color: 'var(--muted-text)', margin: '4px 0 0' }}>Manage all optional notification channels in one place. Changes are saved to your account.</p></div>
+              {preferenceCard('in-app-notifications-toggle', '🔔 In-app notifications', 'Show notification messages inside Resume Analyzer.', 'On (opt-out)', notificationPreferences.in_app, (enabled) => updateNotificationPreference('in_app', enabled))}
+              {preferenceCard('browser-notifications-toggle', '🌐 Browser notifications', 'Show a native browser notification when analysis finishes in a background tab.', 'Off (opt-in)', notificationPreferences.browser, (enabled) => updateNotificationPreference('browser', enabled))}
+              {preferenceCard('weekly-digest-toggle', '📧 Weekly Resume-Tips Email Digest', 'Receive actionable resume guidelines and score improvement nudges once a week.', 'Off (opt-in)', weeklyDigestOptIn, setWeeklyDigestOptIn)}
             </div>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-              <label htmlFor="profile-email" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Email Address</label>
-              <input
-                id="profile-email"
-                name="email"
-                type="email"
-                autoComplete="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                disabled={!isEditing || saving}
-                style={{
-                  padding: '10px 14px',
-                  borderRadius: 'var(--radius-md)',
-                  border: '1px solid var(--control-border)',
-                  background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)',
-                  color: 'var(--control-text)',
-                  fontSize: '0.95rem',
-                  outline: 'none',
-                  transition: 'border-color 0.2s ease',
-                  cursor: isEditing ? 'text' : 'not-allowed'
-                }}
-              />
-            </div>
-
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              padding: '12px 16px',
-              borderRadius: 'var(--radius-md)',
-              border: '1px solid var(--control-border)',
-              background: 'rgba(255, 255, 255, 0.02)'
-            }}>
-              <div>
-                <label htmlFor="weekly-digest-toggle" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)', display: 'block' }}>
-                  📧 Weekly Resume-Tips Email Digest
-                </label>
-                <span style={{ fontSize: '0.8rem', color: 'var(--muted-text)', display: 'block', marginTop: '2px' }}>
-                  Receive actionable resume guidelines and score improvement nudges once a week.
-                </span>
-              </div>
-              <div className="form-check form-switch" style={{ margin: 0, paddingLeft: '2.5em' }}>
-                <input
-                  id="weekly-digest-toggle"
-                  className="form-check-input"
-                  type="checkbox"
-                  role="switch"
-                  checked={weeklyDigestOptIn}
-                  onChange={(e) => setWeeklyDigestOptIn(e.target.checked)}
-                  disabled={!isEditing || saving}
-                  style={{ width: '2.2em', height: '1.2em', cursor: isEditing ? 'pointer' : 'not-allowed' }}
-                />
-              </div>
-            </div>
-
-            {/* Optional Data Collection: Analytics (#536) */}
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              padding: '12px 16px',
-              borderRadius: 'var(--radius-md)',
-              border: '1px solid var(--control-border)',
-              background: 'rgba(255, 255, 255, 0.02)'
-            }}>
-              <div>
-                <label htmlFor="profile-analytics-toggle" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)', display: 'block' }}>
-                  📊 Analytics & Performance Telemetry
-                </label>
-                <span style={{ fontSize: '0.8rem', color: 'var(--muted-text)', display: 'block', marginTop: '2px' }}>
-                  Allow anonymous usage telemetry to diagnose issues and optimize ATS parsing accuracy (Off by default).
-                </span>
-              </div>
-              <div className="form-check form-switch" style={{ margin: 0, paddingLeft: '2.5em' }}>
-                <input
-                  id="profile-analytics-toggle"
-                  className="form-check-input"
-                  type="checkbox"
-                  role="switch"
-                  checked={analyticsConsent}
-                  onChange={(e) => setAnalyticsConsentState(e.target.checked)}
-                  disabled={!isEditing || saving}
-                  style={{ width: '2.2em', height: '1.2em', cursor: isEditing ? 'pointer' : 'not-allowed' }}
-                />
-              </div>
-            </div>
-
-            {/* Optional Data Collection: Resume Roast (#536) */}
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              padding: '12px 16px',
-              borderRadius: 'var(--radius-md)',
-              border: '1px solid var(--control-border)',
-              background: 'rgba(255, 255, 255, 0.02)'
-            }}>
-              <div>
-                <label htmlFor="profile-roast-toggle" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)', display: 'block' }}>
-                  🔥 AI Resume Roast Feedback Consent
-                </label>
-                <span style={{ fontSize: '0.8rem', color: 'var(--muted-text)', display: 'block', marginTop: '2px' }}>
-                  Opt in to allow processing alternate humorous and spicy feedback tone suggestions (Off by default).
-                </span>
-              </div>
-              <div className="form-check form-switch" style={{ margin: 0, paddingLeft: '2.5em' }}>
-                <input
-                  id="profile-roast-toggle"
-                  className="form-check-input"
-                  type="checkbox"
-                  role="switch"
-                  checked={resumeRoastConsent}
-                  onChange={(e) => setResumeRoastConsentState(e.target.checked)}
-                  disabled={!isEditing || saving}
-                  style={{ width: '2.2em', height: '1.2em', cursor: isEditing ? 'pointer' : 'not-allowed' }}
-                />
-              </div>
-            </div>
+            {preferenceCard('profile-analytics-toggle', '📊 Analytics & Performance Telemetry', 'Allow anonymous usage telemetry to diagnose issues and optimize ATS parsing accuracy.', 'Off (opt-in)', analyticsConsent, setAnalyticsConsentState)}
+            {preferenceCard('profile-roast-toggle', '🔥 AI Resume Roast Feedback Consent', 'Opt in to allow processing alternate humorous and spicy feedback tone suggestions.', 'Off (opt-in)', resumeRoastConsent, setResumeRoastConsentState)}
 
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', marginTop: '10px', borderTop: '1px solid var(--surface-border)', paddingTop: '20px' }}>
-              <button
-                type="button"
-                className="app-btn app-btn--secondary"
-                onClick={handleExportData}
-                disabled={exporting || saving}
-                style={{ minWidth: '140px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}
-              >
-                {exporting ? (
-                  <>
-                    <span
-                      className="spinner-border spinner-border-sm"
-                      role="status"
-                      aria-hidden="true"
-                      style={{ width: '1rem', height: '1rem' }}
-                    />
-                    Exporting...
-                  </>
-                ) : (
-                  'Export My Data'
-                )}
-              </button>
-
-              {!isEditing ? (
-                <button
-                  type="button"
-                  className="app-btn app-btn--primary"
-                  onClick={() => {
-                    setIsEditing(true)
-                    setSuccessMsg(null)
-                  }}
-                  style={{ minWidth: '100px' }}
-                >
-                  ✏️ Edit Profile
-                </button>
-              ) : (
-                <>
-                  <button
-                    type="button"
-                    className="app-btn app-btn--secondary"
-                    onClick={handleCancel}
-                    disabled={saving}
-                    style={{ minWidth: '100px' }}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="submit"
-                    className="app-btn app-btn--primary"
-                    disabled={saving}
-                    style={{ minWidth: '100px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}
-                  >
-                    {saving ? (
-                      <>
-                        <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" style={{ width: '1rem', height: '1rem' }} />
-                        Saving...
-                      </>
-                    ) : (
-                      'Save Changes'
-                    )}
-                  </button>
-                </>
-              )}
+              <button type="button" className="app-btn app-btn--secondary" onClick={handleExportData} disabled={exporting || saving} style={{ minWidth: '140px' }}>{exporting ? 'Exporting...' : 'Export My Data'}</button>
+              {!isEditing ? <button type="button" className="app-btn app-btn--primary" onClick={() => { setIsEditing(true); setSuccessMsg(null) }} style={{ minWidth: '100px' }}>✏️ Edit Profile</button> : <><button type="button" className="app-btn app-btn--secondary" onClick={handleCancel} disabled={saving} style={{ minWidth: '100px' }}>Cancel</button><button type="submit" className="app-btn app-btn--primary" disabled={saving} style={{ minWidth: '100px' }}>{saving ? 'Saving...' : 'Save Changes'}</button></>}
             </div>
           </form>
         )}

--- a/frontend/src/components/ProfilePage.tsx
+++ b/frontend/src/components/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { api } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { getConsentPreferences, saveConsentPreferences } from '../utils/cookieConsent'
@@ -16,12 +16,14 @@ export const ProfilePage: React.FC = () => {
   const [analyticsConsent, setAnalyticsConsentState] = useState<boolean>(() => getConsentPreferences().analytics)
   const [resumeRoastConsent, setResumeRoastConsentState] = useState<boolean>(() => getConsentPreferences().resumeRoast)
   const [isEditing, setIsEditing] = useState(false)
+
   const [originalUsername, setOriginalUsername] = useState('')
   const [originalEmail, setOriginalEmail] = useState('')
   const [originalOptIn, setOriginalOptIn] = useState(false)
   const [originalNotificationPreferences, setOriginalNotificationPreferences] = useState<NotificationPreferences>(DEFAULT_NOTIFICATION_PREFERENCES)
   const [originalAnalyticsConsent, setOriginalAnalyticsConsent] = useState<boolean>(() => getConsentPreferences().analytics)
   const [originalResumeRoastConsent, setOriginalResumeRoastConsent] = useState<boolean>(() => getConsentPreferences().resumeRoast)
+
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [exporting, setExporting] = useState(false)
@@ -30,6 +32,7 @@ export const ProfilePage: React.FC = () => {
 
   useEffect(() => {
     if (!user) return
+
     const fetchProfile = async () => {
       try {
         setLoading(true)
@@ -49,6 +52,7 @@ export const ProfilePage: React.FC = () => {
         setOriginalEmail(data.email || '')
         setOriginalOptIn(!!data.weekly_digest_opt_in)
         setOriginalNotificationPreferences(prefs)
+
         const consentPrefs = getConsentPreferences()
         setAnalyticsConsentState(consentPrefs.analytics)
         setResumeRoastConsentState(consentPrefs.resumeRoast)
@@ -60,6 +64,7 @@ export const ProfilePage: React.FC = () => {
         setLoading(false)
       }
     }
+
     fetchProfile()
   }, [user])
 
@@ -78,12 +83,16 @@ export const ProfilePage: React.FC = () => {
 
   const handleExportData = async () => {
     try {
-      setExporting(true); setError(null); setSuccessMsg(null)
+      setExporting(true)
+      setError(null)
+      setSuccessMsg(null)
       await exportUserData()
       setSuccessMsg('Your account data has been downloaded successfully.')
     } catch (err: any) {
       setError(err.response?.data?.error || err.message || 'Failed to export your data.')
-    } finally { setExporting(false) }
+    } finally {
+      setExporting(false)
+    }
   }
 
   const updateNotificationPreference = async (channel: keyof NotificationPreferences, enabled: boolean) => {
@@ -103,77 +112,210 @@ export const ProfilePage: React.FC = () => {
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!user) return
-    if (!username.trim()) { setError('Username cannot be empty.'); return }
-    if (!email.trim()) { setError('Email cannot be empty.'); return }
+
+    if (!username.trim()) {
+      setError('Username cannot be empty.')
+      return
+    }
+    if (!email.trim()) {
+      setError('Email cannot be empty.')
+      return
+    }
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    if (!emailRegex.test(email)) { setError('Please provide a valid email address.'); return }
+    if (!emailRegex.test(email)) {
+      setError('Please provide a valid email address.')
+      return
+    }
+
     try {
-      setSaving(true); setError(null); setSuccessMsg(null)
+      setSaving(true)
+      setError(null)
+      setSuccessMsg(null)
+
       const response = await api.put('/api/profile/', {
-        username, email, weekly_digest_opt_in: weeklyDigestOptIn,
+        username,
+        email,
+        weekly_digest_opt_in: weeklyDigestOptIn,
         notification_preferences: notificationPreferences,
       })
+
       const updated = response.data
       const savedPrefs: NotificationPreferences = {
         in_app: updated.notification_preferences?.in_app !== false,
         browser: updated.notification_preferences?.browser === true,
       }
-      setUsername(updated.username); setEmail(updated.email)
+      setUsername(updated.username)
+      setEmail(updated.email)
       setWeeklyDigestOptIn(!!updated.weekly_digest_opt_in)
-      setNotificationPreferences(savedPrefs); saveNotificationPreferences(savedPrefs)
-      setOriginalUsername(updated.username); setOriginalEmail(updated.email)
-      setOriginalOptIn(!!updated.weekly_digest_opt_in); setOriginalNotificationPreferences(savedPrefs)
-      saveConsentPreferences({ analytics: analyticsConsent, resumeRoast: resumeRoastConsent })
-      setOriginalAnalyticsConsent(analyticsConsent); setOriginalResumeRoastConsent(resumeRoastConsent)
+      setNotificationPreferences(savedPrefs)
+      saveNotificationPreferences(savedPrefs)
+      setOriginalUsername(updated.username)
+      setOriginalEmail(updated.email)
+      setOriginalOptIn(!!updated.weekly_digest_opt_in)
+      setOriginalNotificationPreferences(savedPrefs)
+
+      saveConsentPreferences({
+        analytics: analyticsConsent,
+        resumeRoast: resumeRoastConsent,
+      })
+      setOriginalAnalyticsConsent(analyticsConsent)
+      setOriginalResumeRoastConsent(resumeRoastConsent)
+
       updateProfileSession(updated.username)
       setSuccessMsg('Profile and notification preferences updated successfully!')
       setIsEditing(false)
     } catch (err: any) {
       if (err.response?.data) {
         const errors = err.response.data
-        if (errors.username) setError(Array.isArray(errors.username) ? errors.username[0] : errors.username)
-        else if (errors.email) setError(Array.isArray(errors.email) ? errors.email[0] : errors.email)
-        else setError(errors.error || 'Failed to update profile details.')
-      } else setError('An unexpected error occurred.')
-    } finally { setSaving(false) }
+        if (errors.username) {
+          setError(Array.isArray(errors.username) ? errors.username[0] : errors.username)
+        } else if (errors.email) {
+          setError(Array.isArray(errors.email) ? errors.email[0] : errors.email)
+        } else {
+          setError(errors.error || 'Failed to update profile details.')
+        }
+      } else {
+        setError('An unexpected error occurred.')
+      }
+    } finally {
+      setSaving(false)
+    }
   }
 
-  const preferenceCard = (id: string, label: string, description: string, defaultText: string, checked: boolean, onChange: (enabled: boolean) => void) => (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 16px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: 'rgba(255, 255, 255, 0.02)', gap: '16px' }}>
+  const preferenceCard = (
+    id: string,
+    label: string,
+    description: string,
+    defaultText: string,
+    checked: boolean,
+    onChange: (enabled: boolean) => void,
+  ) => (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: '14px 16px',
+      borderRadius: 'var(--radius-md)',
+      border: '1px solid var(--control-border)',
+      background: 'rgba(255, 255, 255, 0.02)',
+      gap: '16px',
+    }}>
       <div>
         <label htmlFor={id} style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)', display: 'block' }}>{label}</label>
         <span style={{ fontSize: '0.8rem', color: 'var(--muted-text)', display: 'block', marginTop: '3px' }}>{description}</span>
         <span style={{ fontSize: '0.75rem', color: 'var(--muted-text)', display: 'block', marginTop: '4px' }}>Default: {defaultText}</span>
       </div>
       <div className="form-check form-switch" style={{ margin: 0, paddingLeft: '2.5em', flexShrink: 0 }}>
-        <input id={id} className="form-check-input" type="checkbox" role="switch" checked={checked} onChange={(e) => onChange(e.target.checked)} disabled={!isEditing || saving} style={{ width: '2.2em', height: '1.2em', cursor: isEditing ? 'pointer' : 'not-allowed' }} />
+        <input
+          id={id}
+          className="form-check-input"
+          type="checkbox"
+          role="switch"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          disabled={!isEditing || saving}
+          style={{ width: '2.2em', height: '1.2em', cursor: isEditing ? 'pointer' : 'not-allowed' }}
+        />
       </div>
     </div>
   )
 
-  if (!user) return <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '60px 20px' }}><div className="analysis-card text-center" style={{ maxWidth: '400px', width: '100%', padding: '40px' }}><h2 style={{ color: 'var(--color-danger)', marginBottom: '16px' }}>Access Denied</h2><p style={{ color: 'var(--muted-text)', marginBottom: '24px' }}>Please log in to manage your account details.</p></div></div>
+  if (!user) {
+    return (
+      <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '60px 20px' }}>
+        <div className="analysis-card text-center" style={{ maxWidth: '400px', width: '100%', padding: '40px' }}>
+          <h2 style={{ color: 'var(--color-danger)', marginBottom: '16px' }}>Access Denied</h2>
+          <p style={{ color: 'var(--muted-text)', marginBottom: '24px' }}>Please log in to manage your account details.</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '40px 20px' }}>
       <div className="analysis-card" style={{ maxWidth: '700px', width: '100%', padding: '30px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px', borderBottom: '1px solid var(--surface-border)', paddingBottom: '16px' }}><span style={{ fontSize: '2rem' }}>👤</span><div><h1 style={{ fontSize: '1.5rem', fontWeight: '700', margin: 0, color: 'var(--heading-text)' }}>Account Profile</h1><p style={{ fontSize: '0.85rem', color: 'var(--muted-text)', margin: '4px 0 0' }}>Manage your account and notification preferences</p></div></div>
-        {loading ? <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '40px 0', gap: '12px' }}><div className="spinner" style={{ borderTopColor: 'var(--color-primary)' }} /><p style={{ color: 'var(--muted-text)' }}>Fetching profile information...</p></div> : (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px', borderBottom: '1px solid var(--surface-border)', paddingBottom: '16px' }}>
+          <span style={{ fontSize: '2rem' }}>👤</span>
+          <div>
+            <h1 style={{ fontSize: '1.5rem', fontWeight: '700', margin: 0, color: 'var(--heading-text)' }}>Account Profile</h1>
+            <p style={{ fontSize: '0.85rem', color: 'var(--muted-text)', margin: '4px 0 0 0' }}>Manage your account and notification preferences</p>
+          </div>
+        </div>
+
+        {loading ? (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '40px 0', gap: '12px' }}>
+            <div className="spinner" style={{ borderTopColor: 'var(--color-primary)' }} />
+            <p style={{ color: 'var(--muted-text)' }}>Fetching profile information...</p>
+          </div>
+        ) : (
           <form onSubmit={handleSave} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-            {error && <div style={{ background: 'rgba(239, 68, 68, 0.1)', border: '1px solid var(--color-danger)', color: 'var(--color-danger)', padding: '12px 16px', borderRadius: 'var(--radius-md)', fontSize: '0.9rem' }}>⚠️ {error}</div>}
-            {successMsg && <div style={{ background: 'rgba(34, 197, 94, 0.1)', border: '1px solid var(--color-accent)', color: 'var(--color-accent)', padding: '12px 16px', borderRadius: 'var(--radius-md)', fontSize: '0.9rem' }}>✅ {successMsg}</div>}
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}><label htmlFor="profile-username" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Username</label><input id="profile-username" name="username" type="text" autoComplete="username" value={username} onChange={(e) => setUsername(e.target.value)} disabled={!isEditing || saving} style={{ padding: '10px 14px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)', color: 'var(--control-text)', fontSize: '0.95rem' }} /></div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}><label htmlFor="profile-email" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Email Address</label><input id="profile-email" name="email" type="email" autoComplete="email" value={email} onChange={(e) => setEmail(e.target.value)} disabled={!isEditing || saving} style={{ padding: '10px 14px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)', color: 'var(--control-text)', fontSize: '0.95rem' }} /></div>
+            {error && (
+              <div style={{ background: 'rgba(239, 68, 68, 0.1)', border: '1px solid var(--color-danger)', color: 'var(--color-danger)', padding: '12px 16px', borderRadius: 'var(--radius-md)', fontSize: '0.9rem', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <span>⚠️</span><span>{error}</span>
+              </div>
+            )}
+            {successMsg && (
+              <div style={{ background: 'rgba(34, 197, 94, 0.1)', border: '1px solid var(--color-accent)', color: 'var(--color-accent)', padding: '12px 16px', borderRadius: 'var(--radius-md)', fontSize: '0.9rem', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <span>✅</span><span>{successMsg}</span>
+              </div>
+            )}
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              <label htmlFor="profile-username" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Username</label>
+              <input id="profile-username" name="username" type="text" autoComplete="username" value={username} onChange={(e) => setUsername(e.target.value)} disabled={!isEditing || saving} style={{ padding: '10px 14px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)', color: 'var(--control-text)', fontSize: '0.95rem', outline: 'none', transition: 'border-color 0.2s ease', cursor: isEditing ? 'text' : 'not-allowed' }} />
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              <label htmlFor="profile-email" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Email Address</label>
+              <input id="profile-email" name="email" type="email" autoComplete="email" value={email} onChange={(e) => setEmail(e.target.value)} disabled={!isEditing || saving} style={{ padding: '10px 14px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)', color: 'var(--control-text)', fontSize: '0.95rem', outline: 'none', transition: 'border-color 0.2s ease', cursor: isEditing ? 'text' : 'not-allowed' }} />
+            </div>
+
             <div style={{ borderTop: '1px solid var(--surface-border)', paddingTop: '20px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
-              <div><h2 style={{ fontSize: '1.1rem', margin: 0, color: 'var(--heading-text)' }}>🔔 Notification Preferences</h2><p style={{ fontSize: '0.8rem', color: 'var(--muted-text)', margin: '4px 0 0' }}>Manage all optional notification channels in one place. Changes are saved to your account.</p></div>
+              <div>
+                <h2 style={{ fontSize: '1.1rem', margin: 0, color: 'var(--heading-text)' }}>🔔 Notification Preferences</h2>
+                <p style={{ fontSize: '0.8rem', color: 'var(--muted-text)', margin: '4px 0 0' }}>Manage all optional notification channels in one place. Changes are saved to your account.</p>
+              </div>
               {preferenceCard('in-app-notifications-toggle', '🔔 In-app notifications', 'Show notification messages inside Resume Analyzer.', 'On (opt-out)', notificationPreferences.in_app, (enabled) => updateNotificationPreference('in_app', enabled))}
               {preferenceCard('browser-notifications-toggle', '🌐 Browser notifications', 'Show a native browser notification when analysis finishes in a background tab.', 'Off (opt-in)', notificationPreferences.browser, (enabled) => updateNotificationPreference('browser', enabled))}
               {preferenceCard('weekly-digest-toggle', '📧 Weekly Resume-Tips Email Digest', 'Receive actionable resume guidelines and score improvement nudges once a week.', 'Off (opt-in)', weeklyDigestOptIn, setWeeklyDigestOptIn)}
             </div>
-            {preferenceCard('profile-analytics-toggle', '📊 Analytics & Performance Telemetry', 'Allow anonymous usage telemetry to diagnose issues and optimize ATS parsing accuracy.', 'Off (opt-in)', analyticsConsent, setAnalyticsConsentState)}
-            {preferenceCard('profile-roast-toggle', '🔥 AI Resume Roast Feedback Consent', 'Opt in to allow processing alternate humorous and spicy feedback tone suggestions.', 'Off (opt-in)', resumeRoastConsent, setResumeRoastConsentState)}
+
+            {/* Optional Data Collection: Analytics (#536) */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: 'rgba(255, 255, 255, 0.02)' }}>
+              <div>
+                <label htmlFor="profile-analytics-toggle" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)', display: 'block' }}>📊 Analytics & Performance Telemetry</label>
+                <span style={{ fontSize: '0.8rem', color: 'var(--muted-text)', display: 'block', marginTop: '2px' }}>Allow anonymous usage telemetry to diagnose issues and optimize ATS parsing accuracy (Off by default).</span>
+              </div>
+              <div className="form-check form-switch" style={{ margin: 0, paddingLeft: '2.5em' }}>
+                <input id="profile-analytics-toggle" className="form-check-input" type="checkbox" role="switch" checked={analyticsConsent} onChange={(e) => setAnalyticsConsentState(e.target.checked)} disabled={!isEditing || saving} style={{ width: '2.2em', height: '1.2em', cursor: isEditing ? 'pointer' : 'not-allowed' }} />
+              </div>
+            </div>
+
+            {/* Optional Data Collection: Resume Roast (#536) */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: 'rgba(255, 255, 255, 0.02)' }}>
+              <div>
+                <label htmlFor="profile-roast-toggle" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)', display: 'block' }}>🔥 AI Resume Roast Feedback Consent</label>
+                <span style={{ fontSize: '0.8rem', color: 'var(--muted-text)', display: 'block', marginTop: '2px' }}>Opt in to allow processing alternate humorous and spicy feedback tone suggestions (Off by default).</span>
+              </div>
+              <div className="form-check form-switch" style={{ margin: 0, paddingLeft: '2.5em' }}>
+                <input id="profile-roast-toggle" className="form-check-input" type="checkbox" role="switch" checked={resumeRoastConsent} onChange={(e) => setResumeRoastConsentState(e.target.checked)} disabled={!isEditing || saving} style={{ width: '2.2em', height: '1.2em', cursor: isEditing ? 'pointer' : 'not-allowed' }} />
+              </div>
+            </div>
+
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', marginTop: '10px', borderTop: '1px solid var(--surface-border)', paddingTop: '20px' }}>
-              <button type="button" className="app-btn app-btn--secondary" onClick={handleExportData} disabled={exporting || saving} style={{ minWidth: '140px' }}>{exporting ? 'Exporting...' : 'Export My Data'}</button>
-              {!isEditing ? <button type="button" className="app-btn app-btn--primary" onClick={() => { setIsEditing(true); setSuccessMsg(null) }} style={{ minWidth: '100px' }}>✏️ Edit Profile</button> : <><button type="button" className="app-btn app-btn--secondary" onClick={handleCancel} disabled={saving} style={{ minWidth: '100px' }}>Cancel</button><button type="submit" className="app-btn app-btn--primary" disabled={saving} style={{ minWidth: '100px' }}>{saving ? 'Saving...' : 'Save Changes'}</button></>}
+              <button type="button" className="app-btn app-btn--secondary" onClick={handleExportData} disabled={exporting || saving} style={{ minWidth: '140px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}>
+                {exporting ? <><span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" style={{ width: '1rem', height: '1rem' }} />Exporting...</> : 'Export My Data'}
+              </button>
+              {!isEditing ? (
+                <button type="button" className="app-btn app-btn--primary" onClick={() => { setIsEditing(true); setSuccessMsg(null) }} style={{ minWidth: '100px' }}>✏️ Edit Profile</button>
+              ) : (
+                <>
+                  <button type="button" className="app-btn app-btn--secondary" onClick={handleCancel} disabled={saving} style={{ minWidth: '100px' }}>Cancel</button>
+                  <button type="submit" className="app-btn app-btn--primary" disabled={saving} style={{ minWidth: '100px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}>
+                    {saving ? <><span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" style={{ width: '1rem', height: '1rem' }} />Saving...</> : 'Save Changes'}
+                  </button>
+                </>
+              )}
             </div>
           </form>
         )}

--- a/frontend/src/components/ProfilePage.tsx
+++ b/frontend/src/components/ProfilePage.tsx
@@ -2,17 +2,10 @@ import React, { useEffect, useState } from 'react'
 import { api } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { getConsentPreferences, saveConsentPreferences } from '../utils/cookieConsent'
-import { requestNotificationPermission } from '../utils/notification'
+import { requestNotificationPermission, saveNotificationPreferences } from '../utils/notification'
 
-type NotificationPreferences = {
-  in_app: boolean
-  browser: boolean
-}
-
-const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
-  in_app: true,
-  browser: false,
-}
+type NotificationPreferences = { in_app: boolean; browser: boolean }
+const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = { in_app: true, browser: false }
 
 export const ProfilePage: React.FC = () => {
   const { user, updateProfileSession, exportUserData } = useAuth()
@@ -43,7 +36,7 @@ export const ProfilePage: React.FC = () => {
         setError(null)
         const response = await api.get('/api/profile/')
         const data = response.data
-        const prefs = {
+        const prefs: NotificationPreferences = {
           in_app: data.notification_preferences?.in_app !== false,
           browser: data.notification_preferences?.browser === true,
         }
@@ -51,6 +44,7 @@ export const ProfilePage: React.FC = () => {
         setEmail(data.email || '')
         setWeeklyDigestOptIn(!!data.weekly_digest_opt_in)
         setNotificationPreferences(prefs)
+        saveNotificationPreferences(prefs)
         setOriginalUsername(data.username)
         setOriginalEmail(data.email || '')
         setOriginalOptIn(!!data.weekly_digest_opt_in)
@@ -74,6 +68,7 @@ export const ProfilePage: React.FC = () => {
     setEmail(originalEmail)
     setWeeklyDigestOptIn(originalOptIn)
     setNotificationPreferences(originalNotificationPreferences)
+    saveNotificationPreferences(originalNotificationPreferences)
     setAnalyticsConsentState(originalAnalyticsConsent)
     setResumeRoastConsentState(originalResumeRoastConsent)
     setIsEditing(false)
@@ -83,16 +78,12 @@ export const ProfilePage: React.FC = () => {
 
   const handleExportData = async () => {
     try {
-      setExporting(true)
-      setError(null)
-      setSuccessMsg(null)
+      setExporting(true); setError(null); setSuccessMsg(null)
       await exportUserData()
       setSuccessMsg('Your account data has been downloaded successfully.')
     } catch (err: any) {
       setError(err.response?.data?.error || err.message || 'Failed to export your data.')
-    } finally {
-      setExporting(false)
-    }
+    } finally { setExporting(false) }
   }
 
   const updateNotificationPreference = async (channel: keyof NotificationPreferences, enabled: boolean) => {
@@ -112,46 +103,28 @@ export const ProfilePage: React.FC = () => {
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!user) return
-    if (!username.trim()) {
-      setError('Username cannot be empty.')
-      return
-    }
-    if (!email.trim()) {
-      setError('Email cannot be empty.')
-      return
-    }
+    if (!username.trim()) { setError('Username cannot be empty.'); return }
+    if (!email.trim()) { setError('Email cannot be empty.'); return }
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    if (!emailRegex.test(email)) {
-      setError('Please provide a valid email address.')
-      return
-    }
-
+    if (!emailRegex.test(email)) { setError('Please provide a valid email address.'); return }
     try {
-      setSaving(true)
-      setError(null)
-      setSuccessMsg(null)
+      setSaving(true); setError(null); setSuccessMsg(null)
       const response = await api.put('/api/profile/', {
-        username,
-        email,
-        weekly_digest_opt_in: weeklyDigestOptIn,
+        username, email, weekly_digest_opt_in: weeklyDigestOptIn,
         notification_preferences: notificationPreferences,
       })
       const updated = response.data
-      const savedPrefs = {
+      const savedPrefs: NotificationPreferences = {
         in_app: updated.notification_preferences?.in_app !== false,
         browser: updated.notification_preferences?.browser === true,
       }
-      setUsername(updated.username)
-      setEmail(updated.email)
+      setUsername(updated.username); setEmail(updated.email)
       setWeeklyDigestOptIn(!!updated.weekly_digest_opt_in)
-      setNotificationPreferences(savedPrefs)
-      setOriginalUsername(updated.username)
-      setOriginalEmail(updated.email)
-      setOriginalOptIn(!!updated.weekly_digest_opt_in)
-      setOriginalNotificationPreferences(savedPrefs)
+      setNotificationPreferences(savedPrefs); saveNotificationPreferences(savedPrefs)
+      setOriginalUsername(updated.username); setOriginalEmail(updated.email)
+      setOriginalOptIn(!!updated.weekly_digest_opt_in); setOriginalNotificationPreferences(savedPrefs)
       saveConsentPreferences({ analytics: analyticsConsent, resumeRoast: resumeRoastConsent })
-      setOriginalAnalyticsConsent(analyticsConsent)
-      setOriginalResumeRoastConsent(resumeRoastConsent)
+      setOriginalAnalyticsConsent(analyticsConsent); setOriginalResumeRoastConsent(resumeRoastConsent)
       updateProfileSession(updated.username)
       setSuccessMsg('Profile and notification preferences updated successfully!')
       setIsEditing(false)
@@ -161,22 +134,11 @@ export const ProfilePage: React.FC = () => {
         if (errors.username) setError(Array.isArray(errors.username) ? errors.username[0] : errors.username)
         else if (errors.email) setError(Array.isArray(errors.email) ? errors.email[0] : errors.email)
         else setError(errors.error || 'Failed to update profile details.')
-      } else {
-        setError('An unexpected error occurred.')
-      }
-    } finally {
-      setSaving(false)
-    }
+      } else setError('An unexpected error occurred.')
+    } finally { setSaving(false) }
   }
 
-  const preferenceCard = (
-    id: string,
-    label: string,
-    description: string,
-    defaultText: string,
-    checked: boolean,
-    onChange: (enabled: boolean) => void,
-  ) => (
+  const preferenceCard = (id: string, label: string, description: string, defaultText: string, checked: boolean, onChange: (enabled: boolean) => void) => (
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 16px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: 'rgba(255, 255, 255, 0.02)', gap: '16px' }}>
       <div>
         <label htmlFor={id} style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)', display: 'block' }}>{label}</label>
@@ -189,34 +151,26 @@ export const ProfilePage: React.FC = () => {
     </div>
   )
 
-  if (!user) {
-    return <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '60px 20px' }}><div className="analysis-card text-center" style={{ maxWidth: '400px', width: '100%', padding: '40px' }}><h2 style={{ color: 'var(--color-danger)', marginBottom: '16px' }}>Access Denied</h2><p style={{ color: 'var(--muted-text)', marginBottom: '24px' }}>Please log in to manage your account details.</p></div></div>
-  }
+  if (!user) return <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '60px 20px' }}><div className="analysis-card text-center" style={{ maxWidth: '400px', width: '100%', padding: '40px' }}><h2 style={{ color: 'var(--color-danger)', marginBottom: '16px' }}>Access Denied</h2><p style={{ color: 'var(--muted-text)', marginBottom: '24px' }}>Please log in to manage your account details.</p></div></div>
 
   return (
     <div className="app-container" style={{ display: 'flex', justifyContent: 'center', padding: '40px 20px' }}>
       <div className="analysis-card" style={{ maxWidth: '700px', width: '100%', padding: '30px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px', borderBottom: '1px solid var(--surface-border)', paddingBottom: '16px' }}>
-          <span style={{ fontSize: '2rem' }}>👤</span>
-          <div><h1 style={{ fontSize: '1.5rem', fontWeight: '700', margin: 0, color: 'var(--heading-text)' }}>Account Profile</h1><p style={{ fontSize: '0.85rem', color: 'var(--muted-text)', margin: '4px 0 0' }}>Manage your account and notification preferences</p></div>
-        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '24px', borderBottom: '1px solid var(--surface-border)', paddingBottom: '16px' }}><span style={{ fontSize: '2rem' }}>👤</span><div><h1 style={{ fontSize: '1.5rem', fontWeight: '700', margin: 0, color: 'var(--heading-text)' }}>Account Profile</h1><p style={{ fontSize: '0.85rem', color: 'var(--muted-text)', margin: '4px 0 0' }}>Manage your account and notification preferences</p></div></div>
         {loading ? <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '40px 0', gap: '12px' }}><div className="spinner" style={{ borderTopColor: 'var(--color-primary)' }} /><p style={{ color: 'var(--muted-text)' }}>Fetching profile information...</p></div> : (
           <form onSubmit={handleSave} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             {error && <div style={{ background: 'rgba(239, 68, 68, 0.1)', border: '1px solid var(--color-danger)', color: 'var(--color-danger)', padding: '12px 16px', borderRadius: 'var(--radius-md)', fontSize: '0.9rem' }}>⚠️ {error}</div>}
             {successMsg && <div style={{ background: 'rgba(34, 197, 94, 0.1)', border: '1px solid var(--color-accent)', color: 'var(--color-accent)', padding: '12px 16px', borderRadius: 'var(--radius-md)', fontSize: '0.9rem' }}>✅ {successMsg}</div>}
             <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}><label htmlFor="profile-username" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Username</label><input id="profile-username" name="username" type="text" autoComplete="username" value={username} onChange={(e) => setUsername(e.target.value)} disabled={!isEditing || saving} style={{ padding: '10px 14px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)', color: 'var(--control-text)', fontSize: '0.95rem' }} /></div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}><label htmlFor="profile-email" style={{ fontSize: '0.9rem', fontWeight: '600', color: 'var(--heading-text)' }}>Email Address</label><input id="profile-email" name="email" type="email" autoComplete="email" value={email} onChange={(e) => setEmail(e.target.value)} disabled={!isEditing || saving} style={{ padding: '10px 14px', borderRadius: 'var(--radius-md)', border: '1px solid var(--control-border)', background: isEditing ? 'var(--control-bg)' : 'var(--upload-bg)', color: 'var(--control-text)', fontSize: '0.95rem' }} /></div>
-
             <div style={{ borderTop: '1px solid var(--surface-border)', paddingTop: '20px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
               <div><h2 style={{ fontSize: '1.1rem', margin: 0, color: 'var(--heading-text)' }}>🔔 Notification Preferences</h2><p style={{ fontSize: '0.8rem', color: 'var(--muted-text)', margin: '4px 0 0' }}>Manage all optional notification channels in one place. Changes are saved to your account.</p></div>
               {preferenceCard('in-app-notifications-toggle', '🔔 In-app notifications', 'Show notification messages inside Resume Analyzer.', 'On (opt-out)', notificationPreferences.in_app, (enabled) => updateNotificationPreference('in_app', enabled))}
               {preferenceCard('browser-notifications-toggle', '🌐 Browser notifications', 'Show a native browser notification when analysis finishes in a background tab.', 'Off (opt-in)', notificationPreferences.browser, (enabled) => updateNotificationPreference('browser', enabled))}
               {preferenceCard('weekly-digest-toggle', '📧 Weekly Resume-Tips Email Digest', 'Receive actionable resume guidelines and score improvement nudges once a week.', 'Off (opt-in)', weeklyDigestOptIn, setWeeklyDigestOptIn)}
             </div>
-
             {preferenceCard('profile-analytics-toggle', '📊 Analytics & Performance Telemetry', 'Allow anonymous usage telemetry to diagnose issues and optimize ATS parsing accuracy.', 'Off (opt-in)', analyticsConsent, setAnalyticsConsentState)}
             {preferenceCard('profile-roast-toggle', '🔥 AI Resume Roast Feedback Consent', 'Opt in to allow processing alternate humorous and spicy feedback tone suggestions.', 'Off (opt-in)', resumeRoastConsent, setResumeRoastConsentState)}
-
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', marginTop: '10px', borderTop: '1px solid var(--surface-border)', paddingTop: '20px' }}>
               <button type="button" className="app-btn app-btn--secondary" onClick={handleExportData} disabled={exporting || saving} style={{ minWidth: '140px' }}>{exporting ? 'Exporting...' : 'Export My Data'}</button>
               {!isEditing ? <button type="button" className="app-btn app-btn--primary" onClick={() => { setIsEditing(true); setSuccessMsg(null) }} style={{ minWidth: '100px' }}>✏️ Edit Profile</button> : <><button type="button" className="app-btn app-btn--secondary" onClick={handleCancel} disabled={saving} style={{ minWidth: '100px' }}>Cancel</button><button type="submit" className="app-btn app-btn--primary" disabled={saving} style={{ minWidth: '100px' }}>{saving ? 'Saving...' : 'Save Changes'}</button></>}

--- a/frontend/src/hooks/useAnalysisHistory.ts
+++ b/frontend/src/hooks/useAnalysisHistory.ts
@@ -27,7 +27,6 @@ export interface AnalysisEntry {
 
 const STORAGE_KEY = 'resume_analysis_history'
 const LAST_VIEWED_KEY = 'resume_analysis_last_viewed'
-const NOTIFICATION_PREFERENCES_STORAGE_KEY = 'resume_notification_preferences'
 
 function loadHistory(): AnalysisEntry[] {
   try {
@@ -36,11 +35,17 @@ function loadHistory(): AnalysisEntry[] {
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
     return parsed
-  } catch { return [] }
+  } catch {
+    return []
+  }
 }
 
 function saveHistory(entries: AnalysisEntry[]): void {
-  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(entries)) } catch { /* storage unavailable */ }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+  } catch {
+    // localStorage may be unavailable in restricted modes
+  }
 }
 
 function loadLastViewed(): number {
@@ -49,33 +54,27 @@ function loadLastViewed(): number {
     if (!raw) return 0
     const val = Number(raw)
     return isNaN(val) ? 0 : val
-  } catch { return 0 }
+  } catch {
+    return 0
+  }
 }
 
 function saveLastViewed(ts: number): void {
-  try { localStorage.setItem(LAST_VIEWED_KEY, ts.toString()) } catch { /* storage unavailable */ }
-}
-
-function loadInAppPreference(): boolean {
   try {
-    const raw = localStorage.getItem(NOTIFICATION_PREFERENCES_STORAGE_KEY)
-    if (!raw) return true
-    return JSON.parse(raw)?.in_app !== false
-  } catch { return true }
+    localStorage.setItem(LAST_VIEWED_KEY, ts.toString())
+  } catch {
+    // localStorage may be unavailable
+  }
 }
 
 export function useAnalysisHistory() {
   const [entries, setEntries] = useState<AnalysisEntry[]>(() => loadHistory())
   const [lastViewedTimestamp, setLastViewedTimestamp] = useState<number>(() => loadLastViewed())
-  const [inAppNotificationsEnabled, setInAppNotificationsEnabled] = useState<boolean>(() => loadInAppPreference())
 
-  useEffect(() => { saveHistory(entries) }, [entries])
-
+  // Sync to localStorage whenever entries change
   useEffect(() => {
-    const syncPreference = () => setInAppNotificationsEnabled(loadInAppPreference())
-    window.addEventListener('notification-preferences-changed', syncPreference)
-    return () => window.removeEventListener('notification-preferences-changed', syncPreference)
-  }, [])
+    saveHistory(entries)
+  }, [entries])
 
   const markAllAsViewed = useCallback(() => {
     const now = Date.now()
@@ -83,19 +82,31 @@ export function useAnalysisHistory() {
     saveLastViewed(now)
   }, [])
 
-  const unreadCount = inAppNotificationsEnabled
-    ? entries.filter((entry) => entry.timestamp > lastViewedTimestamp).length
-    : 0
+  const unreadCount = entries.filter((entry) => entry.timestamp > lastViewedTimestamp).length
 
   const addEntry = useCallback((entry: Omit<AnalysisEntry, 'id' | 'timestamp'>) => {
     setEntries((prev) => {
       const filteredEntries = prev.filter((e) => e.fileName !== entry.fileName)
-      return [{ ...entry, id: Date.now().toString(), timestamp: Date.now() }, ...filteredEntries]
+
+      const updated: AnalysisEntry[] = [
+        {
+          ...entry,
+          id: Date.now().toString(),
+          timestamp: Date.now(),
+        },
+        ...filteredEntries,
+      ]
+      return updated
     })
   }, [])
 
-  const deleteEntry = (id: string) => setEntries((prev) => prev.filter((e) => e.id !== id))
-  const clearHistory = () => setEntries([])
+  const deleteEntry = (id: string) => {
+    setEntries((prev) => prev.filter((e) => e.id !== id))
+  }
+
+  const clearHistory = () => {
+    setEntries([])
+  }
 
   return {
     entries,

--- a/frontend/src/hooks/useAnalysisHistory.ts
+++ b/frontend/src/hooks/useAnalysisHistory.ts
@@ -27,6 +27,7 @@ export interface AnalysisEntry {
 
 const STORAGE_KEY = 'resume_analysis_history'
 const LAST_VIEWED_KEY = 'resume_analysis_last_viewed'
+const NOTIFICATION_PREFERENCES_STORAGE_KEY = 'resume_notification_preferences'
 
 function loadHistory(): AnalysisEntry[] {
   try {
@@ -35,17 +36,11 @@ function loadHistory(): AnalysisEntry[] {
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
     return parsed
-  } catch {
-    return []
-  }
+  } catch { return [] }
 }
 
 function saveHistory(entries: AnalysisEntry[]): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
-  } catch {
-    // localStorage may be unavailable in restricted modes
-  }
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(entries)) } catch { /* storage unavailable */ }
 }
 
 function loadLastViewed(): number {
@@ -54,27 +49,33 @@ function loadLastViewed(): number {
     if (!raw) return 0
     const val = Number(raw)
     return isNaN(val) ? 0 : val
-  } catch {
-    return 0
-  }
+  } catch { return 0 }
 }
 
 function saveLastViewed(ts: number): void {
+  try { localStorage.setItem(LAST_VIEWED_KEY, ts.toString()) } catch { /* storage unavailable */ }
+}
+
+function loadInAppPreference(): boolean {
   try {
-    localStorage.setItem(LAST_VIEWED_KEY, ts.toString())
-  } catch {
-    // localStorage may be unavailable
-  }
+    const raw = localStorage.getItem(NOTIFICATION_PREFERENCES_STORAGE_KEY)
+    if (!raw) return true
+    return JSON.parse(raw)?.in_app !== false
+  } catch { return true }
 }
 
 export function useAnalysisHistory() {
   const [entries, setEntries] = useState<AnalysisEntry[]>(() => loadHistory())
   const [lastViewedTimestamp, setLastViewedTimestamp] = useState<number>(() => loadLastViewed())
+  const [inAppNotificationsEnabled, setInAppNotificationsEnabled] = useState<boolean>(() => loadInAppPreference())
 
-  // Sync to localStorage whenever entries change
+  useEffect(() => { saveHistory(entries) }, [entries])
+
   useEffect(() => {
-    saveHistory(entries)
-  }, [entries])
+    const syncPreference = () => setInAppNotificationsEnabled(loadInAppPreference())
+    window.addEventListener('notification-preferences-changed', syncPreference)
+    return () => window.removeEventListener('notification-preferences-changed', syncPreference)
+  }, [])
 
   const markAllAsViewed = useCallback(() => {
     const now = Date.now()
@@ -82,31 +83,19 @@ export function useAnalysisHistory() {
     saveLastViewed(now)
   }, [])
 
-  const unreadCount = entries.filter((entry) => entry.timestamp > lastViewedTimestamp).length
+  const unreadCount = inAppNotificationsEnabled
+    ? entries.filter((entry) => entry.timestamp > lastViewedTimestamp).length
+    : 0
 
   const addEntry = useCallback((entry: Omit<AnalysisEntry, 'id' | 'timestamp'>) => {
     setEntries((prev) => {
       const filteredEntries = prev.filter((e) => e.fileName !== entry.fileName)
-
-      const updated: AnalysisEntry[] = [
-        {
-          ...entry,
-          id: Date.now().toString(),
-          timestamp: Date.now(),
-        },
-        ...filteredEntries,
-      ]
-      return updated
+      return [{ ...entry, id: Date.now().toString(), timestamp: Date.now() }, ...filteredEntries]
     })
   }, [])
 
-  const deleteEntry = (id: string) => {
-    setEntries((prev) => prev.filter((e) => e.id !== id))
-  }
-
-  const clearHistory = () => {
-    setEntries([])
-  }
+  const deleteEntry = (id: string) => setEntries((prev) => prev.filter((e) => e.id !== id))
+  const clearHistory = () => setEntries([])
 
   return {
     entries,

--- a/frontend/src/utils/notification.test.ts
+++ b/frontend/src/utils/notification.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  getNotificationPreferences,
+  saveNotificationPreferences,
+  sendAnalysisCompleteNotification,
+} from './notification'
+
+describe('notification preferences', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true })
+  })
+
+  it('uses opt-in browser notifications and opt-out in-app defaults', () => {
+    expect(getNotificationPreferences()).toEqual(DEFAULT_NOTIFICATION_PREFERENCES)
+  })
+
+  it('persists preferences locally and emits a synchronization event', () => {
+    const listener = vi.fn()
+    window.addEventListener('notification-preferences-changed', listener)
+    saveNotificationPreferences({ in_app: false, browser: true })
+
+    expect(getNotificationPreferences()).toEqual({ in_app: false, browser: true })
+    expect(listener).toHaveBeenCalledTimes(1)
+    window.removeEventListener('notification-preferences-changed', listener)
+  })
+
+  it('does not create a browser notification when the preference is off', () => {
+    saveNotificationPreferences({ in_app: true, browser: false })
+    const notification = vi.fn()
+    vi.stubGlobal('Notification', Object.assign(notification, { permission: 'granted' }))
+
+    sendAnalysisCompleteNotification('resume.pdf')
+
+    expect(notification).not.toHaveBeenCalled()
+  })
+
+  it('creates a browser notification when opted in and permission is granted', () => {
+    saveNotificationPreferences({ in_app: true, browser: true })
+    const notification = vi.fn()
+    vi.stubGlobal('Notification', Object.assign(notification, { permission: 'granted' }))
+
+    sendAnalysisCompleteNotification('resume.pdf')
+
+    expect(notification).toHaveBeenCalledWith(
+      'Resume Analysis Complete 🚀',
+      expect.objectContaining({ body: expect.stringContaining('resume.pdf') }),
+    )
+  })
+})

--- a/frontend/src/utils/notification.test.ts
+++ b/frontend/src/utils/notification.test.ts
@@ -1,12 +1,7 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  DEFAULT_NOTIFICATION_PREFERENCES,
-  getNotificationPreferences,
-  saveNotificationPreferences,
-  sendAnalysisCompleteNotification,
-} from './notification'
+import { DEFAULT_NOTIFICATION_PREFERENCES, getNotificationPreferences, saveNotificationPreferences, sendAnalysisCompleteNotification } from './notification'
 
 describe('notification preferences', () => {
   beforeEach(() => {
@@ -23,7 +18,6 @@ describe('notification preferences', () => {
     const listener = vi.fn()
     window.addEventListener('notification-preferences-changed', listener)
     saveNotificationPreferences({ in_app: false, browser: true })
-
     expect(getNotificationPreferences()).toEqual({ in_app: false, browser: true })
     expect(listener).toHaveBeenCalledTimes(1)
     window.removeEventListener('notification-preferences-changed', listener)
@@ -31,22 +25,20 @@ describe('notification preferences', () => {
 
   it('does not create a browser notification when the preference is off', () => {
     saveNotificationPreferences({ in_app: true, browser: false })
-    const notification = vi.fn()
-    vi.stubGlobal('Notification', Object.assign(notification, { permission: 'granted' }))
-
+    const NotificationMock = vi.fn()
+    Object.assign(NotificationMock, { permission: 'granted' })
+    vi.stubGlobal('Notification', NotificationMock)
     sendAnalysisCompleteNotification('resume.pdf')
-
-    expect(notification).not.toHaveBeenCalled()
+    expect(NotificationMock).not.toHaveBeenCalled()
   })
 
   it('creates a browser notification when opted in and permission is granted', () => {
     saveNotificationPreferences({ in_app: true, browser: true })
-    const notification = vi.fn()
-    vi.stubGlobal('Notification', Object.assign(notification, { permission: 'granted' }))
-
+    const NotificationMock = vi.fn().mockImplementation(() => ({ close: vi.fn(), onclick: null }))
+    Object.assign(NotificationMock, { permission: 'granted' })
+    vi.stubGlobal('Notification', NotificationMock)
     sendAnalysisCompleteNotification('resume.pdf')
-
-    expect(notification).toHaveBeenCalledWith(
+    expect(NotificationMock).toHaveBeenCalledWith(
       'Resume Analysis Complete 🚀',
       expect.objectContaining({ body: expect.stringContaining('resume.pdf') }),
     )

--- a/frontend/src/utils/notification.ts
+++ b/frontend/src/utils/notification.ts
@@ -1,17 +1,49 @@
 /**
- * Utility functions for Web Notifications API and Page Visibility API integration.
+ * Utility functions for the Web Notifications API and Page Visibility API.
+ *
+ * The user's browser-notification preference is persisted by the profile API
+ * and mirrored in localStorage so this utility can make a synchronous decision
+ * when an analysis completes without performing an API request in the hot path.
  */
 
-/**
- * Requests notification permission if the browser supports notifications
- * and permission has not already been granted or denied.
- * Called on user action (e.g. clicking analyze/sample button) to ensure gesture context.
- */
-export const requestNotificationPermission = async (): Promise<NotificationPermission | null> => {
-  if (typeof window === 'undefined' || !('Notification' in window)) {
-    return null
+export const NOTIFICATION_PREFERENCES_STORAGE_KEY = 'resume_notification_preferences'
+
+export type NotificationPreferences = {
+  in_app: boolean
+  browser: boolean
+}
+
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  in_app: true,
+  browser: false,
+}
+
+export const getNotificationPreferences = (): NotificationPreferences => {
+  try {
+    const raw = localStorage.getItem(NOTIFICATION_PREFERENCES_STORAGE_KEY)
+    if (!raw) return DEFAULT_NOTIFICATION_PREFERENCES
+    const parsed = JSON.parse(raw)
+    return {
+      in_app: parsed?.in_app !== false,
+      browser: parsed?.browser === true,
+    }
+  } catch {
+    return DEFAULT_NOTIFICATION_PREFERENCES
   }
+}
 
+export const saveNotificationPreferences = (preferences: NotificationPreferences): void => {
+  try {
+    localStorage.setItem(NOTIFICATION_PREFERENCES_STORAGE_KEY, JSON.stringify(preferences))
+    window.dispatchEvent(new Event('notification-preferences-changed'))
+  } catch {
+    // localStorage may be unavailable in restricted modes.
+  }
+}
+
+/** Requests notification permission after an explicit user action. */
+export const requestNotificationPermission = async (): Promise<NotificationPermission | null> => {
+  if (typeof window === 'undefined' || !('Notification' in window)) return null
   if (Notification.permission === 'default') {
     try {
       return await Notification.requestPermission()
@@ -19,18 +51,13 @@ export const requestNotificationPermission = async (): Promise<NotificationPermi
       return Notification.permission
     }
   }
-
   return Notification.permission
 }
 
-/**
- * Fires a native browser notification if the current tab is unfocused/hidden
- * and notification permission has been granted.
- */
+/** Fires only when the user has opted in, permission is granted, and the tab is hidden. */
 export const sendAnalysisCompleteNotification = (fileName?: string): void => {
-  if (typeof window === 'undefined' || !('Notification' in window)) {
-    return
-  }
+  if (getNotificationPreferences().browser === false) return
+  if (typeof window === 'undefined' || !('Notification' in window)) return
 
   if (Notification.permission === 'granted' && document.hidden) {
     const title = 'Resume Analysis Complete 🚀'


### PR DESCRIPTION
## 📝 Description

Implements #607 by adding a unified Notification Preferences section where users can manage all available notification channels from one place.

### ✨ Changes

- Added a unified Notification Preferences section to the Profile/Settings page
- Added individual toggles for:
  - In-app notifications
  - Browser native notifications
  - Weekly email digest
- Added persistent notification preference storage to `UserProfile`
- Updated the profile API/serializer to read and save notification preferences
- Updated browser notifications to respect the user's browser notification preference
- Updated in-app notification behavior to respect the user's preference
- Kept analysis history independent from notification preferences
- Added browser notification permission handling
- Added clear default states for every notification type
- Added backend and frontend tests covering notification preferences and persistence

### 🔔 Default States

| Notification Type | Default | Behavior |
|---|---|---|
| In-app notifications | ON | Opt-out |
| Browser notifications | OFF | Opt-in |
| Weekly email digest | OFF | Opt-in |

### 🧪 Testing

- Added backend tests for notification preference defaults and persistence
- Added frontend tests for preference handling
- Added browser notification tests for enabled/disabled states
- Verified existing weekly digest opt-in behavior remains intact
- Verified notification preferences persist after saving and reloading

### 📋 Acceptance Criteria

- [x] Single preferences page listing all notification types
- [x] Individual toggles for each notification type
- [x] Preferences persist between sessions
- [x] Each notification feature respects its corresponding preference
- [x] Default opt-in/opt-out state is clearly documented

### 🔗 Related Issue

Closes #607