### PR TITLE
fix: treat a hyphen as a word boundary when extracting skills (#830)

### DIFF
--- a/backend/analyzer/skill_matcher.py
+++ b/backend/analyzer/skill_matcher.py
@@ -83,15 +83,38 @@ def build_automaton():
 AUTOMATON = build_automaton()
 
 
+#: Characters that continue a skill token rather than ending one.
+#:
+#: ``-`` is deliberately absent. It used to be here, which made every
+#: hyphenated mention of a skill invisible: "Python-based", "React-Redux",
+#: "Docker-compose" and "Kubernetes-managed" all extracted nothing at all,
+#: because the hyphen on one side was read as "this match is part of a longer
+#: word". A hyphen joins two words; it does not make them one.
+#:
+#: ``is_word_in_text`` in this same module has always disagreed — its
+#: ``(?<!\w)…(?!\w)`` guard treats ``-`` as a boundary, since ``\w`` does not
+#: include it. The two functions now agree.
+#:
+#: ``#`` and ``+`` stay, because they are the last character of a skill name
+#: rather than a join: without them "C" matches inside "C#" and "C++".
+SKILL_TOKEN_CHARS = ('_', '#', '+')
+
+
 def is_word_boundary(text: str, start: int, end: int) -> bool:
     r"""
     Checks if a matched substring is bounded by non-word / non-skill characters.
     Prevents matching "react" inside "react.js" or "c" inside "c++".
+
+    A hyphen counts as a boundary. The hyphenated skill names that exist in the
+    dictionary — objective-c, react-native, scikit-learn — are matched as whole
+    aliases by the automaton, and the shorter matches now sitting inside them
+    ("c" in "objective-c") are discarded by :func:`_longest_matches` rather than
+    by this function.
     """
     # Check preceding character
     if start > 0:
         prev_char = text[start - 1]
-        if prev_char.isalnum() or prev_char in ('_', '#', '+', '-'):
+        if prev_char.isalnum() or prev_char in SKILL_TOKEN_CHARS:
             return False
         if prev_char == '.' and start - 1 > 0 and text[start - 2].isalnum():
             return False
@@ -99,12 +122,88 @@ def is_word_boundary(text: str, start: int, end: int) -> bool:
     # Check following character
     if end < len(text):
         next_char = text[end]
-        if next_char.isalnum() or next_char in ('_', '#', '+', '-'):
+        if next_char.isalnum() or next_char in SKILL_TOKEN_CHARS:
             return False
         if next_char == '.' and end + 1 < len(text) and text[end + 1].isalnum():
             return False
 
     return True
+
+
+def _longest_matches(spans):
+    """Drop any match that sits entirely inside a longer one.
+
+    The automaton reports every alias it finds, including aliases nested in
+    other aliases. While ``-`` blocked a match on either side that nesting was
+    invisible, because the inner match was rejected as unbounded. Now that a
+    hyphen is a boundary, "objective-c" also reports "c" and "react-native"
+    also reports "react", so the overlap has to be resolved explicitly.
+
+    Longest wins, which is the usual rule for this: "Objective-C" names one
+    language, not two.
+
+    ``spans`` is an iterable of ``(start, end, alias, canonical)`` with ``end``
+    exclusive. Equal spans from different aliases are a genuine ambiguity in
+    the dictionary rather than nesting, so the first is kept.
+    """
+    # Start ascending, then longest first, so a container is always visited
+    # before anything nested inside it.
+    ordered = sorted(spans, key=lambda span: (span[0], -(span[1] - span[0])))
+
+    kept = []
+    covered_to = -1
+    for span in ordered:
+        start, end = span[0], span[1]
+        # Every span already visited starts at or before this one, so being
+        # inside the furthest end reached means being inside one of them.
+        if end <= covered_to:
+            continue
+        kept.append(span)
+        covered_to = max(covered_to, end)
+
+    return kept
+
+
+def _scan(text: str):
+    """Boundary-checked automaton hits in ``text`` as ``(start, end, alias, canonical)``."""
+    spans = []
+    # pyahocorasick returns (end_index, (alias_lower, canonical));
+    # end_index is inclusive.
+    for end_index, (alias_lower, canonical) in AUTOMATON.iter(text):
+        start_index = end_index - len(alias_lower) + 1
+        # Match complete words only, to prevent false positives
+        # (e.g. "react" inside "reactive").
+        if is_word_boundary(text, start_index, end_index + 1):
+            spans.append((start_index, end_index + 1, alias_lower, canonical))
+    return spans
+
+
+def _iter_skill_matches(normalized_text: str):
+    """Every non-nested, correctly bounded skill match in already-normalised text.
+
+    Returns ``(start, end, alias_lower, canonical)`` tuples, ordered by where
+    the match starts.
+
+    The text is scanned twice. The second pass replaces every hyphen with a
+    space, because a hyphen is also how people join the words of a
+    multi-word skill name: the dictionary carries ``node js``,
+    ``machine learning`` and ``deep learning`` as aliases, and someone writing
+    "node-js", "machine-learning" or "deep-learning" means exactly those.
+    Substituting one character for another keeps the string the same length,
+    so offsets from both passes refer to the same positions and can be
+    compared directly.
+
+    Hyphenated skill names in the dictionary (objective-c, react-native,
+    scikit-learn) still match on the first pass, and win over anything the
+    second pass finds inside them because they are longer.
+    """
+    spans = _scan(normalized_text)
+
+    if "-" in normalized_text:
+        # Same length, so the spans are directly comparable.
+        spans.extend(_scan(normalized_text.replace("-", " ")))
+
+    return _longest_matches(spans)
 
 
 def is_word_in_text(word: str, text: str) -> bool:
@@ -151,16 +250,7 @@ def extract_skills(text: str):
         list[str]
     """
     normalized = normalize_text(text)
-    detected = []
-
-    # pyahocorasick returns (end_index, (alias_lower, canonical))
-    # end_index is inclusive.
-    for end_index, (alias_lower, canonical) in AUTOMATON.iter(normalized):
-        start_index = end_index - len(alias_lower) + 1
-        
-        # Match complete words only to prevent false positives (e.g. react in reactive)
-        if is_word_boundary(normalized, start_index, end_index + 1):
-            detected.append(canonical)
+    detected = [canonical for _, _, _, canonical in _iter_skill_matches(normalized)]
 
     # Preserve insertion order and remove duplicates.
     return list(dict.fromkeys(detected))
@@ -176,13 +266,11 @@ def extract_skills_detailed(text: str):
     normalized = normalize_text(text)
     matched_details = {}
 
-    for end_index, (alias_lower, canonical) in AUTOMATON.iter(normalized):
-        start_index = end_index - len(alias_lower) + 1
-        if is_word_boundary(normalized, start_index, end_index + 1):
-            if canonical not in matched_details:
-                matched_details[canonical] = []
-            if alias_lower not in matched_details[canonical]:
-                matched_details[canonical].append(alias_lower)
+    for _, _, alias_lower, canonical in _iter_skill_matches(normalized):
+        if canonical not in matched_details:
+            matched_details[canonical] = []
+        if alias_lower not in matched_details[canonical]:
+            matched_details[canonical].append(alias_lower)
 
     return matched_details
 
@@ -308,4 +396,4 @@ def match_skills_with_partial(required_skills, text, detected_skills=None):
         else:
             missing.append(req_clean)
 
-    return matched, partial, missing
+    return matched, partial, missing

--- a/backend/analyzer/tests_skill_boundaries.py
+++ b/backend/analyzer/tests_skill_boundaries.py
@@ -1,0 +1,261 @@
+"""Where a skill name starts and stops.
+
+``is_word_boundary`` treated ``-`` as a character that continues a skill token,
+which meant a hyphen on either side of a match disqualified it. Because
+``normalize_text`` deliberately *keeps* hyphens, every hyphenated mention of a
+skill extracted nothing at all::
+
+    extract_skills("Python-based microservices")  -> []
+    extract_skills("React-Redux frontends")       -> []
+    extract_skills("Docker-compose deployments")  -> []
+
+That is not a rare way to write a resume. It fed straight through
+``nlp_matcher.calculate_jd_match``, which builds its resume-skill set from
+``extract_skills``, so a resume naming five of the job's skills scored 12 and
+reported all five as missing.
+
+The tests below are in three groups:
+
+* hyphenated mentions are found (the bug),
+* the false positives the old rule was protecting against are still rejected
+  (``c`` in ``c++``, ``react`` in ``reactive``, ``java`` in ``javascript``),
+* hyphenated *skill names* — objective-c, react-native, scikit-learn — still
+  resolve to themselves and do not also emit the fragments now visible inside
+  them.
+
+The third group is the one that makes the fix non-trivial: once a hyphen is a
+boundary, "Objective-C" contains a perfectly well-bounded "c".
+"""
+
+from django.test import SimpleTestCase
+
+from .nlp_matcher import calculate_jd_match
+from .skill_matcher import (
+    _longest_matches,
+    extract_skills,
+    extract_skills_detailed,
+    is_word_boundary,
+    is_word_in_text,
+    normalize_text,
+)
+
+
+class HyphenatedMentionTests(SimpleTestCase):
+    """A hyphen joins two words. It does not make them one word."""
+
+    def assert_extracts(self, text, expected):
+        self.assertIn(
+            expected,
+            extract_skills(text),
+            f"{expected!r} not extracted from {text!r}",
+        )
+
+    def test_skill_used_as_a_compound_adjective(self):
+        for text, skill in [
+            ("Built Python-based microservices", "python"),
+            ("Java-based backend services", "java"),
+            ("Docker-compose deployments", "docker"),
+            ("Kubernetes-managed clusters", "kubernetes"),
+            ("Terraform-managed infrastructure", "terraform"),
+            ("AWS-hosted workloads", "amazon web services"),
+            ("SQL-heavy reporting pipelines", "sql"),
+        ]:
+            with self.subTest(text=text):
+                self.assert_extracts(text, skill)
+
+    def test_skill_after_a_hyphen(self):
+        for text, skill in [
+            ("Full-stack React work", "react"),
+            ("in-house Python tooling", "python"),
+            ("Cross-team Kubernetes rollout", "kubernetes"),
+        ]:
+            with self.subTest(text=text):
+                self.assert_extracts(text, skill)
+
+    def test_two_skills_hyphenated_together(self):
+        found = extract_skills("React-Redux frontends")
+        self.assertIn("react", found)
+        self.assertIn("redux", found)
+
+    def test_skill_followed_by_a_hyphenated_version(self):
+        self.assert_extracts("Java-8 experience", "java")
+        self.assert_extracts("Python-3 scripts", "python")
+
+    def test_hyphen_used_to_join_a_multi_word_skill_name(self):
+        """The dictionary carries the spaced form; people write the hyphen."""
+        for text, skill in [
+            ("machine-learning pipelines", "machine learning"),
+            ("deep-learning research", "deep learning"),
+            ("data-science team", "data science"),
+            ("node-js backend", "node.js"),
+        ]:
+            with self.subTest(text=text):
+                self.assert_extracts(text, skill)
+
+
+class BoundaryRegressionTests(SimpleTestCase):
+    """What the old rule was actually protecting. None of it should change."""
+
+    def test_c_is_not_found_inside_c_plus_plus_or_c_sharp(self):
+        self.assertEqual(extract_skills("C++ and C# developer"), ["c++", "c#"])
+        self.assertNotIn("c", extract_skills("C++ developer"))
+        self.assertNotIn("c", extract_skills("C# developer"))
+
+    def test_c_on_its_own_is_still_found(self):
+        self.assertIn("c", extract_skills("Systems programming in C and assembly"))
+
+    def test_react_is_not_found_inside_reactive(self):
+        self.assertNotIn("react", extract_skills("reactive programming"))
+
+    def test_java_is_not_found_inside_javascript(self):
+        found = extract_skills("JavaScript developer")
+        self.assertIn("javascript", found)
+        self.assertNotIn("java", found)
+
+    def test_dotted_names_resolve_to_their_canonical_skill(self):
+        found = extract_skills("node.js and react.js")
+        self.assertIn("node.js", found)
+        self.assertIn("react", found)
+
+    def test_underscore_still_continues_a_token(self):
+        self.assertNotIn("react", extract_skills("my_react_helper"))
+
+    def test_plain_mentions_are_unaffected(self):
+        self.assertEqual(
+            extract_skills("Python, Java, React, Docker"),
+            ["python", "java", "react", "docker"],
+        )
+
+
+class HyphenatedSkillNameTests(SimpleTestCase):
+    """Skills whose own name contains a hyphen.
+
+    Once ``-`` is a boundary, "objective-c" contains a well-bounded "c" and
+    "react-native" contains a well-bounded "react". Longest match wins.
+    """
+
+    def test_objective_c_does_not_also_report_c(self):
+        found = extract_skills("Objective-C developer")
+        self.assertEqual(found, ["objective-c"])
+
+    def test_react_native_does_not_also_report_react(self):
+        found = extract_skills("React-Native app")
+        self.assertEqual(found, ["react native"])
+
+    def test_scikit_learn_stays_whole(self):
+        self.assertEqual(extract_skills("scikit-learn models"), ["scikit-learn"])
+
+    def test_react_and_react_native_both_appear_when_both_are_mentioned(self):
+        found = extract_skills("React on the web and React-Native on mobile")
+        self.assertIn("react", found)
+        self.assertIn("react native", found)
+
+
+class LongestMatchTests(SimpleTestCase):
+    """The overlap rule on its own, without the dictionary in the way."""
+
+    def test_nested_span_is_dropped(self):
+        spans = [(0, 11, "objective-c", "objective-c"), (10, 11, "c", "c")]
+        self.assertEqual(_longest_matches(spans), [(0, 11, "objective-c", "objective-c")])
+
+    def test_disjoint_spans_are_both_kept(self):
+        spans = [(0, 6, "python", "python"), (11, 15, "java", "java")]
+        self.assertEqual(len(_longest_matches(spans)), 2)
+
+    def test_partial_overlap_keeps_both(self):
+        # Not nesting: neither span contains the other.
+        spans = [(0, 5, "aaaaa", "a"), (3, 9, "aaaaaa", "b")]
+        self.assertEqual(len(_longest_matches(spans)), 2)
+
+    def test_identical_spans_keep_the_first(self):
+        spans = [(0, 4, "java", "java"), (0, 4, "java", "other")]
+        kept = _longest_matches(spans)
+        self.assertEqual(len(kept), 1)
+
+    def test_input_order_does_not_matter(self):
+        forwards = [(0, 11, "objective-c", "objective-c"), (10, 11, "c", "c")]
+        backwards = list(reversed(forwards))
+        self.assertEqual(_longest_matches(forwards), _longest_matches(backwards))
+
+    def test_empty_input(self):
+        self.assertEqual(_longest_matches([]), [])
+
+
+class BoundaryHelperAgreementTests(SimpleTestCase):
+    """The two boundary checks in this module used to disagree.
+
+    ``is_word_in_text`` guards with ``(?<!\\w)…(?!\\w)``, and ``\\w`` does not
+    include ``-``, so it has always treated a hyphen as a boundary.
+    ``is_word_boundary`` did not. ``match_skills_with_partial`` calls both, so
+    whether a hyphenated mention counted depended on which branch it reached.
+    """
+
+    def test_both_helpers_agree_that_a_hyphen_ends_a_word(self):
+        text = normalize_text("Python-based work")
+        start = text.index("python")
+
+        self.assertTrue(is_word_in_text("python", text))
+        self.assertTrue(is_word_boundary(text, start, start + len("python")))
+
+    def test_both_helpers_agree_that_a_letter_does_not(self):
+        text = normalize_text("reactive programming")
+        start = text.index("react")
+
+        self.assertFalse(is_word_in_text("react", text))
+        self.assertFalse(is_word_boundary(text, start, start + len("react")))
+
+
+class DetailedExtractionTests(SimpleTestCase):
+    """``extract_skills_detailed`` feeds the partial-match logic."""
+
+    def test_records_the_alias_that_matched(self):
+        details = extract_skills_detailed("Python-based services")
+        self.assertIn("python", details)
+        self.assertIn("python", details["python"])
+
+    def test_does_not_record_a_fragment_of_a_hyphenated_name(self):
+        details = extract_skills_detailed("Objective-C developer")
+        self.assertNotIn("c", details)
+        self.assertIn("objective-c", details)
+
+
+class JobDescriptionMatchTests(SimpleTestCase):
+    """The user-visible consequence.
+
+    ``calculate_jd_match`` builds its resume-skill set from ``extract_skills``,
+    so the hyphen bug turned every one of these into a missing skill.
+    """
+
+    JD = "We need Python, Java, React, Docker and Kubernetes experience."
+
+    HYPHENATED = (
+        "Built Python-based and Java-based microservices, React-Redux "
+        "frontends, Docker-compose deployments and Kubernetes-managed clusters."
+    )
+    PLAIN = (
+        "Built Python and Java microservices, React frontends, Docker "
+        "deployments and Kubernetes clusters."
+    )
+
+    def test_hyphenated_resume_no_longer_reports_everything_as_missing(self):
+        score, missing, matched = calculate_jd_match(self.HYPHENATED, self.JD)
+
+        self.assertEqual(missing, [], f"still reported as missing: {missing}")
+        self.assertCountEqual(
+            matched, ["python", "java", "react", "docker", "kubernetes"]
+        )
+        self.assertGreater(score, 50)
+
+    def test_hyphenation_no_longer_decides_the_score(self):
+        """The two resumes say the same thing. They used to score 12 and 77."""
+        hyphenated, _, _ = calculate_jd_match(self.HYPHENATED, self.JD)
+        plain, _, _ = calculate_jd_match(self.PLAIN, self.JD)
+
+        # Not equal: the TF-IDF half of the score legitimately sees different
+        # tokens. The skill half — 60% of the weight — must agree.
+        self.assertLess(
+            abs(hyphenated - plain),
+            15,
+            f"hyphenated={hyphenated} plain={plain}: writing a skill with a "
+            "hyphen should not meaningfully change the match score",
+        )


### PR DESCRIPTION
## 📝 Description

`is_word_boundary` counted `-` as a character that *continues* a skill token, and `normalize_text` deliberately keeps hyphens. So a hyphen on either side of a match disqualified it, and every hyphenated mention of a skill extracted nothing at all.

```python
>>> extract_skills('Python-based microservices')     # before
[]
>>> extract_skills('Built Python microservices')
['python']
```

Because `calculate_jd_match` builds its resume-skill set from `extract_skills`, and the skill half is 60% of the match score, two resumes saying the same thing scored very differently:

| resume | score | reported missing |
|---|---|---|
| `Python-based … Java-based … React-Redux … Docker-compose … Kubernetes-managed` | **12** | python, java, react, docker, kubernetes |
| `Python … Java … React … Docker … Kubernetes` | **77** | — |

The first names all five required skills and was told it had none of them, with every one listed back in the "skills you're missing" panel. After this change it scores 72 with nothing missing.

## 🔗 Related Issue

Closes #830

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## 🔍 What's in here

**The boundary rule.** `-` removed from the token characters; `#` and `+` kept, because without them `C` matches inside `C#` and `C++`. Worth noting that `is_word_in_text`, twelve lines below in the same module, has always disagreed — its `(?<!\w)…(?!\w)` guard treats a hyphen as a boundary, since `\w` does not include one. `match_skills_with_partial` calls both, which is why the behaviour looked inconsistent rather than uniformly broken. They agree now, and there is a test asserting that.

**`_longest_matches`.** Removing `-` from the tuple is not sufficient on its own. Three dictionary entries have a hyphen in their own name — `objective-c`, `react-native`, `scikit-learn` — and once a hyphen is a boundary, those contain well-bounded fragments. Without overlap resolution, `Objective-C` reports *Objective-C and C*, and `React-Native` reports *React Native and React*. Longest match wins, which is the usual rule: "Objective-C" names one language.

The sweep is `O(n log n)` on the number of hits, not the pairwise comparison — the input is sorted by start ascending then length descending, so a container is always visited before anything nested inside it, and a running `covered_to` is enough.

**A second scan over hyphen-flattened text.** The dictionary already carries `node js`, `machine learning`, `deep learning` and `data science` as aliases, and a hyphen is also how people join the words of a multi-word skill name. Replacing `-` with a space keeps the string the same length, so spans from both passes refer to the same offsets and go through the same overlap resolution. `machine-learning`, `deep-learning`, `data-science` and `node-js` now resolve; the hyphenated skill *names* still win on the first pass because they are longer.

**Behaviour, after:**

```
'Python-based microservices'    -> ['python']
'Full-stack React-Redux app'    -> ['react', 'redux']
'Kubernetes-managed clusters'   -> ['kubernetes']
'machine-learning pipelines'    -> ['machine learning']
'node-js backend'               -> ['node.js']
'Objective-C developer'         -> ['objective-c']        (not also 'c')
'React-Native app'              -> ['react native']       (not also 'react')
'C++ and C# developer'          -> ['c++', 'c#']          (not also 'c')
'reactive programming'          -> []
```

## 🧪 How Has This Been Tested?

- [x] Backend tests pass — **590 tests, `OK (skipped=1)`**
- [x] All 562 pre-existing tests unchanged and still passing. None had encoded the old behaviour, which is part of why this survived.
- [x] 28 new tests in `tests_skill_boundaries.py`, in four groups: hyphenated mentions are found; the false positives the old rule protected against are still rejected (`c` in `c++`, `react` in `reactive`, `java` in `javascript`, `_` still joining); hyphenated skill names stay whole; and the overlap rule tested directly, including that input order does not change its output.

## ⚠️ One thing I'd flag

`extract_skills('non-Python work')` now returns `['python']`. Negation is not something this matcher models anywhere — `"no Python experience"` has always matched too — so this is not a regression introduced here, but it is a new way to reach it. I left it alone rather than special-casing `non-`; if it is worth handling it deserves its own issue covering negation generally.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)

## 📌 Note for reviewers

`skill_matcher.py` is one of the few CRLF files in the repo. I kept it that way so the diff stays at the ~100 lines that actually changed rather than showing as a whole-file rewrite.

CI will be red on the Backend job until #827 lands — the migration conflict in #826 breaks it for every PR. I ran the suite locally with that merge migration applied to get the numbers above.
