### PR TITLE
fix: three ways the employment timeline read a resume wrong (#834)

### DIFF
--- a/backend/analyzer/tests_timeline_edges.py
+++ b/backend/analyzer/tests_timeline_edges.py
@@ -1,0 +1,273 @@
+"""Three gaps in the employment timeline analysis (#709 / #714).
+
+All three are mine, from the original change. Each one is quiet: the module
+returns a confident answer and nothing indicates it is wrong.
+
+* ``to date`` and ``till date`` could never match. ``_SEPARATOR`` lists ``to``
+  and ``till`` as range separators and runs before ``_PRESENT``, so by the time
+  the present-word alternation is tried the preposition is gone and only
+  ``date`` is left — which was not in the list. A resume whose only role ran
+  "Jan 2020 to date" reported *no employment dates at all*.
+
+* Only the *start* of a range was checked against the future cutoff. A typo in
+  the end year was counted in full, and ``total_months`` is what the seniority
+  cross-check reads.
+
+* Two consecutive year-only ranges always reported a twelve-month overlap,
+  because a year-only end reads as December and a year-only start reads as
+  January. That is the most common way there is to write a promotion.
+
+The existing ``tests_timeline.py`` did not catch the first one: its
+present-word loop iterates ``("Present", "current", "Now", "ongoing", "today")``
+— a hand-written list beside the real one, which happens to omit the single
+entry of ``PRESENT_WORDS`` that did not work. The test below drives off
+``PRESENT_WORDS`` itself, so a word cannot be added without being exercised.
+"""
+
+from datetime import date
+
+from django.test import SimpleTestCase
+
+from .timeline import (
+    PRESENT_WORDS,
+    _shares_only_a_boundary_year,
+    analyse,
+    extract_ranges,
+)
+
+
+TODAY = date(2024, 6, 1)
+
+
+def codes(result):
+    return [finding["code"] for finding in result.as_dict()["findings"]]
+
+
+class PresentWordTests(SimpleTestCase):
+    """Every word the module claims to understand has to actually work."""
+
+    def test_every_present_word_parses_as_a_current_role(self):
+        # The assertion tests_timeline.py should have had: driven from
+        # PRESENT_WORDS itself rather than from a list written out beside it.
+        #
+        # A dash separator, because that is the one form every present word has
+        # to work after. "to date" and "till date" additionally work with their
+        # own preposition as the separator, which is the case that was broken —
+        # covered separately below.
+        for word in PRESENT_WORDS:
+            with self.subTest(word=word):
+                ranges = extract_ranges(f"Software Engineer, Jan 2020 - {word}")
+                self.assertEqual(
+                    len(ranges), 1, f"{word!r} did not parse as a range end"
+                )
+                self.assertTrue(ranges[0].is_current)
+                self.assertEqual(ranges[0].end_format, "present")
+
+    def test_to_date_and_till_date(self):
+        for text in ("Engineer Jan 2020 to date", "Engineer Jan 2020 till date"):
+            with self.subTest(text=text):
+                ranges = extract_ranges(text)
+                self.assertEqual(len(ranges), 1)
+                self.assertTrue(ranges[0].is_current)
+
+    def test_to_date_after_a_dash_separator(self):
+        ranges = extract_ranges("Engineer Jan 2020 – to date")
+        self.assertEqual(len(ranges), 1)
+        self.assertTrue(ranges[0].is_current)
+
+    def test_a_resume_ending_to_date_is_not_reported_as_undated(self):
+        result = analyse(
+            "Senior Software Engineer, Acme\nJan 2020 to date\nBuilt things",
+            today=TODAY,
+        )
+
+        self.assertTrue(result.parsed)
+        self.assertNotIn("no_dates_found", codes(result))
+        self.assertTrue(result.has_current_role)
+        self.assertEqual(result.total_months, 54)
+
+    def test_longer_present_words_win_over_their_prefixes(self):
+        """Alternation must not stop at a shorter branch.
+
+        ``current`` is a prefix of ``currently``, and ``to date`` and ``today``
+        share a prefix. The trailing lookahead in RANGE_PATTERN forces a
+        backtrack today, but sorting the alternation longest-first means the
+        next word added does not have to rely on that.
+        """
+        for word in ("currently", "today", "to date"):
+            with self.subTest(word=word):
+                ranges = extract_ranges(f"Engineer Jan 2020 - {word}")
+                self.assertEqual(len(ranges), 1)
+                self.assertTrue(
+                    ranges[0].text.strip().endswith(word),
+                    f"{ranges[0].text.strip()!r} did not consume all of {word!r}",
+                )
+
+
+class FutureEndDateTests(SimpleTestCase):
+    """A typo in the end year invented years of experience."""
+
+    def test_a_future_end_year_is_flagged(self):
+        result = analyse(
+            "Backend Engineer\nJan 2020 - Dec 2029\nBuilt things", today=TODAY
+        )
+        self.assertIn("future_end_date", codes(result))
+
+    def test_a_future_end_year_is_not_counted_as_experience(self):
+        # Before: total_years 10.0, findings [].
+        result = analyse(
+            "Backend Engineer\nJan 2020 - Dec 2029\nBuilt things", today=TODAY
+        )
+        self.assertEqual(result.total_months, 0)
+        self.assertEqual(result.total_years, 0.0)
+
+    def test_a_far_future_end_year_is_flagged(self):
+        # _YEAR accepts 21xx, so this parses cleanly.
+        result = analyse("Engineer\n2015 - 2099\nThings", today=TODAY)
+        self.assertIn("future_end_date", codes(result))
+
+    def test_a_current_role_is_not_a_future_end_date(self):
+        result = analyse("Engineer\nJan 2020 - Present\nThings", today=TODAY)
+        self.assertNotIn("future_end_date", codes(result))
+
+    def test_an_end_inside_the_tolerance_window_is_accepted(self):
+        # FUTURE_TOLERANCE_MONTHS is 3: a notice period is not a typo.
+        result = analyse("Engineer\nJan 2020 - Aug 2024\nThings", today=TODAY)
+        self.assertNotIn("future_end_date", codes(result))
+        self.assertGreater(result.total_months, 0)
+
+    def test_a_past_end_is_untouched(self):
+        result = analyse("Engineer\nJan 2020 - Mar 2022\nThings", today=TODAY)
+        self.assertNotIn("future_end_date", codes(result))
+        self.assertEqual(result.total_months, 27)
+
+    def test_a_future_start_is_still_flagged_separately(self):
+        result = analyse("Engineer\nJan 2030 - Dec 2032\nThings", today=TODAY)
+        self.assertIn("future_date", codes(result))
+
+
+class BoundaryYearOverlapTests(SimpleTestCase):
+    """A shared year between two year-only ranges is precision, not an overlap."""
+
+    def test_consecutive_year_only_roles_do_not_report_an_overlap(self):
+        result = analyse(
+            "Junior Developer\n2019 - 2021\nSenior Developer\n2021 - 2023",
+            today=TODAY,
+        )
+        self.assertNotIn("overlapping_roles", codes(result))
+
+    def test_the_total_agrees_with_the_findings(self):
+        """merged_months always said 60. The finding claimed a year on top."""
+        result = analyse(
+            "Junior Developer\n2019 - 2021\nSenior Developer\n2021 - 2023",
+            today=TODAY,
+        )
+        self.assertEqual(result.total_months, 60)
+        self.assertEqual(result.total_years, 5.0)
+
+    def test_a_genuine_year_only_overlap_is_still_reported(self):
+        result = analyse(
+            "Contractor\n2018 - 2021\nStaff Engineer\n2020 - 2023", today=TODAY
+        )
+        self.assertIn("overlapping_roles", codes(result))
+
+    def test_mixed_precision_is_deliberately_still_reported(self):
+        # "Jan 2018 - Dec 2021" really does cover all of 2021, so an overlap of
+        # somewhere between one and twelve months is real. Narrowing the rule to
+        # both-year-only keeps this signal.
+        result = analyse(
+            "Engineer\nJan 2018 - Dec 2021\nLead\n2021 - 2023", today=TODAY
+        )
+        self.assertIn("overlapping_roles", codes(result))
+
+    def test_a_month_precise_overlap_is_still_reported(self):
+        result = analyse(
+            "Engineer\nJan 2019 - Dec 2021\nLead\nMar 2021 - Dec 2023", today=TODAY
+        )
+        self.assertIn("overlapping_roles", codes(result))
+
+    def test_year_only_ranges_that_do_not_touch_report_a_gap_not_an_overlap(self):
+        result = analyse(
+            "Engineer\n2016 - 2018\nLead\n2021 - 2023", today=TODAY
+        )
+        self.assertIn("employment_gap", codes(result))
+        self.assertNotIn("overlapping_roles", codes(result))
+
+    def test_three_consecutive_year_only_roles(self):
+        result = analyse(
+            "Junior\n2017 - 2019\nMid\n2019 - 2021\nSenior\n2021 - 2023",
+            today=TODAY,
+        )
+        self.assertNotIn("overlapping_roles", codes(result))
+        self.assertNotIn("employment_gap", codes(result))
+        self.assertEqual(result.total_months, 84)
+
+
+class BoundaryYearHelperTests(SimpleTestCase):
+    """The predicate on its own."""
+
+    def make(self, start_year, end_year, start_format, end_format, is_current=False):
+        from .timeline import DateRange
+
+        return DateRange(
+            start_year=start_year,
+            start_month=None,
+            end_year=end_year,
+            end_month=None,
+            is_current=is_current,
+            start_format=start_format,
+            end_format=end_format,
+            text=f"{start_year} - {end_year}",
+        )
+
+    def test_both_year_only_sharing_a_year(self):
+        earlier = self.make(2019, 2021, "year-only", "year-only")
+        later = self.make(2021, 2023, "year-only", "year-only")
+        self.assertTrue(_shares_only_a_boundary_year(earlier, later))
+
+    def test_different_years(self):
+        earlier = self.make(2019, 2020, "year-only", "year-only")
+        later = self.make(2021, 2023, "year-only", "year-only")
+        self.assertFalse(_shares_only_a_boundary_year(earlier, later))
+
+    def test_month_precise_end(self):
+        earlier = self.make(2018, 2021, "month-name", "month-name")
+        later = self.make(2021, 2023, "year-only", "year-only")
+        self.assertFalse(_shares_only_a_boundary_year(earlier, later))
+
+    def test_month_precise_start(self):
+        earlier = self.make(2019, 2021, "year-only", "year-only")
+        later = self.make(2021, 2023, "month-name", "year-only")
+        self.assertFalse(_shares_only_a_boundary_year(earlier, later))
+
+    def test_a_current_earlier_role_is_never_a_boundary_join(self):
+        earlier = self.make(2019, None, "year-only", "present", is_current=True)
+        later = self.make(2021, 2023, "year-only", "year-only")
+        self.assertFalse(_shares_only_a_boundary_year(earlier, later))
+
+
+class UnchangedBehaviourTests(SimpleTestCase):
+    """Spot checks that the ordinary cases still read the same."""
+
+    def test_a_clean_two_role_history(self):
+        result = analyse(
+            "Engineer\nJan 2020 - Mar 2022\nLead\nApr 2022 - Present", today=TODAY
+        )
+        self.assertEqual(codes(result), [])
+        self.assertTrue(result.has_current_role)
+        self.assertEqual(result.total_months, 54)
+
+    def test_a_reversed_range_is_still_flagged(self):
+        result = analyse("Engineer\nDec 2022 - Jan 2020\nThings", today=TODAY)
+        self.assertIn("reversed_range", codes(result))
+
+    def test_a_real_gap_is_still_flagged(self):
+        result = analyse(
+            "Engineer\nJan 2018 - Mar 2019\nLead\nJan 2021 - Mar 2022", today=TODAY
+        )
+        self.assertIn("employment_gap", codes(result))
+
+    def test_a_resume_with_no_dates_still_says_so(self):
+        result = analyse("Software Engineer\nBuilt some things", today=TODAY)
+        self.assertFalse(result.parsed)
+        self.assertIn("no_dates_found", codes(result))

--- a/backend/analyzer/timeline.py
+++ b/backend/analyzer/timeline.py
@@ -79,9 +79,29 @@ MONTHS = {
     "dec": 12, "december": 12,
 }
 
-#: Words that mean "still there". ``to date`` is included because it is common
-#: and is otherwise parsed as a stray preposition.
-PRESENT_WORDS = ("present", "current", "currently", "now", "ongoing", "to date", "today")
+#: Words that mean "still there".
+#:
+#: ``date`` is in here on its own, and that is not a mistake. ``_SEPARATOR``
+#: below lists ``to`` and ``till`` as range separators and is applied *before*
+#: this alternation, so in "Jan 2020 to date" the separator has already
+#: consumed the "to" and only "date" is left to match. Listing the full phrase
+#: alone meant it could never match, and a resume whose only role ended "to
+#: date" parsed as having no dates at all. The phrases stay for the case where
+#: the separator was a dash — "Jan 2020 – to date".
+#:
+#: A bare "date" is only ever reached after a parsed start endpoint and a
+#: separator, so it cannot match a stray word elsewhere in the line.
+PRESENT_WORDS = (
+    "present",
+    "current",
+    "currently",
+    "now",
+    "ongoing",
+    "to date",
+    "till date",
+    "today",
+    "date",
+)
 
 #: Separators between the two ends of a range: hyphen, en dash, em dash,
 #: "to", "until", "through". Written out rather than as a character class so the
@@ -126,7 +146,15 @@ def _endpoint(prefix):
     return "(?:" + "|".join((iso, month_year, numeric, bare)) + ")"
 
 
-_PRESENT = r"(?P<present>" + "|".join(PRESENT_WORDS) + r")"
+#: Longest first. Python's alternation takes the first branch that matches, so
+#: an unsorted list lets "current" win over "currently" and "to date" over
+#: "today". The trailing lookahead in RANGE_PATTERN currently rescues those by
+#: forcing a backtrack, but relying on that is a trap for the next word added.
+_PRESENT = (
+    r"(?P<present>"
+    + "|".join(sorted(PRESENT_WORDS, key=len, reverse=True))
+    + r")"
+)
 
 RANGE_PATTERN = re.compile(
     r"(?<![\w/])"
@@ -356,6 +384,28 @@ def extract_ranges(text: str) -> List[DateRange]:
     return ranges
 
 
+def _shares_only_a_boundary_year(earlier: DateRange, later: DateRange) -> bool:
+    """Do two ranges meet at a year whose precision hides where in it they met?
+
+    Only true when *both* endpoints at the join are year-only and name the same
+    year. In that case the twelve months the arithmetic produces are an artefact
+    of the two conventions in :meth:`DateRange.end_index` and
+    :meth:`DateRange.start_index`, not something the resume claimed.
+
+    Deliberately narrow. A mixed pair — "Jan 2018 - Dec 2021" followed by
+    "2021 - 2023" — really does overlap by somewhere between one and twelve
+    months, and that is worth saying even though the exact figure is unknown.
+    Widening this rule to cover that case would suppress a real signal.
+    """
+    return (
+        not earlier.is_current
+        and earlier.end_format == "year-only"
+        and later.start_format == "year-only"
+        and earlier.end_year is not None
+        and earlier.end_year == later.start_year
+    )
+
+
 def _describe_months(months: int) -> str:
     """Render a month count the way a person would say it."""
     if months < 12:
@@ -556,6 +606,29 @@ def analyse(text, experience_level="", today=None) -> Timeline:
             )
             continue
 
+        # Only the *start* used to be checked against the cutoff. A typo in the
+        # end year sailed through and was counted in full: "Jan 2020 - Dec 2029"
+        # read on a 2024 resume reported 10.0 years of experience with no
+        # finding raised at all, and total_months is what the seniority
+        # cross-check below reads — so it would confirm a Senior claim on
+        # fabricated time. _YEAR accepts up to 21xx, so "2015 - 2099" parses
+        # cleanly too.
+        if not r.is_current and r.end_index(today) > future_cutoff:
+            findings.append(
+                Finding(
+                    code="future_end_date",
+                    severity=SEVERITY_MEDIUM,
+                    message=(
+                        f"\"{r.label()}\" ends in the future. If the role is ongoing, "
+                        "write \"Present\" rather than a future year — an end year that "
+                        "has not happened yet is usually a typo, and it silently adds "
+                        "the difference to your total experience."
+                    ),
+                    evidence=r.line or r.label(),
+                )
+            )
+            continue
+
         usable.append(r)
 
     ordered = sorted(usable, key=lambda r: (r.start_index(), r.end_index(today)))
@@ -585,6 +658,19 @@ def analyse(text, experience_level="", today=None) -> Timeline:
                 )
 
             overlap = furthest_end - current.start_index() + 1
+            if _shares_only_a_boundary_year(previous, current):
+                # Both ends are year-only and name the same year. That is not a
+                # claimed overlap, it is the precision of the dates: a year-only
+                # end reads as December (deliberately — see DateRange.end_index)
+                # and a year-only start reads as January, so "2019 - 2021" then
+                # "2021 - 2023" always produced a phantom twelve months.
+                #
+                # That is the single most common way to write a promotion, and
+                # the module's own union arithmetic disagreed with the finding:
+                # merged_months returned 60, while the finding claimed a year of
+                # overlap on top.
+                overlap -= 12
+
             if overlap >= OVERLAP_THRESHOLD_MONTHS:
                 findings.append(
                     Finding(

--- a/docs/TIMELINE.md
+++ b/docs/TIMELINE.md
@@ -16,8 +16,9 @@ filtered on its history. The analysis is returned under `timeline` alongside
 | `reversed_range` | high | A range ends before it starts |
 | `employment_gap` | medium / high | A gap of 4 months or more; high past a year |
 | `future_date` | medium | A start more than 3 months from now |
+| `future_end_date` | medium | An end more than 3 months from now on a role that is not marked current |
 | `seniority_mismatch` | medium | Total experience falls short of the selected level |
-| `overlapping_roles` | low | Two roles run concurrently for 2 months or more |
+| `overlapping_roles` | low | Two roles run concurrently for 2 months or more (see *Year-only ranges* below) |
 | `mixed_date_formats` | low | More than one date format in the document |
 | `year_only_dates` | low | A range gives years but no months |
 | `no_dates_found` | info | Nothing parseable — see below |
@@ -32,11 +33,42 @@ line can be found.
 Jan 2020 – Mar 2022      January 2020 to March 2022      Sept. 2019 - Dec. 2021
 03/2017 - 06/2019        2020-01 until 2021-11           2015 – 2016
 Jan 2020 – Present       Mar 2021 - Current              Feb 2019 - now
+Jan 2020 to date         Mar 2021 till date              Feb 2019 – to date
 ```
 
 Hyphen, double hyphen, en dash, em dash, tilde, `to`, `until`, `through` and
 `till` all separate a range. `Present`, `Current`, `Currently`, `Now`,
-`Ongoing`, `To date` and `Today` all mean an open end.
+`Ongoing`, `To date`, `Till date` and `Today` all mean an open end.
+
+`to date` and `till date` are worth a note. The separator list above already
+contains `to` and `till`, and separators are matched *before* the open-end
+words, so by the time the parser looks for one the preposition has been
+consumed and only `date` is left. `date` is therefore an open-end word in its
+own right. It is only ever reached after a parsed start and a separator, so it
+cannot match a stray word elsewhere on the line.
+
+## Year-only ranges
+
+A year-only *end* reads as December of that year and a year-only *start* reads
+as January, so that `2019 - 2021` describes work through 2021 rather than
+inventing an eleven-month gap.
+
+The two conventions are asymmetric, which means two consecutive year-only
+ranges share a whole year:
+
+```
+Junior Developer   2019 - 2021
+Senior Developer   2021 - 2023
+```
+
+That is the most common way there is to write a promotion, and it is not a
+claim of concurrent employment — the resume simply does not say where in 2021
+one ended and the next began. `overlapping_roles` is therefore not raised when
+both endpoints at the join are year-only and name the same year.
+
+It *is* still raised when either side is month-precise. `Jan 2018 - Dec 2021`
+followed by `2021 - 2023` really does describe between one and twelve months of
+overlap, and that is worth saying even though the exact figure is unknown.
 
 Ranges are matched **within a line**, never across a line break. Two-column
 resumes flatten to text in ways that would otherwise let the end of one line and


### PR DESCRIPTION
## 📝 Description

Three defects in the employment timeline analysis. All three are from my own #714, and all three are quiet — the module returns a confident answer and nothing signals that it is wrong.

## 🔗 Related Issue

Closes #834

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

---

### 1. `to date` and `till date` could never match

`_SEPARATOR` lists `to` and `till` as range separators, and `RANGE_PATTERN` applies the separator **before** the present-word alternation. So for `"Jan 2020 to date"` the separator consumes the `to` and only `date` is left — which was not in `PRESENT_WORDS`. The entry that *was* in the list, `to date`, was unreachable, and there is no backtrack path because the separator is not optional.

On a single-role resume that isn't a degraded result, it's total failure:

```python
>>> analyse('Senior Software Engineer, Acme\nJan 2020 to date\nBuilt stuff')
parsed=False
findings=[{'code': 'no_dates_found',
           'message': 'We could not read any employment dates from this resume.
                       If your roles do have dates, they may be in a layout an
                       ATS cannot parse either …'}]
```

The message tells the person their date format is unparseable and asks them to rewrite it. Their format was fine.

`date` is now an open-end word in its own right. It is only ever reached after a parsed start endpoint *and* a separator, so it cannot match a stray word elsewhere on the line. The full phrases stay for `"Jan 2020 – to date"`.

I also sorted the alternation longest-first. Today the trailing `(?![\w/])` forces the backtrack that stops `current` winning over `currently` — that works, but it's a trap for the next word someone adds.

### 2. Only the *start* of a range was checked against the future

`r.end_index(today)` was never compared to `future_cutoff`. With `today = 2024-06-01` and a one-keystroke typo:

```python
>>> analyse('Backend Engineer\nJan 2020 - Dec 2029\nBuilt stuff')
total_months=120  total_years=10.0  findings=[]
```

Ten years from a four-year-old resume, **no finding raised at all** — and `total_months` is what the seniority cross-check reads, so it would confirm a Senior claim on time that hasn't happened yet. `_YEAR` accepts `21\d{2}`, so `2015 - 2099` parsed cleanly too.

Ends are now validated the same way starts are, under their own `future_end_date` code so the two are distinguishable in the UI. The 3-month `FUTURE_TOLERANCE_MONTHS` window still applies, so a notice period isn't flagged.

### 3. Consecutive year-only roles always reported a phantom one-year overlap

`end_index` maps a year-only end to **December** (deliberate — otherwise `2019 - 2021` invents an eleven-month gap) and `start_index` maps a year-only start to **January** (also deliberate). Both are right on their own; the overlap arithmetic didn't account for them being asymmetric.

```python
>>> analyse('Junior Developer\n2019 - 2021\nSenior Developer\n2021 - 2023')
total_months=60
findings=[{'code': 'overlapping_roles',
           'message': '"2019 - 2021" and "2021 - 2023" overlap by 1 year. …'}]
```

That's the most common way there is to write a promotion, and the resume isn't claiming concurrent employment — it just doesn't say where in 2021 one ended and the next began. The module's own union arithmetic disagreed with the finding beside it: `merged_months` correctly returned 60.

**The rule is deliberately narrow** — both endpoints at the join must be year-only. `Jan 2018 - Dec 2021` followed by `2021 - 2023` really does describe between one and twelve months of overlap, and that's worth saying even though the exact figure is unknown. There's a test pinning that it's still reported.

---

## 🧪 How Has This Been Tested?

- [x] Backend tests pass — **590 tests, `OK (skipped=1)`**
- [x] All 562 pre-existing tests unchanged and still passing, `tests_timeline.py`'s 457 lines included
- [x] 28 new tests in `tests_timeline_edges.py`

The one I'd point at: `test_every_present_word_parses_as_a_current_role` iterates `PRESENT_WORDS` itself. `tests_timeline.py:73` iterates a hand-written list beside the real one — `("Present", "current", "Now", "ongoing", "today")` — which happens to omit the single entry that didn't work. That's how a documented format stayed broken through a 457-line test module.

## 📚 Docs

`docs/TIMELINE.md` documented `To date` as supported. It now describes both new behaviours, including *why* `date` is an open-end word on its own, so the next person to read that list doesn't remove it as a mistake.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)

## 📌 Note for reviewers

A range with a future end is now **dropped** from the totals, not just flagged — matching what already happens to a reversed range and a future start. That means the typo'd example reports 0 months with a finding explaining why, rather than 120 months silently. Consistent with the existing handling, but it is a behaviour change worth being deliberate about.

Backend CI will be red until #827 lands — the migration conflict in #826 breaks it for every PR. I ran the suite locally with that merge migration applied.
