### PR TITLE
fix: score the ATS factors against the input they claim to measure (#832)

### DIFF
--- a/backend/analyzer/scoring.py
+++ b/backend/analyzer/scoring.py
@@ -91,15 +91,67 @@ WEAK_OPENERS = (
 )
 
 EMAIL_PATTERN = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+#: A run of digits that *could* be a phone number. Every group but the first
+#: is optional-ish, so this is deliberately loose; :func:`_find_phone` decides.
 PHONE_PATTERN = re.compile(
-    r"(?:\+\d{1,3}[\s.-]?)?(?:\(\d{2,4}\)[\s.-]?)?\d{3,5}[\s.-]?\d{3,4}[\s.-]?\d{0,4}"
+    r"(?:\+\d{1,3}[\s.\-–—]?)?(?:\(\d{2,4}\)[\s.\-–—]?)?"
+    r"\d{2,5}(?:[\s.\-–—]?\d{2,4}){1,3}"
 )
+
+#: Two four-digit years joined by a dash or slash — "2019-2023", "1998 – 2002".
+#:
+#: The old pattern matched these and counted them as a phone number. It is
+#: searched against the first fifteen lines of the resume, which is exactly
+#: where a graduation year range lives, so a resume with no phone number at all
+#: was awarded the points for having one and told "Found: email address, phone
+#: number" — so the person never added the number the ATS is actually keying on.
+YEAR_RANGE_PATTERN = re.compile(
+    r"^(?:19|20)\d{2}\s*[-–—/]\s*(?:(?:19|20)\d{2}|present|current|now)$",
+    re.IGNORECASE,
+)
+
+#: E.164 allows at most 15 digits. Seven is the shortest real subscriber number.
+PHONE_DIGIT_RANGE = (7, 15)
+
+
+def _find_phone(text: str) -> Optional[str]:
+    """The first digit run in ``text`` that plausibly is a phone number.
+
+    Length alone does not separate a phone number from a year range —
+    "2019-2023" is eight digits — so the year-range shape is rejected
+    explicitly rather than by counting.
+    """
+    low, high = PHONE_DIGIT_RANGE
+
+    for match in PHONE_PATTERN.finditer(text):
+        candidate = match.group(0).strip()
+
+        digits = re.sub(r"\D", "", candidate)
+        if not low <= len(digits) <= high:
+            continue
+
+        if YEAR_RANGE_PATTERN.match(candidate):
+            continue
+
+        return candidate
+
+    return None
 PROFILE_LINK_PATTERN = re.compile(
     r"(linkedin\.com/\S+|github\.com/\S+|gitlab\.com/\S+|"
     r"[\w-]+\.(?:dev|io|me|com)/\S*portfolio\S*)",
     re.IGNORECASE,
 )
-BULLET_PATTERN = re.compile(r"^\s*(?:[-*•▪▸●o]|\d+[.)])\s+")
+#: Characters people actually start a bullet with.
+#:
+#: The en dash (U+2013) and em dash (U+2014) are the important additions: Word
+#: and Google Docs autoformat a leading "-" into "–", so the glyph in the file
+#: is usually not the one that was typed. Leaving them out meant the same four
+#: bullets scored 12/12 written with "-" and 0/12 written with "–", because
+#: ``score_impact_language`` strips the marker with this pattern and then reads
+#: the first word — with the dash left in place, the first word is "".
+#:
+#: ``-`` is first in the class so it is a literal rather than a range.
+BULLET_PATTERN = re.compile(r"^\s*(?:[-–—*•▪▫▸▹●○◦‣∙·]|\d+[.)])\s+")
 
 #: A resume in this word range reads as complete without being a wall of text.
 IDEAL_WORD_RANGE = (350, 900)
@@ -162,16 +214,42 @@ def _make_factor(key: str, earned: float, detail: str) -> FactorScore:
     )
 
 
-def _bullet_lines(lines: Sequence[str]) -> List[str]:
-    """Lines that read as accomplishment bullets rather than headings or contact rows."""
-    bullets = []
-    for raw in lines:
+def _bullet_line_indices(lines: Sequence[str]) -> List[int]:
+    """Indices of the lines that read as accomplishment bullets.
+
+    Indices rather than text, because ``quantify_checker`` reports its findings
+    by line index and the two have to be compared. See
+    :func:`score_quantification`.
+    """
+    indices = []
+    for index, raw in enumerate(lines):
         line = raw.strip()
         if len(line) < 25:
             continue
         if BULLET_PATTERN.match(raw) or len(line.split()) >= 6:
-            bullets.append(line)
-    return bullets
+            indices.append(index)
+    return indices
+
+
+def _bullet_lines(lines: Sequence[str]) -> List[str]:
+    """Lines that read as accomplishment bullets rather than headings or contact rows."""
+    return [lines[index].strip() for index in _bullet_line_indices(lines)]
+
+
+def _nudged_line_indices(quantify_nudges: Sequence[Dict]) -> set:
+    """Line indices from ``quantify_checker.flag_unquantified_bullets``.
+
+    Tolerant of a nudge without a usable ``line_index``: the caller may be an
+    older code path, and a missing index should cost the user nothing.
+    """
+    indices = set()
+    for nudge in quantify_nudges or []:
+        if not isinstance(nudge, dict):
+            continue
+        index = nudge.get("line_index")
+        if isinstance(index, int) and not isinstance(index, bool):
+            indices.add(index)
+    return indices
 
 
 def score_keyword_match(matched: Sequence[str], required: Sequence[str],
@@ -228,7 +306,7 @@ def score_contact_details(text: str) -> FactorScore:
     head = "\n".join(text.splitlines()[:15]) or text
 
     has_email = bool(EMAIL_PATTERN.search(text))
-    has_phone = bool(PHONE_PATTERN.search(head))
+    has_phone = _find_phone(head) is not None
     has_link = bool(PROFILE_LINK_PATTERN.search(text))
 
     present = [
@@ -312,28 +390,61 @@ def score_quantification(quantify_nudges: Sequence[Dict], lines: Sequence[str]) 
     """Points for achievements backed by a number.
 
     ``quantify_nudges`` comes from ``quantify_checker.flag_unquantified_bullets``:
-    one entry per bullet that describes an accomplishment without a metric.
-    """
-    bullets = _bullet_lines(lines)
-    unquantified = len(quantify_nudges)
+    one entry per line that describes an accomplishment without a metric.
 
-    if not bullets:
+    The two halves of this factor used to be counted over different sets of
+    lines. ``_bullet_lines`` keeps lines of 25 characters or more;
+    ``quantify_checker.is_exempt`` skips lines under 15. So the numerator was
+    ``len(bullets) - len(nudges)`` where the two counts came from different
+    populations, and the subtraction was not a count of anything.
+
+    In the worst case the sets are disjoint. A resume with three long,
+    fully-quantified bullets and three short unquantified ones scored **0/10**
+    and was told three bullets had no metric — while every bullet the factor
+    was actually looking at had one. ``max(0, ...)`` hid the negative rather
+    than surfacing it.
+
+    Both counts are now over the same set: every line that *either* check calls
+    an accomplishment bullet. That is also the set the user sees, since the
+    nudge panel lists exactly the lines ``quantify_checker`` flagged — so the
+    score and the advice beside it now describe the same lines.
+    """
+    bullet_indices = set(_bullet_line_indices(lines))
+    reported_indices = _nudged_line_indices(quantify_nudges)
+
+    # Ignore an index that does not point at a line we were given, rather than
+    # letting it inflate the denominator.
+    nudged_indices = {i for i in reported_indices if 0 <= i < len(lines)}
+
+    considered = bullet_indices | nudged_indices
+
+    if not considered:
         return _make_factor(
             "quantification",
             0,
             "No accomplishment bullets were found to check for metrics.",
         )
 
-    quantified = max(0, len(bullets) - unquantified)
-    ratio = quantified / len(bullets)
+    unquantified = len(considered & nudged_indices)
+
+    if quantify_nudges and not reported_indices:
+        # A caller that reported nudges without any line index at all. Fall
+        # back to the old count, clamped to the denominator so it cannot go
+        # negative. Note this checks `reported_indices`, not `nudged_indices`:
+        # indices that were given but point outside `lines` have already been
+        # judged and discarded, and must not re-enter through here.
+        unquantified = min(len(quantify_nudges), len(considered))
+
+    quantified = len(considered) - unquantified
+    ratio = quantified / len(considered)
     earned = ratio * WEIGHTS["quantification"]
 
     if unquantified == 0:
         detail = "Every accomplishment bullet includes a number, percentage or other metric."
     else:
         detail = (
-            f"{unquantified} accomplishment bullet(s) have no metric. Numbers make "
-            "the same work measurably more convincing."
+            f"{unquantified} of {len(considered)} accomplishment bullets have no "
+            "metric. Numbers make the same work measurably more convincing."
         )
 
     return _make_factor("quantification", earned, detail)

--- a/backend/analyzer/services.py
+++ b/backend/analyzer/services.py
@@ -559,7 +559,11 @@ def analyze_resume(file_path, target_role, file_name="resume.pdf", user_id=None,
             "skills_source": role_set.source,
         }
 
-    quantify_nudges = flag_unquantified_bullets(raw_text.split('\n'))
+    # splitlines(), not split('\n'): compute_score_breakdown splits the same
+    # text with splitlines(), and score_quantification compares the two by line
+    # index. The two disagree on a form feed (\x0c), which pdfplumber emits at
+    # a page break, and that would shift every index after the first page.
+    quantify_nudges = flag_unquantified_bullets(raw_text.splitlines())
 
     # Structural formatting & ATS-friendliness checks (#80)
     formatting_checks = check_resume_formatting(

--- a/backend/analyzer/tests_scoring_inputs.py
+++ b/backend/analyzer/tests_scoring_inputs.py
@@ -1,0 +1,334 @@
+"""Three ATS factors that were scored against the wrong input.
+
+Each of these produced a confident, specific, wrong number, with advice
+attached that contradicted the resume in front of it:
+
+* ``impact_language`` — the same four bullets scored 12/12 written with "-"
+  and 0/12 written with "–", the glyph Word and Google Docs autoformat a
+  leading hyphen into. The advice on the 0/12 was "Opening with verbs like
+  built, led or reduced reads as achievement rather than duty", on four
+  bullets opening with Built, Reduced, Led and Designed.
+
+* ``quantification`` — the numerator and denominator were counted over
+  different sets of lines, so the subtraction between them was not a count of
+  anything. A resume whose every bullet contained a metric scored 0/10.
+
+* ``contact_details`` — the phone regex matched a bare year range, and it is
+  searched against the first fifteen lines, which is where a graduation year
+  range lives. A resume with no phone number was awarded the points for having
+  one and told "Found: email address, phone number", so the person never added
+  the number an ATS actually keys on.
+"""
+
+from django.test import SimpleTestCase
+
+from resume_analyzer.quantify_checker import flag_unquantified_bullets
+
+from .scoring import (
+    _bullet_line_indices,
+    _find_phone,
+    compute_score_breakdown,
+    score_contact_details,
+    score_impact_language,
+    score_quantification,
+)
+
+
+STRONG_BULLETS = [
+    "Built a payments API serving 2M requests per day",
+    "Reduced p99 latency by 40% across three services",
+    "Led a team of five engineers through a migration",
+    "Designed the schema behind the reporting pipeline",
+]
+
+
+class BulletGlyphTests(SimpleTestCase):
+    """The score must not depend on which dash the word processor produced."""
+
+    GLYPHS = ["-", "–", "—", "*", "•", "▪", "▸", "●", "◦", "‣"]
+
+    def score_for(self, glyph):
+        lines = [f"{glyph} {bullet}" for bullet in STRONG_BULLETS]
+        return score_impact_language(lines)
+
+    def test_every_bullet_glyph_scores_the_same(self):
+        scores = {glyph: self.score_for(glyph).earned for glyph in self.GLYPHS}
+        self.assertEqual(
+            len(set(scores.values())),
+            1,
+            f"the bullet character changed the score: {scores}",
+        )
+
+    def test_en_and_em_dash_bullets_score_full_marks(self):
+        for glyph in ("–", "—"):
+            with self.subTest(glyph=glyph):
+                factor = self.score_for(glyph)
+                self.assertEqual(factor.earned, factor.possible)
+                self.assertEqual(factor.status, "strong")
+                self.assertIn("4 of 4", factor.detail)
+
+    def test_numbered_bullets_still_work(self):
+        for marker in ("1.", "2)"):
+            with self.subTest(marker=marker):
+                lines = [f"{marker} {STRONG_BULLETS[0]}"]
+                self.assertEqual(score_impact_language(lines).earned, 12)
+
+    def test_dash_bullets_are_recognised_as_bullets(self):
+        for glyph in ("-", "–", "—"):
+            with self.subTest(glyph=glyph):
+                lines = [f"{glyph} {STRONG_BULLETS[0]}"]
+                self.assertEqual(_bullet_line_indices(lines), [0])
+
+    def test_a_weak_opener_is_still_called_out(self):
+        lines = [f"– Responsible for maintaining the reporting pipeline"]
+        factor = score_impact_language(lines)
+        self.assertEqual(factor.earned, 0)
+        self.assertIn("responsible for", factor.detail)
+
+    def test_a_hyphen_inside_a_bullet_is_not_a_marker(self):
+        # Only a leading marker is stripped.
+        lines = ["Built a well-tested payments API serving 2M requests per day"]
+        self.assertEqual(score_impact_language(lines).earned, 12)
+
+
+class PhoneDetectionTests(SimpleTestCase):
+    """A year range is not a phone number."""
+
+    REAL_NUMBERS = [
+        "+44 20 7946 0958",
+        "+1 202 555 0143",
+        "(555) 123-4567",
+        "555-123-4567",
+        "555.123.4567",
+        "+91-98765-43210",
+        "9876543210",
+        "Phone: 020 7946 0958",
+    ]
+
+    NOT_NUMBERS = [
+        "BSc Computer Science 2019-2023",
+        "2019 – 2023",
+        "1998-2002",
+        "2020 - present",
+        "Class of 2019",
+        "GPA 3.85",
+        "London, UK",
+        "Jan 2020 — Mar 2022",
+        "5 years of experience",
+        "Top 10% of cohort",
+    ]
+
+    def test_finds_real_phone_numbers(self):
+        for text in self.REAL_NUMBERS:
+            with self.subTest(text=text):
+                self.assertIsNotNone(_find_phone(text))
+
+    def test_rejects_things_that_are_not_phone_numbers(self):
+        for text in self.NOT_NUMBERS:
+            with self.subTest(text=text):
+                self.assertIsNone(_find_phone(text), f"{text!r} matched as a phone")
+
+    def test_header_with_a_graduation_year_range_is_not_credited_a_phone(self):
+        head = (
+            "John Smith\n"
+            "BSc Computer Science 2019-2023\n"
+            "London, UK\n"
+            "john@example.com"
+        )
+        factor = score_contact_details(head)
+
+        self.assertNotIn("phone number.", factor.detail.split("Consider adding:")[0])
+        self.assertIn("Consider adding:", factor.detail)
+        self.assertIn("phone number", factor.detail.split("Consider adding:")[1])
+        # Email only: half of the ten points.
+        self.assertEqual(factor.earned, 5)
+
+    def test_header_with_a_real_number_is_credited(self):
+        head = "Jane Doe\n+44 20 7946 0958\njane@example.com"
+        factor = score_contact_details(head)
+
+        self.assertIn("phone number", factor.detail.split("Consider adding:")[0])
+        self.assertEqual(factor.earned, 8)
+
+    def test_a_number_too_short_to_dial_is_rejected(self):
+        self.assertIsNone(_find_phone("Room 12 34"))
+
+    def test_a_number_too_long_for_e164_is_rejected(self):
+        self.assertIsNone(_find_phone("1234 5678 9012 3456 7890"))
+
+
+class QuantificationDenominatorTests(SimpleTestCase):
+    """The numerator and the denominator have to count the same lines."""
+
+    def factor_for(self, raw):
+        lines = raw.splitlines()
+        return score_quantification(flag_unquantified_bullets(lines), lines), lines
+
+    def test_a_fully_quantified_resume_scores_full_marks(self):
+        # Every bullet here carries a metric. This scored 0/10, and reported
+        # "3 accomplishment bullet(s) have no metric".
+        raw = "\n".join(
+            [
+                "EXPERIENCE",
+                "- Built a payments API serving 2M requests per day",
+                "- Reduced p99 latency by 40% across three services",
+                "- Led a migration that cut build times by 12 minutes",
+            ]
+        )
+        factor, _ = self.factor_for(raw)
+
+        self.assertEqual(factor.earned, factor.possible)
+        self.assertEqual(factor.status, "strong")
+        self.assertIn("Every accomplishment bullet", factor.detail)
+
+    def test_short_unquantified_lines_no_longer_zero_out_long_quantified_ones(self):
+        """The disjoint case — the one that produced 0/10.
+
+        The three long bullets are what ``_bullet_lines`` scores; the three
+        short lines are what ``quantify_checker`` flags. Neither set contains
+        the other, so ``len(bullets) - len(nudges)`` was 0.
+        """
+        raw = "\n".join(
+            [
+                "EXPERIENCE",
+                "- Built a payments API serving 2M requests per day",
+                "- Reduced p99 latency by 40% across three services",
+                "- Led a migration that cut build times by 12 minutes",
+                "Managed the team",
+                "Led the redesign",
+                "Designed the schema",
+            ]
+        )
+        factor, lines = self.factor_for(raw)
+
+        self.assertEqual(len(_bullet_line_indices(lines)), 3)
+        self.assertEqual(len(flag_unquantified_bullets(lines)), 3)
+
+        # Three of six carry a metric.
+        self.assertEqual(factor.earned, 5)
+        self.assertIn("3 of 6", factor.detail)
+
+    def test_a_resume_with_no_metrics_at_all_scores_zero(self):
+        raw = "\n".join(
+            [
+                "- Managed the release process for the platform team",
+                "- Led the redesign of the checkout flow end to end",
+                "- Built the internal tooling used by the support team",
+            ]
+        )
+        factor, _ = self.factor_for(raw)
+        self.assertEqual(factor.earned, 0)
+
+    def test_a_mixed_resume_scores_in_between(self):
+        raw = "\n".join(
+            [
+                "- Built a payments API serving 2M requests per day",
+                "- Led a redesign of the checkout flow",
+                "- Managed the release process for the platform team",
+            ]
+        )
+        factor, _ = self.factor_for(raw)
+
+        self.assertGreater(factor.earned, 0)
+        self.assertLess(factor.earned, factor.possible)
+        self.assertIn("2 of 3", factor.detail)
+
+    def test_the_detail_never_names_more_bullets_than_it_counted(self):
+        """``max(0, ...)`` used to hide the mismatch instead of surfacing it."""
+        raw = "\n".join(
+            [
+                "Managed the team",
+                "Led the redesign",
+                "Designed the schema",
+                "Owned the roadmap",
+            ]
+        )
+        factor, lines = self.factor_for(raw)
+        nudges = flag_unquantified_bullets(lines)
+
+        self.assertLessEqual(len(nudges), len(lines))
+        self.assertIn(f"of {len(nudges)}", factor.detail)
+
+    def test_no_bullets_at_all(self):
+        factor = score_quantification([], ["EXPERIENCE", "Skills: Python"])
+        self.assertEqual(factor.earned, 0)
+        self.assertIn("No accomplishment bullets", factor.detail)
+
+    def test_nudges_without_a_line_index_fall_back_rather_than_going_negative(self):
+        """An older caller, or a nudge dict from somewhere else."""
+        lines = ["- Built a payments API serving 2M requests per day"]
+        factor = score_quantification(
+            [{"original_text": "x"}, {"original_text": "y"}, {"original_text": "z"}],
+            lines,
+        )
+        # Three nudges against one bullet: clamped to zero, not negative.
+        self.assertEqual(factor.earned, 0)
+
+    def test_an_out_of_range_line_index_is_ignored(self):
+        lines = ["- Built a payments API serving 2M requests per day"]
+        factor = score_quantification([{"line_index": 99}], lines)
+        self.assertEqual(factor.earned, factor.possible)
+
+
+class BreakdownIntegrationTests(SimpleTestCase):
+    """The three factors together, through the function the pipeline calls."""
+
+    RESUME = "\n".join(
+        [
+            "Jane Doe",
+            "+44 20 7946 0958",
+            "jane@example.com",
+            "linkedin.com/in/janedoe",
+            "",
+            "EXPERIENCE",
+            "– Built a payments API serving 2M requests per day",
+            "– Reduced p99 latency by 40% across three services",
+            "– Led a migration that cut build times by 12 minutes",
+            "",
+            "EDUCATION",
+            "BSc Computer Science 2019-2023",
+            "",
+            "SKILLS",
+            "Python, Django, PostgreSQL, Docker",
+        ]
+    )
+
+    def breakdown(self, text):
+        lines = text.splitlines()
+        return compute_score_breakdown(
+            text=text,
+            matched_skills=["python", "django"],
+            required_skills=["python", "django"],
+            detected_skills=["python", "django", "postgresql", "docker"],
+            quantify_nudges=flag_unquantified_bullets(lines),
+        )
+
+    def factor(self, breakdown, key):
+        return next(f for f in breakdown.factors if f.key == key)
+
+    def test_en_dash_bullets_score_the_same_as_hyphen_bullets(self):
+        en_dash = self.breakdown(self.RESUME).overall
+        hyphen = self.breakdown(self.RESUME.replace("– ", "- ")).overall
+        self.assertEqual(en_dash, hyphen)
+
+    def test_a_good_resume_scores_well_on_all_three_factors(self):
+        breakdown = self.breakdown(self.RESUME)
+
+        self.assertEqual(self.factor(breakdown, "impact_language").status, "strong")
+        self.assertEqual(self.factor(breakdown, "quantification").status, "strong")
+        self.assertEqual(self.factor(breakdown, "contact_details").status, "strong")
+
+    def test_the_graduation_year_range_does_not_stand_in_for_the_phone_number(self):
+        without_phone = self.RESUME.replace("+44 20 7946 0958\n", "")
+        breakdown = self.breakdown(without_phone)
+        contact = self.factor(breakdown, "contact_details")
+
+        self.assertLess(contact.earned, self.factor(self.breakdown(self.RESUME), "contact_details").earned)
+        self.assertIn("phone number", contact.detail.split("Consider adding:")[1])
+
+    def test_the_overall_score_still_sums_the_factors(self):
+        breakdown = self.breakdown(self.RESUME)
+        self.assertEqual(
+            breakdown.overall,
+            min(100, max(0, sum(f.earned for f in breakdown.factors))),
+        )


### PR DESCRIPTION
## 📝 Description

Three factors in `scoring.py` were computed against inputs that don't match what they claim to measure. Each produced a confident, specific number with advice attached that contradicted the resume it had just read.

## 🔗 Related Issue

Closes #832

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

---

### 1. `impact_language` — 12 points on one Unicode codepoint

`BULLET_PATTERN` had ASCII `-`, `*`, `•`, `▪`, `▸`, `●` and the letter `o`, but no `–` (U+2013) or `—` (U+2014) — which is what Word and Google Docs autoformat a typed hyphen into, so the glyph in the exported file is usually not the one the person typed.

`score_impact_language` strips the marker with that pattern and then reads the first word. With the dash left in place, `re.split(r"[^\w]+", …)` returns `""` first, so no bullet matches an action verb.

**Before**, same four bullets, only the leading character changed:

```
hyphen  '-': 12/12 strong | 4 of 4 bullets open with a strong action verb.
en dash '–':  0/12 weak   | 0 of 4 … Opening with verbs like "built", "led"
                            or "reduced" reads as achievement rather than duty.
```

on bullets opening with **Built**, **Reduced**, **Led** and **Designed**.

**After** — every glyph in `- – — * • ▪ ▸ ● ◦ ‣` scores 12/12, and there's a test asserting they all agree rather than asserting each one's value.

### 2. `quantification` — a subtraction between two different populations

```python
quantified = max(0, len(bullets) - unquantified)
```

`unquantified` is `len(quantify_nudges)`, and `quantify_checker.is_exempt` skips lines **under 15 characters**, while `_bullet_lines` keeps lines of **25 or more**. The two never agreed on what a bullet is, so that subtraction wasn't a count of anything. In the disjoint case:

```
- Built a payments API serving 2M requests per day     ← scored, has a metric
- Reduced p99 latency by 40% across three services     ← scored, has a metric
- Led a migration that cut build times by 12 minutes   ← scored, has a metric
Managed the team                                        ← nudged, not scored
Led the redesign                                        ← nudged, not scored
Designed the schema                                     ← nudged, not scored

quantification: 0/10 weak
  "3 accomplishment bullet(s) have no metric."
```

Every bullet the factor looked at had a number in it. `max(0, ...)` is what kept this from being an obvious crash — it clamped the negative and hid the mismatch.

Both counts are now over the same set: every line **either** check calls an accomplishment bullet. That's deliberately the union rather than the intersection, because it's also the set the user sees — the nudge panel lists exactly what `quantify_checker` flagged, so the score and the advice beside it now describe the same lines. The example above scores 5/10, "3 of 6".

`services.py` also switched from `raw_text.split('\n')` to `.splitlines()`, so the `line_index` joining the two counts means the same thing on both sides. They disagree on a form feed (`\x0c`), which pdfplumber emits at a page break — enough to shift every index after page one.

### 3. `contact_details` — a graduation year range counted as a phone number

```python
>>> head = "John Smith\nBSc Computer Science 2019-2023\nLondon, UK\njohn@x.com"
>>> PHONE_PATTERN.search(head)
<re.Match object; match='2019-2023\n'>
>>> score_contact_details(head)
8/10 'strong' | "Found: email address, phone number."
```

Every group but one was optional, so any 6–9 digit run with a separator matched — and `head` is the first fifteen lines, exactly where education dates live. The user is told they have a phone number, so they never add the field an ATS actually keys on.

Length can't separate these (`2019-2023` is eight digits), so `_find_phone` rejects the year-range *shape* explicitly, then bounds the digit count to 7–15 (E.164's maximum).

Checked against 20 cases:

| accepted | rejected |
|---|---|
| `+44 20 7946 0958`, `+1 202 555 0143`, `(555) 123-4567`, `555-123-4567`, `555.123.4567`, `+91-98765-43210`, `9876543210`, `Phone: 020 7946 0958` | `BSc Computer Science 2019-2023`, `2019 – 2023`, `1998-2002`, `2020 - present`, `Class of 2019`, `GPA 3.85`, `Jan 2020 — Mar 2022`, `5 years`, `Top 10%`, `London, UK` |

---

## 🧪 How Has This Been Tested?

- [x] Backend tests pass — **586 tests** across `analyzer` and `resume_analyzer`, `OK (skipped=1)`
- [x] All 562 pre-existing tests unchanged and still passing
- [x] 24 new tests in `tests_scoring_inputs.py`, including the two integration checks that matter: an en-dash resume and a hyphen resume produce the same `overall`, and the overall still sums its factors

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)

## 📌 Notes for reviewers

**The quantification denominator is a judgement call.** I used the union of the two definitions. The alternative is to score only `_bullet_lines` and ignore nudges outside it — that scores the example above 10/10 while the panel beside it lists three unquantified bullets, which reads as a contradiction. Happy to switch if you'd rather the factor stayed strictly about long-form bullets.

**Line endings.** `services.py` is one of the CRLF files in the repo; I kept it that way so its diff is the 5 lines that changed rather than a whole-file rewrite.

Backend CI will be red until #827 lands — the migration conflict in #826 breaks it for every PR. I ran the suite locally with that merge migration applied.
