### PR TITLE
fix: rejoin the migration graph so the backend suite can run again (#826)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,10 +49,27 @@ jobs:
       - name: Django system checks
         run: python manage.py check
 
+      - name: Fail if the migration graph has more than one leaf
+        # Two branches each added a migration on top of 0019 and both merged.
+        # Django then refuses to build a plan at all, so `manage.py test` exits
+        # non-zero *before collecting a single test* — the run below printed
+        # "Found 359 test(s)" and then a CommandError, which reads like a test
+        # failure and is not one.
+        #
+        # This runs first, and runs only the SimpleTestCase module, because
+        # that needs no test database. Creating the test database is the step
+        # that explodes when the graph is broken, so a check which depends on
+        # it can never be the check that explains it.
+        run: python manage.py test analyzer.tests_migration_graph --verbosity 2
+
       - name: Fail if a model change has no migration
         # `Webhook` was added to models.py with no migration and went unnoticed
         # until it started breaking unrelated tests. This makes that a build
         # failure at the point the model changes instead.
+        #
+        # Ordered after the leaf check deliberately: with two leaves this
+        # command raises the conflict error instead of reporting a missing
+        # migration, so on its own it points at the wrong problem.
         run: python manage.py makemigrations --check --dry-run
 
       - name: Run tests

--- a/backend/analyzer/migrations/0021_merge_resumebadge_and_jd_match_fields.py
+++ b/backend/analyzer/migrations/0021_merge_resumebadge_and_jd_match_fields.py
@@ -1,0 +1,29 @@
+"""Rejoin the migration graph after two 0020 leaves were merged in parallel.
+
+``0020_resumebadge`` (the score badge, #611) and ``0020_merge_20260824_0025``
+(the JD match fields) were both written against ``0019_batchupload`` and merged
+within a day of each other. Neither is aware of the other, so the analyzer app
+ended up with two leaf nodes.
+
+Django refuses to build a migration plan at all in that state, which meant
+``manage.py migrate``, ``manage.py test`` and every ``manage.py`` command that
+touches the loader failed on ``main`` with:
+
+    CommandError: Conflicting migrations detected; multiple leaf nodes in the
+    migration graph: (0020_merge_20260824_0025, 0020_resumebadge in analyzer).
+
+This migration has no operations. Its only job is to depend on both leaves so
+there is a single tip again. It is what ``makemigrations --merge`` generates.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("analyzer", "0020_merge_20260824_0025"),
+        ("analyzer", "0020_resumebadge"),
+    ]
+
+    operations = []

--- a/backend/analyzer/tests_migration_graph.py
+++ b/backend/analyzer/tests_migration_graph.py
@@ -1,0 +1,164 @@
+"""The migration graph must stay buildable.
+
+Two parallel pull requests each added a ``0020_*`` migration on top of
+``0019_batchupload``. Neither branch knew about the other, so ``main`` ended up
+with two leaf nodes and Django refused to build a plan at all::
+
+    CommandError: Conflicting migrations detected; multiple leaf nodes in the
+    migration graph: (0020_merge_20260824_0025, 0020_resumebadge in analyzer).
+
+That is not a test failure — it is raised before a single test is collected, so
+``manage.py test`` exited non-zero having run nothing, and every ``manage.py``
+command that touches the loader (``migrate``, ``showmigrations``,
+``makemigrations --check``) failed the same way.
+
+A red build that runs zero assertions looks very different from a red build
+with a failing assertion, and it stayed on ``main`` for a day because nothing
+distinguished the two. These tests make the graph itself an assertion, so the
+next time two branches collide the failure names the cause.
+
+They deliberately use ``MigrationLoader`` rather than shelling out to
+``makemigrations``: the loader is what actually raises in production, and it
+does not need a database.
+"""
+
+from django.db.migrations.exceptions import InconsistentMigrationHistory
+from django.db.migrations.loader import MigrationLoader
+from django.test import SimpleTestCase
+
+
+class MigrationGraphTests(SimpleTestCase):
+    """Structural checks on the migration graph, no database required."""
+
+    def _loader(self):
+        # connection=None skips the applied-migrations query: we are asking
+        # about the files on disk, not about any particular database.
+        return MigrationLoader(None, ignore_no_migrations=True)
+
+    def test_analyzer_has_exactly_one_leaf_migration(self):
+        """Two leaves means `migrate` and `test` both refuse to run.
+
+        This is the check that would have caught the conflict at the point the
+        second 0020 was merged.
+        """
+        loader = self._loader()
+        leaves = sorted(
+            name for app_label, name in loader.graph.leaf_nodes()
+            if app_label == "analyzer"
+        )
+
+        self.assertEqual(
+            len(leaves),
+            1,
+            "The analyzer app has more than one migration leaf: "
+            f"{leaves}. Django cannot build a migration plan in this state, so "
+            "`manage.py migrate` and `manage.py test` both fail before doing "
+            "any work. Run `python manage.py makemigrations --merge analyzer` "
+            "and commit the merge migration it generates.",
+        )
+
+    def test_every_app_has_exactly_one_leaf_migration(self):
+        """The same rule, for every app in the project.
+
+        The conflict happened in ``analyzer`` this time, but nothing about the
+        failure mode is specific to that app.
+        """
+        loader = self._loader()
+
+        leaves_by_app = {}
+        for app_label, name in loader.graph.leaf_nodes():
+            leaves_by_app.setdefault(app_label, []).append(name)
+
+        conflicted = {
+            app: sorted(names)
+            for app, names in leaves_by_app.items()
+            if len(names) > 1
+        }
+
+        self.assertEqual(
+            conflicted,
+            {},
+            f"Apps with a conflicting migration graph: {conflicted}. "
+            "Each one needs a merge migration.",
+        )
+
+    def test_migration_graph_builds_without_error(self):
+        """Building the graph is what raises in production — do it here too."""
+        try:
+            loader = self._loader()
+            loader.graph.validate_consistency()
+        except InconsistentMigrationHistory as exc:  # pragma: no cover
+            self.fail(f"Migration graph is inconsistent: {exc}")
+
+    def test_every_migration_dependency_resolves(self):
+        """A dependency naming a migration that does not exist.
+
+        ``graph.leaf_nodes()`` is happy with a dangling edge, but ``migrate``
+        is not. Django records unresolved references as dummy nodes, so check
+        for those directly.
+        """
+        loader = self._loader()
+
+        dangling = sorted(
+            f"{app}.{name}"
+            for (app, name), node in loader.graph.node_map.items()
+            if getattr(node, "children", None) is not None
+            and (app, name) not in loader.disk_migrations
+            and app == "analyzer"
+        )
+
+        self.assertEqual(
+            dangling,
+            [],
+            f"These analyzer migrations are referenced but do not exist: {dangling}",
+        )
+
+
+class NoMissingMigrationsTests(SimpleTestCase):
+    """A model change with no migration is the other way this breaks.
+
+    CI already runs ``makemigrations --check --dry-run``, but that step is
+    skipped entirely when the graph has two leaves — the command raises the
+    conflict error before it gets as far as comparing models to migrations.
+    Running the equivalent check from inside the suite means it is exercised
+    locally too, and it stays honest about which of the two problems it found.
+    """
+
+    def test_models_match_migrations(self):
+        from django.apps import apps
+        from django.db.migrations.autodetector import MigrationAutodetector
+        from django.db.migrations.questioner import NonInteractiveMigrationQuestioner
+        from django.db.migrations.state import ProjectState
+
+        loader = MigrationLoader(None, ignore_no_migrations=True)
+
+        # If the graph is broken, say so rather than reporting a confusing
+        # "missing migration" for every model in the project.
+        analyzer_leaves = [
+            name for app_label, name in loader.graph.leaf_nodes()
+            if app_label == "analyzer"
+        ]
+        if len(analyzer_leaves) > 1:
+            self.skipTest(
+                "Migration graph has multiple leaves; "
+                "test_analyzer_has_exactly_one_leaf_migration covers that."
+            )
+
+        autodetector = MigrationAutodetector(
+            loader.project_state(),
+            ProjectState.from_apps(apps),
+            NonInteractiveMigrationQuestioner(specified_apps=set(), dry_run=True),
+        )
+        changes = autodetector.changes(graph=loader.graph)
+
+        described = {
+            app: [str(op) for migration in migrations for op in migration.operations]
+            for app, migrations in changes.items()
+        }
+
+        self.assertEqual(
+            described,
+            {},
+            "Model changes have no matching migration: "
+            f"{described}. Run `python manage.py makemigrations`.",
+        )

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -165,3 +165,56 @@ and most proxies, which is the exposure the change exists to avoid.
 To poke the endpoint freely in local development, set
 `ANALYSIS_CLAIM_REQUIRED=false`. It defaults to on, and production should leave
 it there.
+
+## "Conflicting migrations detected" — the suite is not failing, it never ran
+
+If `python manage.py test analyzer` prints something like:
+
+```
+Found 359 test(s).
+Creating test database for alias 'default'...
+CommandError: Conflicting migrations detected; multiple leaf nodes in the
+migration graph: (0020_merge_20260824_0025, 0020_resumebadge in analyzer).
+To fix them run 'python manage.py makemigrations --merge'
+```
+
+then nothing was executed. The count on the first line is discovery, not
+results — Django found the tests, then failed while building the test database
+and exited. `migrate`, `showmigrations` and `makemigrations --check` all fail
+the same way, because they all build the migration graph first.
+
+It happens when two branches each add a migration on top of the same parent and
+both get merged. Neither knows about the other, so the app is left with two
+tips and there is no single "latest" migration to plan towards.
+
+Fix it with a merge migration:
+
+```bash
+cd backend
+python manage.py makemigrations --merge analyzer
+```
+
+That writes an empty migration depending on both leaves. Commit it. It is a
+real migration and belongs in the pull request that discovered the conflict —
+do not resolve it by deleting or renumbering someone else's migration, which
+breaks any database that has already applied it.
+
+`analyzer/tests_migration_graph.py` asserts the graph has a single leaf, and CI
+runs that module on its own before the rest of the suite. It is a
+`SimpleTestCase`, so it needs no test database — which is the point, since
+creating the test database is the step that fails when the graph is broken.
+
+### Rebasing onto a new migration
+
+If your branch adds a migration and `main` has since gained one with the same
+number, rebase and renumber **your** migration rather than merging:
+
+```bash
+git fetch origin && git rebase origin/main
+git mv backend/analyzer/migrations/0021_my_change.py \
+       backend/analyzer/migrations/0022_my_change.py
+# then edit its `dependencies` to point at the new tip on main
+```
+
+A merge migration is for conflicts that already reached `main`. For a branch
+that has not merged yet, renumbering keeps the history linear.


### PR DESCRIPTION
## 📝 Description

The analyzer app had two migration leaf nodes, so Django could not build a migration plan and every `manage.py` command that touches the loader failed on `main` — `migrate`, `showmigrations`, `makemigrations --check` and `test`.

`0020_resumebadge` (score badge) and `0020_merge_20260824_0025` (JD match fields) were written against the same parent on separate branches and both merged. Neither knows about the other. Nothing was wrong with either branch; this is just what two green PRs off one parent produce when they both add a migration.

This adds the merge migration, plus a check that fails on the graph itself so the next collision is reported as what it is.

**Before**

```
$ python manage.py test analyzer
Found 359 test(s).
Creating test database for alias 'default'...
CommandError: Conflicting migrations detected; multiple leaf nodes in the
migration graph: (0020_merge_20260824_0025, 0020_resumebadge in analyzer).
```

That `Found 359 test(s)` is discovery, not results — zero assertions ran. It is why this survived a day of red builds: a suite that never executes looks the same in the Actions summary as one that failed.

**After**

```
Ran 567 tests in 15.5s
OK (skipped=1)
```

Nothing was actually broken behind the conflict. The tests have just been invisible since 23 Aug.

## 🔗 Related Issue

Closes #826

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## 🔍 What's in here

**`0021_merge_resumebadge_and_jd_match_fields.py`** — depends on both `0020` leaves, no operations. This is the `makemigrations --merge` output and is safe on a database that has already applied either branch. I did not renumber or delete either existing migration: both have shipped, and rewriting them would break anyone whose database has applied one.

**`analyzer/tests_migration_graph.py`** — five checks: exactly one leaf in `analyzer`, exactly one leaf in every app, the graph builds and validates, no dependency names a migration that does not exist, and models still match migrations.

Every one is a `SimpleTestCase`, which matters more than it looks. Creating the test database is the step that explodes when the graph is broken, so a check that needs a database can never be the check that explains why the database could not be created. These run with `Skipping setup of unused database(s)`.

Confirmed it fails on the broken state — with `0021` removed:

```
FAIL: test_analyzer_has_exactly_one_leaf_migration
AssertionError: 2 != 1 : The analyzer app has more than one migration leaf:
['0020_merge_20260824_0025', '0020_resumebadge']. Django cannot build a
migration plan in this state, so `manage.py migrate` and `manage.py test` both
fail before doing any work. Run `python manage.py makemigrations --merge
analyzer` and commit the merge migration it generates.
```

**`.github/workflows/tests.yml`** — a step that runs only that module, placed *before* `makemigrations --check --dry-run`. Ordering is deliberate: with two leaves, `makemigrations --check` raises the conflict error rather than reporting a missing migration, so on its own it points at the wrong problem. The existing check was added in #635 for this family of bug and could not catch this member of it.

**`docs/TESTING.md`** — what the error means, why the discovery count is not a pass, how to fix it, and the rebase-vs-merge rule: a merge migration is for a conflict that already reached `main`; a branch that has not landed yet should rebase and renumber instead.

## 🧪 How Has This Been Tested?

- [x] Backend tests pass (`python manage.py test analyzer`) — 567 tests, `OK (skipped=1)`
- [x] `python manage.py migrate` succeeds on a fresh database
- [x] `python manage.py makemigrations --check --dry-run` → `No changes detected`
- [x] Regression test verified to fail with `0021` removed and pass with it present

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)

## 📌 Note for reviewers

Worth merging ahead of the other open PRs — until it lands, every PR shows a red Backend job caused by this and not by the PR's own changes. I have four other fixes queued behind it whose CI will stay red for the same reason.
