### PR TITLE
fix: render the career track controls once instead of twice (#828)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import PrivacyPolicyPage from './pages/PrivacyPolicyPage'
 import { InterviewQuestionsPanel } from './components/InterviewQuestionsPanel'
 import { TimelinePanel } from './components/TimelinePanel'
 import { type TimelineData } from './utils/timelineFormat'
+import CareerTrackSelector from './components/CareerTrackSelector'
 import { ScoreBreakdown, type ScoreBreakdownData } from './components/ScoreBreakdown'
 import { FormattingChecks, type FormattingChecksData } from './components/FormattingChecks'
 import { WhatsNewModal } from './components/WhatsNewModal'
@@ -714,59 +715,6 @@ function App() {
             />
           )}
           <h1 className="mb-4">🚀 AI Resume Analyzer</h1>
-          {/* Role and Experience Level Selectors */}
-          <div
-            className="role-selector-container mb-4 p-3 d-flex flex-wrap gap-3 align-items-center justify-content-center"
-            style={{
-              background: 'rgba(255, 255, 255, 0.03)',
-              border: '1.5px solid var(--surface-border)',
-              borderRadius: 'var(--radius-lg)',
-              maxWidth: '680px',
-              margin: '0 auto var(--space-4)',
-            }}
-          >
-            <div className="d-flex align-items-center">
-              <label
-                htmlFor="roleSelect"
-                style={{ marginRight: '10px', fontWeight: '600', color: '#fff' }}
-              >
-                Target Career Track:
-              </label>
-              <div className="custom-select-container">
-                <select
-                  id="roleSelect"
-                  value={targetRole}
-                  onChange={(e) => setTargetRole(e.target.value)}
-                  className="custom-select-element"
-                >
-                  <option value="Frontend Developer">Frontend Developer</option>
-                  <option value="Backend Developer">Backend Developer</option>
-                  <option value="Data Analyst">Data Analyst</option>
-                </select>
-              </div>
-            </div>
-
-            <div className="d-flex align-items-center">
-              <label
-                htmlFor="experienceLevelSelect"
-                style={{ marginRight: '10px', fontWeight: '600', color: '#fff' }}
-              >
-                Experience Level:
-              </label>
-              <div className="custom-select-container">
-                <select
-                  id="experienceLevelSelect"
-                  value={experienceLevel}
-                  onChange={(e) => setExperienceLevel(e.target.value)}
-                  className="custom-select-element"
-                >
-                  <option value="Junior">Junior (0-2 yrs)</option>
-                  <option value="Mid-Level">Mid-Level (2-5 yrs)</option>
-                  <option value="Senior">Senior (5+ yrs)</option>
-                </select>
-              </div>
-            </div>
-          </div>
           <div
             className="upload-flow-container"
             style={{
@@ -824,66 +772,13 @@ function App() {
                 </h3>
               </div>
 
-              {/* Role and Experience Level Selectors */}
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-                  gap: '14px',
-                }}
-              >
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                  <label
-                    htmlFor="roleSelect"
-                    style={{ fontWeight: '600', fontSize: '0.85rem', color: 'var(--heading-text, #fff)' }}
-                  >
-                    Target Career Track:
-                  </label>
-                  <select
-                    id="roleSelect"
-                    value={targetRole}
-                    onChange={(e) => setTargetRole(e.target.value)}
-                    style={{
-                      padding: '10px 14px',
-                      borderRadius: '8px',
-                      border: '1px solid var(--surface-border, rgba(255, 255, 255, 0.15))',
-                      background: 'var(--control-bg, rgba(255, 255, 255, 0.05))',
-                      color: 'var(--control-text, #fff)',
-                      fontSize: '0.9rem',
-                    }}
-                  >
-                    <option value="Frontend Developer">Frontend Developer</option>
-                    <option value="Backend Developer">Backend Developer</option>
-                    <option value="Data Analyst">Data Analyst</option>
-                  </select>
-                </div>
-
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                  <label
-                    htmlFor="experienceLevelSelect"
-                    style={{ fontWeight: '600', fontSize: '0.85rem', color: 'var(--heading-text, #fff)' }}
-                  >
-                    Experience Level:
-                  </label>
-                  <select
-                    id="experienceLevelSelect"
-                    value={experienceLevel}
-                    onChange={(e) => setExperienceLevel(e.target.value)}
-                    style={{
-                      padding: '10px 14px',
-                      borderRadius: '8px',
-                      border: '1px solid var(--surface-border, rgba(255, 255, 255, 0.15))',
-                      background: 'var(--control-bg, rgba(255, 255, 255, 0.05))',
-                      color: 'var(--control-text, #fff)',
-                      fontSize: '0.9rem',
-                    }}
-                  >
-                    <option value="Junior">Junior (0-2 yrs)</option>
-                    <option value="Mid-Level">Mid-Level (2-5 yrs)</option>
-                    <option value="Senior">Senior (5+ yrs)</option>
-                  </select>
-                </div>
-              </div>
+              {/* Role and Experience Level Selectors — the single copy. */}
+              <CareerTrackSelector
+                targetRole={targetRole}
+                onTargetRoleChange={setTargetRole}
+                experienceLevel={experienceLevel}
+                onExperienceLevelChange={setExperienceLevel}
+              />
 
               {/* Job Description Draft Input (#533) */}
               <div style={{ marginTop: '16px' }}>

--- a/frontend/src/components/CareerTrackSelector.test.tsx
+++ b/frontend/src/components/CareerTrackSelector.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import App from '../App'
+import CareerTrackSelector from './CareerTrackSelector'
+import { CAREER_TRACKS, EXPERIENCE_LEVELS } from '../data/careerTracks'
+
+describe('CareerTrackSelector', () => {
+  it('renders one labelled dropdown per field', () => {
+    render(
+      <CareerTrackSelector
+        targetRole="Frontend Developer"
+        onTargetRoleChange={() => {}}
+        experienceLevel="Mid-Level"
+        onExperienceLevelChange={() => {}}
+      />
+    )
+
+    const role = screen.getByRole('combobox', { name: /target career track/i })
+    const level = screen.getByRole('combobox', { name: /experience level/i })
+
+    expect(role).toBeInTheDocument()
+    expect(level).toBeInTheDocument()
+    expect(screen.getAllByRole('combobox')).toHaveLength(2)
+  })
+
+  it('offers every career track and experience level', () => {
+    render(
+      <CareerTrackSelector
+        targetRole="Frontend Developer"
+        onTargetRoleChange={() => {}}
+        experienceLevel="Mid-Level"
+        onExperienceLevelChange={() => {}}
+      />
+    )
+
+    const role = screen.getByRole('combobox', {
+      name: /target career track/i,
+    }) as HTMLSelectElement
+    const level = screen.getByRole('combobox', {
+      name: /experience level/i,
+    }) as HTMLSelectElement
+
+    expect(Array.from(role.options).map((o) => o.value)).toEqual([...CAREER_TRACKS])
+    expect(Array.from(level.options).map((o) => o.value)).toEqual(
+      EXPERIENCE_LEVELS.map((l) => l.value)
+    )
+    expect(Array.from(level.options).map((o) => o.textContent)).toEqual([
+      'Junior (0-2 yrs)',
+      'Mid-Level (2-5 yrs)',
+      'Senior (5+ yrs)',
+    ])
+  })
+
+  it('reports the selected value back to the caller', () => {
+    const onTargetRoleChange = vi.fn()
+    const onExperienceLevelChange = vi.fn()
+
+    render(
+      <CareerTrackSelector
+        targetRole="Frontend Developer"
+        onTargetRoleChange={onTargetRoleChange}
+        experienceLevel="Mid-Level"
+        onExperienceLevelChange={onExperienceLevelChange}
+      />
+    )
+
+    fireEvent.change(screen.getByRole('combobox', { name: /target career track/i }), {
+      target: { value: 'Data Analyst' },
+    })
+    fireEvent.change(screen.getByRole('combobox', { name: /experience level/i }), {
+      target: { value: 'Senior' },
+    })
+
+    expect(onTargetRoleChange).toHaveBeenCalledWith('Data Analyst')
+    expect(onExperienceLevelChange).toHaveBeenCalledWith('Senior')
+  })
+
+  it('reflects the values it is given rather than holding its own state', () => {
+    const { rerender } = render(
+      <CareerTrackSelector
+        targetRole="Frontend Developer"
+        onTargetRoleChange={() => {}}
+        experienceLevel="Mid-Level"
+        onExperienceLevelChange={() => {}}
+      />
+    )
+
+    expect(screen.getByDisplayValue('Frontend Developer')).toBeInTheDocument()
+
+    rerender(
+      <CareerTrackSelector
+        targetRole="Backend Developer"
+        onTargetRoleChange={() => {}}
+        experienceLevel="Junior"
+        onExperienceLevelChange={() => {}}
+      />
+    )
+
+    expect(screen.getByDisplayValue('Backend Developer')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Junior (0-2 yrs)')).toBeInTheDocument()
+  })
+
+  it('can be disabled', () => {
+    render(
+      <CareerTrackSelector
+        targetRole="Frontend Developer"
+        onTargetRoleChange={() => {}}
+        experienceLevel="Mid-Level"
+        onExperienceLevelChange={() => {}}
+        disabled
+      />
+    )
+
+    screen.getAllByRole('combobox').forEach((el) => expect(el).toBeDisabled())
+  })
+
+  it('namespaces its ids so a second instance does not collide', () => {
+    // The original bug was two copies of this markup both hardcoding
+    // `id="roleSelect"`. A caller that genuinely wants a second instance has
+    // to be able to give it distinct ids.
+    const { container } = render(
+      <>
+        <CareerTrackSelector
+          targetRole="Frontend Developer"
+          onTargetRoleChange={() => {}}
+          experienceLevel="Mid-Level"
+          onExperienceLevelChange={() => {}}
+        />
+        <CareerTrackSelector
+          idPrefix="compare-"
+          targetRole="Backend Developer"
+          onTargetRoleChange={() => {}}
+          experienceLevel="Senior"
+          onExperienceLevelChange={() => {}}
+        />
+      </>
+    )
+
+    const ids = Array.from(container.querySelectorAll('[id]')).map((el) => el.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids).toContain('roleSelect')
+    expect(ids).toContain('compare-roleSelect')
+
+    // And each select is still reachable by its own label.
+    ;(container.querySelectorAll('select') as NodeListOf<HTMLSelectElement>).forEach((select) => {
+      expect(select.labels).toHaveLength(1)
+    })
+  })
+})
+
+describe('App renders the career track controls exactly once (#828)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  const renderApp = () =>
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    )
+
+  it('has no duplicate element ids anywhere in the document', () => {
+    // The regression guard. Four elements shared two ids before this change,
+    // and the symptom people actually hit was `Found multiple elements with
+    // the display value` in unrelated tests.
+    const { container } = renderApp()
+
+    const counts = new Map<string, number>()
+    container.querySelectorAll('[id]').forEach((el) => {
+      counts.set(el.id, (counts.get(el.id) ?? 0) + 1)
+    })
+
+    const duplicates = [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([id, count]) => `${id} (×${count})`)
+
+    expect(duplicates).toEqual([])
+  })
+
+  it('renders a single Target Career Track control', () => {
+    renderApp()
+    expect(screen.getAllByRole('combobox', { name: /target career track/i })).toHaveLength(1)
+  })
+
+  it('renders a single Experience Level control', () => {
+    renderApp()
+    expect(screen.getAllByRole('combobox', { name: /experience level/i })).toHaveLength(1)
+  })
+
+  it('gives each dropdown exactly one label', () => {
+    // `<label for>` resolves through getElementById, which returns the first
+    // match. With the ids duplicated, both "Target Career Track:" labels
+    // pointed at the first select — it had two labels and the second copy had
+    // none, so a screen reader announced the second pair as unnamed.
+    const { container } = renderApp()
+
+    const role = container.querySelector('#roleSelect') as HTMLSelectElement
+    const level = container.querySelector('#experienceLevelSelect') as HTMLSelectElement
+
+    expect(role.labels).toHaveLength(1)
+    expect(level.labels).toHaveLength(1)
+    expect(role.labels?.[0].textContent).toMatch(/target career track/i)
+    expect(level.labels?.[0].textContent).toMatch(/experience level/i)
+  })
+
+  it('is found unambiguously by display value', () => {
+    // This is the exact assertion that was failing on main:
+    //   TestingLibraryElementError: Found multiple elements with the display
+    //   value: Backend Developer.
+    localStorage.setItem('selected_target_role', 'Backend Developer')
+    localStorage.setItem('selected_experience_level', 'Senior')
+
+    renderApp()
+
+    expect(screen.getByDisplayValue('Backend Developer')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Senior (5+ yrs)')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/CareerTrackSelector.tsx
+++ b/frontend/src/components/CareerTrackSelector.tsx
@@ -1,0 +1,113 @@
+import type { ChangeEvent } from 'react'
+import { CAREER_TRACKS, EXPERIENCE_LEVELS } from '../data/careerTracks'
+
+/**
+ * The Target Career Track and Experience Level dropdowns.
+ *
+ * These controls used to be written out twice in `App.tsx` — once as a
+ * free-standing banner under the page heading, and again inside the
+ * "Step 1: Set Career Track & Experience" card. Both copies rendered
+ * unconditionally, both hardcoded `id="roleSelect"` and
+ * `id="experienceLevelSelect"`, and both were bound to the same state, so the
+ * page showed the same two dropdowns twice and four elements shared two ids.
+ *
+ * Duplicate ids are not a cosmetic problem. `<label for>` resolves through
+ * `getElementById`, which returns the first match, so *both* labels pointed at
+ * the first dropdown: it had two labels and the second copy had none. A screen
+ * reader announced the second pair as unnamed comboboxes, and clicking the
+ * label above the second dropdown moved focus to the one further up the page.
+ *
+ * Keeping the markup in one component is what stops that coming back. `idPrefix`
+ * exists so that if a second instance is ever genuinely wanted — a modal, a
+ * compare view — it can have its own ids rather than colliding by default.
+ */
+
+interface CareerTrackSelectorProps {
+  targetRole: string
+  onTargetRoleChange: (value: string) => void
+  experienceLevel: string
+  onExperienceLevelChange: (value: string) => void
+  /**
+   * Prefix for the generated element ids. Only worth setting if the component
+   * is rendered more than once in the same document — the default keeps the
+   * ids the existing tests and any deep links already use.
+   */
+  idPrefix?: string
+  /** Disables both dropdowns, e.g. while an analysis is running. */
+  disabled?: boolean
+  className?: string
+}
+
+export default function CareerTrackSelector({
+  targetRole,
+  onTargetRoleChange,
+  experienceLevel,
+  onExperienceLevelChange,
+  idPrefix = '',
+  disabled = false,
+  className = '',
+}: CareerTrackSelectorProps) {
+  const roleId = `${idPrefix}roleSelect`
+  const levelId = `${idPrefix}experienceLevelSelect`
+
+  const handleRoleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    onTargetRoleChange(event.target.value)
+  }
+
+  const handleLevelChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    onExperienceLevelChange(event.target.value)
+  }
+
+  return (
+    <div className={`career-track-selector ${className}`.trim()}>
+      <div className="career-track-selector__field">
+        <label htmlFor={roleId} className="career-track-selector__label">
+          Target Career Track:
+        </label>
+        {/*
+          `.custom-select-container` / `.custom-select-element` carry the themed
+          chevron, the focus ring and the print rules from #261. The step-card
+          copy of this markup used inline styles instead, which meant it lost
+          the light-theme chevron and the focus-visible outline, and hardcoded
+          `color: #fff` on the label so it was invisible on a light background.
+        */}
+        <div className="custom-select-container">
+          <select
+            id={roleId}
+            value={targetRole}
+            onChange={handleRoleChange}
+            disabled={disabled}
+            className="custom-select-element"
+          >
+            {CAREER_TRACKS.map((track) => (
+              <option key={track} value={track}>
+                {track}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="career-track-selector__field">
+        <label htmlFor={levelId} className="career-track-selector__label">
+          Experience Level:
+        </label>
+        <div className="custom-select-container">
+          <select
+            id={levelId}
+            value={experienceLevel}
+            onChange={handleLevelChange}
+            disabled={disabled}
+            className="custom-select-element"
+          >
+            {EXPERIENCE_LEVELS.map((level) => (
+              <option key={level.value} value={level.value}>
+                {level.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/data/careerTracks.ts
+++ b/frontend/src/data/careerTracks.ts
@@ -1,0 +1,32 @@
+/**
+ * The career tracks and experience levels the analyzer scores against.
+ *
+ * These live outside `CareerTrackSelector.tsx` so that file exports only a
+ * component — the `react-refresh/only-export-components` rule, and it is a
+ * real one here: mixing constants into a component module breaks fast refresh
+ * for everything that imports them.
+ *
+ * The option lists were previously written out inline, twice, in `App.tsx`.
+ * Having one source for them means a new track cannot be half-added.
+ */
+
+export const CAREER_TRACKS = ['Frontend Developer', 'Backend Developer', 'Data Analyst'] as const
+
+export type CareerTrack = (typeof CAREER_TRACKS)[number]
+
+export interface ExperienceLevelOption {
+  /** Stored in localStorage and sent to the API. */
+  value: string
+  /** What the dropdown shows. */
+  label: string
+}
+
+export const EXPERIENCE_LEVELS: readonly ExperienceLevelOption[] = [
+  { value: 'Junior', label: 'Junior (0-2 yrs)' },
+  { value: 'Mid-Level', label: 'Mid-Level (2-5 yrs)' },
+  { value: 'Senior', label: 'Senior (5+ yrs)' },
+] as const
+
+/** The value used when nothing has been chosen or restored yet. */
+export const DEFAULT_CAREER_TRACK: CareerTrack = 'Frontend Developer'
+export const DEFAULT_EXPERIENCE_LEVEL = 'Mid-Level'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2241,6 +2241,42 @@ input {
   }
 }
 
+/* ── Career Track + Experience Level selector ───────────────── */
+/*
+   One responsive grid rather than a flex row of fixed-width controls. The two
+   dropdowns sit side by side wherever there is room for both at a usable
+   width, and stack below that instead of squeezing to the point where the
+   longest option ("Mid-Level (2-5 yrs)") is clipped.
+*/
+.career-track-selector {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 14px;
+}
+
+.career-track-selector__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  /* Grid items default to min-width:auto, which lets a long <option> push the
+     column wider than its track and overflow the card. */
+  min-width: 0;
+}
+
+.career-track-selector__label {
+  font-weight: 600;
+  font-size: var(--text-sm, 0.85rem);
+  /* Themed, not hardcoded white: the duplicated copy of this markup set
+     `color: #fff` inline, which disappeared against a light background. */
+  color: var(--heading-text, #fff);
+  margin-bottom: 0;
+}
+
+.career-track-selector .custom-select-element:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 /* ── Target Career Track Custom Select (#261) ───────────────── */
 .custom-select-container {
   position: relative;


### PR DESCRIPTION
## 📝 Description

`App.tsx` rendered the Target Career Track and Experience Level dropdowns twice, unconditionally, both copies hardcoding the same ids. The page showed the same two dropdowns twice, and four elements shared two ids.

Two PRs landed a day apart and neither knew about the other: #757 added the "Step 1: Set Career Track & Experience" card with its own copy of the controls, while #751 restyled the pre-existing free-standing row. Same shape as #826 — two reasonable branches, one duplicated result.

**The part that isn't cosmetic.** `<label for>` resolves through `getElementById`, which returns the first match, so *both* `Target Career Track:` labels pointed at the first select — including the one visually sitting above the second dropdown. Probing the rendered document:

```
DUPLICATE IDS: [["roleSelect",2],["experienceLevelSelect",2]]
  combobox[0] id=roleSelect            labelsResolvedTo=2
  combobox[1] id=experienceLevelSelect labelsResolvedTo=2
  combobox[2] id=roleSelect            labelsResolvedTo=0   <-- no label at all
  combobox[3] id=experienceLevelSelect labelsResolvedTo=0   <-- no label at all
```

The second pair had no accessible name at all — WCAG 1.3.1 and 4.1.2 — and clicking the label above it moved focus to the control further up the page. Because `getByRole(..., { name })` still resolves to exactly one element, the existing accessibility-shaped tests passed throughout.

## 🔗 Related Issue

Closes #828

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Refactor (no functional change)

## 🔍 What's in here

**`components/CareerTrackSelector.tsx`** — the markup, once. `idPrefix` means a second instance (a modal, a compare view) can have its own ids rather than colliding by default; the default keeps `roleSelect` / `experienceLevelSelect` so nothing that already targets them breaks.

**Which copy I kept.** The one inside the Step 1 card. It belongs to the numbered flow and has the job description input directly beneath it, so removing it would leave "Step 1: Set Career Track & Experience" as a heading over nothing. Happy to flip it to the banner position instead if that was the intended design — it is a one-line move now that the markup is in one place.

**Styling carried over.** The step-card copy had swapped `.custom-select-container` / `.custom-select-element` for inline styles, which quietly dropped the `:focus-visible` ring, the `[data-theme='light']` chevron and the print-hide rule from #261, and hardcoded `color: '#fff'` on the labels so they were invisible on a light background. The component uses the classes again, plus a small `.career-track-selector` grid so the two controls stack rather than clip when there is no room for both.

**`data/careerTracks.ts`** — the option lists, which were written out inline in both copies. One source means a new track cannot be half-added to one of them.

**Tests.** Eleven, and the one that matters is the guard: it walks every `[id]` in the rendered app and fails on any duplicate. That is the underlying fault rather than either symptom, so it also catches the next component that does this.

## 🧪 How Has This Been Tested?

- [x] Frontend tests pass — **280 passing (48 files)**, up from 267 passing / 2 failing
- [x] The two tests red on `main` since #757 now pass:
      `restores targetRole from localStorage`, `restores experienceLevel from localStorage`
- [x] `npx tsc -b --noEmit` clean apart from the pre-existing `swagger-ui-react` error noted in `tests.yml`
- [x] `npx eslint` clean on every file added here
- [x] `npx prettier --check` clean on every file added here

I deliberately did **not** run prettier across `App.tsx` — it is one of the 752 pre-existing violations that `tests.yml` documents, and reformatting it would conflict with every open PR. The diff there is only the two blocks being replaced.

## 📸 Screenshots

Not attaching one, since the change is "the second identical row of dropdowns is gone". `document.querySelectorAll('#roleSelect').length` goes from `2` to `1`.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)

## 📌 Note for reviewers

The Backend job will be red until #827 merges — the migration conflict in #826 breaks it for every PR, including this one, which touches no Python at all. The Frontend job is the one to read here.
