### PR TITLE
docs: add PR review requirements and exception process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,16 @@ Before submitting a PR:
 - Link the related issue.
 - Update 'CHANGELOG.md' if you pull request introduces a notable feature, bug fix, enhancement, or other user-visible change.
 
+### Review Requirements
+
+All pull requests targeting the `main` branch require at least **one approving review** from a contributor before they can be merged. This ensures a human check alongside automated tests to maintain code quality.
+
+#### Exception Process for Urgent Fixes
+In genuinely urgent situations (e.g., critical production bug fixes or security patches), maintainers may bypass the review requirement. To do so, the maintainer should:
+1. Clearly state the urgency and reason for bypassing the review in the PR description.
+2. Ensure all automated tests and CI checks pass.
+3. Post-merge, ideally have another contributor review the merged changes as soon as possible.
+
 ### Updating the Changelog
 
 This project follows the **Keep a Changelog** format.


### PR DESCRIPTION
Closes #846

I have updated CONTRIBUTING.md to document the new PR review requirement (1+ approvals) and the exception process for genuinely urgent maintainer fixes.

Note for Maintainers: Since I do not have admin access to this repository, I cannot enable the branch protection rules. To fully satisfy the acceptance criteria, an admin will need to go to Settings > Rules > Rulesets, create a new branch ruleset for main, and check Require a pull request before merging with 1 approval required (adding a bypass for maintainers if needed).