### PR TITLE
fix: take the analysis history with the session when it ends (#864)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -371,7 +371,15 @@ function App() {
   // }
 
   useEffect(() => {
-    if (user) fetchDbHistory()
+    if (user) {
+      fetchDbHistory()
+      return
+    }
+    // The session ended. `useAnalysisHistory` drops the entries and clears
+    // storage on its own, but the "load more" cursor lives here, and a URL
+    // pointing at page 2 of the previous account's history must not survive
+    // into the next one (#864).
+    setHistoryNextUrl(null)
   }, [user, fetchDbHistory])
 
   useEffect(() => {

--- a/frontend/src/hooks/useAnalysisHistory.test.tsx
+++ b/frontend/src/hooks/useAnalysisHistory.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useAnalysisHistory, clearStoredHistory, type AnalysisEntry } from './useAnalysisHistory'
+import { clearSession, saveSession } from '../api/session'
+
+const HISTORY_KEY = 'resume_analysis_history'
+const LAST_VIEWED_KEY = 'resume_analysis_last_viewed'
+
+const entry = (overrides: Partial<AnalysisEntry> = {}): AnalysisEntry => ({
+  id: '1',
+  timestamp: 1_000,
+  score: 85,
+  skills: ['React'],
+  suggestions: [],
+  matchedSkills: ['React'],
+  missingSkills: ['Vue'],
+  targetRole: 'Frontend Developer',
+  fileName: 'resume.pdf',
+  ...overrides,
+})
+
+const storedHistory = () => localStorage.getItem(HISTORY_KEY)
+
+const signIn = () =>
+  act(() => {
+    saveSession({ username: 'ada', token: 'access-token', refresh: 'refresh-token' })
+  })
+
+const signOut = () => act(() => clearSession())
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+})
+
+describe('useAnalysisHistory sign-out (#864)', () => {
+  it('wipes stored history when the session ends', () => {
+    signIn()
+    const { result } = renderHook(() => useAnalysisHistory())
+
+    act(() => {
+      result.current.setEntries([entry(), entry({ id: '2', fileName: 'resume-v2.pdf' })])
+    })
+    act(() => result.current.markAllAsViewed())
+
+    expect(storedHistory()).toContain('resume-v2.pdf')
+    expect(localStorage.getItem(LAST_VIEWED_KEY)).not.toBeNull()
+
+    signOut()
+
+    // The claim that matters is about storage, not about state: this is the
+    // data that outlived the session and was shown to the next person.
+    expect(storedHistory()).toBeNull()
+    expect(localStorage.getItem(LAST_VIEWED_KEY)).toBeNull()
+    expect(result.current.entries).toEqual([])
+  })
+
+  it('does not restore the previous account on the next mount', () => {
+    signIn()
+    const first = renderHook(() => useAnalysisHistory())
+    act(() => first.result.current.setEntries([entry({ fileName: 'confidential.pdf' })]))
+    expect(storedHistory()).toContain('confidential.pdf')
+
+    signOut()
+    first.unmount()
+
+    const second = renderHook(() => useAnalysisHistory())
+    expect(second.result.current.entries).toEqual([])
+  })
+
+  it('leaves a never-signed-in visitor alone', () => {
+    // No session was ever saved, so nothing about a null session is a
+    // transition. A guest's locally held history is theirs.
+    const { result } = renderHook(() => useAnalysisHistory())
+
+    act(() => result.current.setEntries([entry({ fileName: 'guest.pdf' })]))
+    expect(storedHistory()).toContain('guest.pdf')
+
+    signOut()
+
+    expect(storedHistory()).toContain('guest.pdf')
+    expect(result.current.entries).toHaveLength(1)
+  })
+
+  it('clears again when a second session ends', () => {
+    signIn()
+    const { result } = renderHook(() => useAnalysisHistory())
+    act(() => result.current.setEntries([entry({ fileName: 'first.pdf' })]))
+    signOut()
+
+    signIn()
+    act(() => result.current.setEntries([entry({ fileName: 'second.pdf' })]))
+    expect(storedHistory()).toContain('second.pdf')
+
+    signOut()
+    expect(storedHistory()).toBeNull()
+  })
+
+  it('treats an expired session the same as an explicit sign-out', () => {
+    // The axios interceptor calls clearSession() itself when a refresh fails,
+    // which never touches the Logout button. Subscribing to the session rather
+    // than to a logout callback is what makes both paths the same path.
+    signIn()
+    const { result } = renderHook(() => useAnalysisHistory())
+    act(() => result.current.setEntries([entry({ fileName: 'expired.pdf' })]))
+
+    act(() => clearSession())
+
+    expect(storedHistory()).toBeNull()
+    expect(result.current.entries).toEqual([])
+  })
+})
+
+describe('useAnalysisHistory storage hygiene', () => {
+  it('removes the key rather than storing an empty array', () => {
+    const { result } = renderHook(() => useAnalysisHistory())
+
+    act(() => result.current.setEntries([entry()]))
+    expect(storedHistory()).not.toBeNull()
+
+    act(() => result.current.clearHistory())
+    expect(storedHistory()).toBeNull()
+  })
+
+  it('clearStoredHistory removes both keys', () => {
+    localStorage.setItem(HISTORY_KEY, '[]')
+    localStorage.setItem(LAST_VIEWED_KEY, '123')
+
+    clearStoredHistory()
+
+    expect(localStorage.getItem(HISTORY_KEY)).toBeNull()
+    expect(localStorage.getItem(LAST_VIEWED_KEY)).toBeNull()
+  })
+
+  it('survives storage being unavailable', () => {
+    const setItem = Storage.prototype.setItem
+    const removeItem = Storage.prototype.removeItem
+    Storage.prototype.setItem = () => {
+      throw new Error('denied')
+    }
+    Storage.prototype.removeItem = () => {
+      throw new Error('denied')
+    }
+
+    try {
+      expect(() => clearStoredHistory()).not.toThrow()
+    } finally {
+      Storage.prototype.setItem = setItem
+      Storage.prototype.removeItem = removeItem
+    }
+  })
+})

--- a/frontend/src/hooks/useAnalysisHistory.ts
+++ b/frontend/src/hooks/useAnalysisHistory.ts
@@ -1,4 +1,6 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+import { loadSession, subscribeToSession } from '../api/session'
 
 export interface PartialSkillItem {
   skill: string
@@ -42,9 +44,34 @@ function loadHistory(): AnalysisEntry[] {
 
 function saveHistory(entries: AnalysisEntry[]): void {
   try {
+    if (entries.length === 0) {
+      // Remove the key rather than writing `[]`. An empty array is not a leak,
+      // but leaving the key behind means "signed out and cleared" and "never
+      // used this browser" look different in storage for no reason, and it is
+      // one more thing for the next reader to wonder about.
+      localStorage.removeItem(STORAGE_KEY)
+      return
+    }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
   } catch {
     // localStorage may be unavailable in restricted modes
+  }
+}
+
+/**
+ * Remove every trace of the browser-local history.
+ *
+ * Exported because signing out has to be able to do this even from code that
+ * is not rendering the hook, and because it is the thing worth asserting on in
+ * a test — the observable claim is "storage is empty", not "some state
+ * variable was reset".
+ */
+export function clearStoredHistory(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+    localStorage.removeItem(LAST_VIEWED_KEY)
+  } catch {
+    // Nothing to clean up if storage was never reachable.
   }
 }
 
@@ -75,6 +102,51 @@ export function useAnalysisHistory() {
   useEffect(() => {
     saveHistory(entries)
   }, [entries])
+
+  /**
+   * Drop the history from memory and from storage.
+   *
+   * Both halves matter. Clearing storage alone leaves the sidebar rendering
+   * the rows until the page is reloaded; clearing state alone lets the mirror
+   * effect below write them straight back.
+   */
+  const resetHistory = useCallback(() => {
+    setEntries([])
+    setLastViewedTimestamp(0)
+    clearStoredHistory()
+  }, [])
+
+  /**
+   * Signing out has to take the history with it.
+   *
+   * `App` fills `entries` from `/api/history/` for a signed-in user, and the
+   * effect above mirrors whatever is in `entries` into localStorage so the
+   * sidebar renders instantly on the next load. That is fine while the account
+   * is signed in and not fine afterwards: `clearSession()` only removes the
+   * `auth_user` key, so the previous account's file names, scores, target
+   * roles and skill lists stayed in the browser and were rendered to whoever
+   * opened the app next (#864).
+   *
+   * Subscribing to the session rather than taking an `onLogout` callback
+   * covers the other way a session ends: the axios interceptor calls
+   * `clearSession()` itself when a token refresh fails, and that path never
+   * goes near the Logout button.
+   *
+   * The transition is what triggers the reset, not the absence of a session.
+   * A visitor who has never signed in is signed out too, and their locally
+   * held history is theirs to keep.
+   */
+  const hadSessionRef = useRef(loadSession() !== null)
+
+  useEffect(() => {
+    return subscribeToSession((session) => {
+      const hasSession = session !== null
+      if (hadSessionRef.current && !hasSession) {
+        resetHistory()
+      }
+      hadSessionRef.current = hasSession
+    })
+  }, [resetHistory])
 
   const markAllAsViewed = useCallback(() => {
     const now = Date.now()
@@ -116,6 +188,7 @@ export function useAnalysisHistory() {
     addEntry,
     deleteEntry,
     clearHistory,
+    resetHistory,
     setEntries,
   }
 }


### PR DESCRIPTION
Closes #864.

## The bug

Sign in, analyse a resume, sign out, reload the page, open the History sidebar. The previous account's file names, ATS scores, target roles and matched/missing skill lists are all still there, and `localStorage.getItem('resume_analysis_history')` still returns them. On a shared or public machine that is somebody's employment history left behind for whoever uses the browser next.

## Why

The write side is deliberate and fine on its own. `useAnalysisHistory` mirrors `entries` into storage so the sidebar renders instantly on the next load:

```ts
useEffect(() => {
  saveHistory(entries)
}, [entries])
```

and `App` fills `entries` from the server for a signed-in user:

```ts
const res = await api.get(`/api/history/?page=1&page_size=${HISTORY_PAGE_SIZE}`)
setEntries(toAnalysisEntries(res.data))
```

The missing half is the teardown. Signing out calls `clearSession()`, which removes exactly one key:

```ts
export function clearSession(): void {
  saveSession(null)   // removes 'auth_user'
}
```

Nothing touched `resume_analysis_history` or `resume_analysis_last_viewed`, and nothing reset the in-memory `entries` — so the sidebar kept rendering the rows for the life of the page, and `loadHistory()` restored them on every load after that.

## What this changes

**The hook subscribes to the session.** When a session that existed goes away, it drops `entries`, resets the last-viewed marker and removes both storage keys.

Subscribing rather than taking an `onLogout` callback is the point of the design, not an implementation detail: the axios interceptor calls `clearSession()` itself when a token refresh fails, and that path never goes near the Logout button. Both ways a session ends are now the same code path.

**It reacts to the transition, not to the absence of a session.** A visitor who has never signed in is also signed out, and their locally held history is theirs to keep — so `hadSessionRef` gates the reset on having had one.

**`saveHistory` removes the key instead of writing `[]`.** An empty array is not a leak, but "signed out and cleared" and "never used this browser" reading differently in storage is one more thing for the next person to have to work out. This also means `clearHistory()` leaves nothing behind.

**`App` resets `historyNextUrl` when the user goes away.** The pagination cursor lives in `App` rather than in the hook, and a URL pointing at page 2 of the previous account's history must not survive into the next session.

## Tests

Eight, in a new `useAnalysisHistory.test.tsx`. They assert on **storage**, not on state — the data that outlived the session is the thing that mattered:

- history and last-viewed are gone after sign-out, and `entries` is empty
- a fresh mount after sign-out does not restore the previous account
- a never-signed-in visitor's history is untouched by a `clearSession()`
- it works again on a second sign-in/sign-out cycle
- an expired session behaves identically to an explicit sign-out
- `clearHistory()` removes the key rather than storing `[]`
- `clearStoredHistory()` removes both keys
- nothing throws when storage is unavailable

Four of them fail with the subscription disabled:

```
× wipes stored history when the session ends
× does not restore the previous account on the next mount
× clears again when a second session ends
× treats an expired session the same as an explicit sign-out
```

## Verification

```
$ npm run test
 Test Files  1 failed | 57 passed (58)
      Tests  1 failed | 305 passed (306)
```

The single failure is pre-existing and unrelated — `CompareVersions > lets the user pick two saved uploads to diff`, which is #863 and is fixed in #868. It is red on `main` today.
