### PR TITLE
ci: fail on git merge conflict markers

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -1,0 +1,55 @@
+name: CI — Check for Git merge conflict markers
+
+on:
+  pull_request:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  check-conflict-markers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine files to scan
+        run: |
+          set -euo pipefail
+          echo "Event: $GITHUB_EVENT_NAME"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+            git fetch origin "$BASE_REF" --depth=1 || true
+            git diff --name-only "origin/$BASE_REF"...HEAD > files_to_scan.txt || true
+          else
+            git diff --name-only HEAD~1..HEAD > files_to_scan.txt || true
+          fi
+
+          if [ ! -s files_to_scan.txt ]; then
+            echo "No changed files detected; scanning all tracked files."
+            git ls-files > files_to_scan.txt
+          fi
+          echo "Files to scan:"
+          sed -n '1,200p' files_to_scan.txt || true
+
+      - name: Scan for merge-conflict markers and fail fast
+        run: |
+          set -euo pipefail
+          found=0
+          while IFS= read -r file; do
+            case "$file" in
+              .git/*|node_modules/*|dist/*|build/*) continue ;;
+            esac
+            [ -f "$file" ] || continue
+            if grep -nH -e '^<<<<<<<' -e '^=======' -e '^>>>>>>>' "$file"; then
+              found=1
+            fi
+          done < files_to_scan.txt
+
+          if [ "$found" -eq 1 ]; then
+            echo "::error ::Merge conflict markers detected. Please resolve them and push again."
+            exit 1
+          fi
+          echo "No merge conflict markers found."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.4.0
+    hooks:
+      - id: detect-merge-conflict


### PR DESCRIPTION
## 📝 Description

This PR implements a CI check to prevent Git merge-conflict markers from breaking the build. 

**Technical details:**
*   **Added `.github/workflows/conflict-check.yml`**: A new GitHub Actions workflow that triggers on `push` and `pull_request`.
*   **Smart Scanning**: The workflow uses `git diff` to identify only the files changed in the PR relative to the base branch, saving time. If no changed files are detected, it safely falls back to scanning all tracked files (`git ls-files`).
*   **Grep Logic**: It iterates through the target files and uses `grep -nH -e '^<<<<<<<' -e '^=======' -e '^>>>>>>>'` to find leftover markers, which fails fast and prints the exact filename and line number.
*   **Exclusions**: Explicitly ignores `.git`, `node_modules`, `dist`, and `build` directories.
*   **Pre-commit Hook**: Added an optional `.pre-commit-config.yaml` utilizing the `detect-merge-conflict` hook from `pre-commit/pre-commit-hooks` (v5.4.0) to catch issues locally before they are even pushed.

## 🔗 Related Issue

Closes #845

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [x] Verified the `grep` logic correctly flags files containing markers and exits with a non-zero status.
- [x] Verified the `case` exclusion logic correctly skips build and dependency directories.
- [x] Validated `.github/workflows/conflict-check.yml` workflow syntax.

## 📸 Screenshots (if applicable)

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)