### PR TITLE
feat: let a public score badge be switched off and rotated (#865)

### DIFF
--- a/backend/analyzer/badge_serializers.py
+++ b/backend/analyzer/badge_serializers.py
@@ -1,0 +1,51 @@
+"""Request validation for the badge management endpoint.
+
+``manage_resume_badge`` was registered for ``["GET", "POST"]`` and ran the same
+three lines for both, never reading ``request.data``. Adding the two things it
+was missing -- turning the badge off, and issuing a new URL -- means reading a
+body for the first time, and that is worth doing through a serializer rather
+than ``request.data.get(...)``:
+
+* ``request.data.get("enabled")`` returns the string ``"false"`` for a form
+  post and the boolean ``False`` for JSON. ``BooleanField`` normalises both,
+  and rejects ``"maybe"`` with a 400 instead of quietly treating it as truthy.
+* A caller who typos ``enable`` should be told, not silently ignored. The badge
+  is a public URL; "I turned it off and it stayed on" is the one outcome this
+  endpoint must not have.
+"""
+
+from rest_framework import serializers
+
+
+class ResumeBadgeUpdateSerializer(serializers.Serializer):
+    """Body of ``POST /api/badge/``.
+
+    Both fields are optional and independent. ``{"rotate": true}`` re-issues
+    the URL without changing whether the badge is on;
+    ``{"enabled": false, "rotate": true}`` turns it off *and* invalidates the
+    old URL, which is what someone who has just realised where they pasted it
+    actually wants.
+    """
+
+    enabled = serializers.BooleanField(required=False)
+    rotate = serializers.BooleanField(required=False, default=False)
+
+    def validate(self, attrs):
+        if "enabled" not in attrs and not attrs.get("rotate"):
+            raise serializers.ValidationError(
+                "Send `enabled` to turn the badge on or off, `rotate` to issue a "
+                "new URL, or both. An empty body would be a no-op, and a no-op "
+                "that returns 200 reads like it worked."
+            )
+        return attrs
+
+    def unknown_fields(self):
+        """Field names in the request that this serializer does not define.
+
+        ``serializers.Serializer`` ignores extras rather than rejecting them,
+        and for this endpoint being ignored is the dangerous outcome -- see the
+        module docstring. The view turns a non-empty result into a 400.
+        """
+        if not isinstance(self.initial_data, dict):
+            return []
+        return sorted(set(self.initial_data) - set(self.fields))

--- a/backend/analyzer/badge_views.py
+++ b/backend/analyzer/badge_views.py
@@ -1,5 +1,7 @@
 """API endpoints for managing and publicly rendering a user's score badge."""
 
+import uuid
+
 from django.http import HttpResponse
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -8,6 +10,7 @@ from rest_framework.response import Response
 
 from .badge import generate_score_badge
 from .badge_models import ResumeBadge
+from .badge_serializers import ResumeBadgeUpdateSerializer
 from .models import ResumeAnalysis
 
 
@@ -22,20 +25,88 @@ def _latest_analysis(user):
 
 
 def _badge_payload(request, badge):
+    """What the client needs to render the badge panel.
+
+    ``badge_url`` and ``markdown`` are returned whether or not the badge is
+    enabled, which is the opposite of what ``ShareStateSerializer`` does with
+    ``share_url``. The two cases are genuinely different: a revoked share link
+    is dead and copying it would be pointless, whereas a disabled badge keeps
+    the same URL and starts working again the moment it is re-enabled. It is
+    paused, not gone. Rotating is what makes a badge URL dead, and rotating
+    returns the new one.
+
+    The client is told ``enabled`` and decides what to show; it is not left to
+    infer state from a missing field.
+    """
     svg_url = request.build_absolute_uri(f"/api/badge/{badge.badge_id}/svg/")
     return {
         "badge_id": str(badge.badge_id),
         "enabled": badge.enabled,
         "badge_url": svg_url,
         "markdown": f"![ATS Score]({svg_url})",
+        "updated_at": badge.updated_at.isoformat() if badge.updated_at else None,
     }
 
 
-@api_view(["GET", "POST"])
+@api_view(["GET", "POST", "DELETE"])
 @permission_classes([IsAuthenticated])
 def manage_resume_badge(request):
-    """Create/retrieve the stable badge URL for the signed-in user."""
+    """Read, reconfigure or switch off the signed-in user's badge.
+
+    ``GET`` returns the current state, creating the row on first call. The
+    other two verbs were the gap this endpoint had (#865): ``ResumeBadge`` has
+    carried an ``enabled`` column since it was added, ``resume_score_badge``
+    has always 404'd on it and ``tests_badge`` has always covered that path --
+    by flipping the column directly in the ORM, because nothing in the API
+    could produce a disabled badge. The score of a user who had opened an
+    analysis once was published at a permanent URL they had no way to withdraw.
+
+    ``POST`` takes ``enabled`` and/or ``rotate``. ``DELETE`` disables, matching
+    the verb the share endpoint next to it uses for the same meaning.
+    """
     badge, _ = ResumeBadge.objects.get_or_create(user=request.user)
+
+    if request.method == "GET":
+        return Response(_badge_payload(request, badge), status=status.HTTP_200_OK)
+
+    if request.method == "DELETE":
+        # Disable rather than delete the row. The badge_id is the user's
+        # published identifier; destroying it would mean a later `GET` mints a
+        # different one, so a link someone had turned off would silently come
+        # back pointing somewhere else. Rotation is the explicit way to change
+        # the URL.
+        if badge.enabled:
+            badge.enabled = False
+            badge.save(update_fields=["enabled", "updated_at"])
+        return Response(_badge_payload(request, badge), status=status.HTTP_200_OK)
+
+    serializer = ResumeBadgeUpdateSerializer(data=request.data)
+    unknown = serializer.unknown_fields()
+    if unknown:
+        return Response(
+            {
+                "detail": (
+                    "Unrecognised field(s): " + ", ".join(unknown) + ". "
+                    "This endpoint accepts `enabled` and `rotate`."
+                )
+            },
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    serializer.is_valid(raise_exception=True)
+
+    changed = []
+
+    if serializer.validated_data.get("rotate"):
+        badge.badge_id = uuid.uuid4()
+        changed.append("badge_id")
+
+    if "enabled" in serializer.validated_data:
+        badge.enabled = serializer.validated_data["enabled"]
+        changed.append("enabled")
+
+    if changed:
+        badge.save(update_fields=[*changed, "updated_at"])
+
     return Response(_badge_payload(request, badge), status=status.HTTP_200_OK)
 
 

--- a/backend/analyzer/tests_badge.py
+++ b/backend/analyzer/tests_badge.py
@@ -99,3 +99,242 @@ class ResumeScoreBadgeTests(TestCase):
     def test_management_endpoint_requires_authentication(self):
         response = self.client.get("/api/badge/")
         self.assertEqual(response.status_code, 401)
+
+
+class ResumeBadgeControlTests(TestCase):
+    """Turning the badge off, and issuing a new URL (#865).
+
+    Before this, ``ResumeBadge.enabled`` was reachable only from the ORM. The
+    column existed, ``resume_score_badge`` filtered on it, and
+    ``test_disabled_badge_returns_404`` above covered the disabled path -- by
+    setting the field directly, because no request could produce that state.
+    A user whose browser had once opened an analysis had a permanent public URL
+    reporting their newest ATS score and no way to withdraw it.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="badge-owner",
+            password="test-password-123",
+        )
+        self.other = User.objects.create_user(
+            username="someone-else",
+            password="test-password-123",
+        )
+        self.client = APIClient()
+
+    def analysis_for(self, user, score):
+        return ResumeAnalysis.objects.create(
+            user=user,
+            file_name=f"resume-{score}.pdf",
+            score=score,
+            skills_found=[],
+            suggestions=[],
+            matched_skills=[],
+            partial_skills=[],
+            missing_skills=[],
+            target_role="Frontend Developer",
+            experience_level="Junior",
+        )
+
+    def badge_for(self, user):
+        return ResumeBadge.objects.get(user=user)
+
+    # -- disabling ---------------------------------------------------------
+
+    def test_post_enabled_false_takes_the_badge_offline(self):
+        self.analysis_for(self.user, 88)
+        self.client.force_authenticate(self.user)
+        badge_url = self.client.get("/api/badge/").data["badge_url"]
+        badge_id = self.badge_for(self.user).badge_id
+
+        self.assertEqual(self.client.get(f"/api/badge/{badge_id}/svg/").status_code, 200)
+
+        response = self.client.post("/api/badge/", {"enabled": False}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["enabled"])
+        self.assertFalse(self.badge_for(self.user).enabled)
+        self.assertEqual(self.client.get(f"/api/badge/{badge_id}/svg/").status_code, 404)
+        # The URL is unchanged -- disabled is paused, not rotated.
+        self.assertEqual(response.data["badge_url"], badge_url)
+
+    def test_delete_takes_the_badge_offline(self):
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+        badge_id = self.badge_for(self.user).badge_id
+
+        response = self.client.delete("/api/badge/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["enabled"])
+        self.assertEqual(self.client.get(f"/api/badge/{badge_id}/svg/").status_code, 404)
+
+    def test_delete_keeps_the_row_and_the_identifier(self):
+        """A second DELETE must not mint a different badge.
+
+        Deleting the row would mean the next GET creates a new one with a new
+        badge_id, so a badge someone had switched off would come back pointing
+        somewhere else. Rotation is the explicit way to change the URL.
+        """
+        self.client.force_authenticate(self.user)
+        original = self.client.get("/api/badge/").data["badge_id"]
+
+        self.client.delete("/api/badge/")
+        self.client.delete("/api/badge/")
+
+        self.assertEqual(ResumeBadge.objects.filter(user=self.user).count(), 1)
+        self.assertEqual(self.client.get("/api/badge/").data["badge_id"], original)
+        self.assertFalse(self.badge_for(self.user).enabled)
+
+    def test_a_disabled_badge_can_be_switched_back_on(self):
+        self.analysis_for(self.user, 64)
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+        badge_id = self.badge_for(self.user).badge_id
+
+        self.client.delete("/api/badge/")
+        response = self.client.post("/api/badge/", {"enabled": True}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["enabled"])
+        svg = self.client.get(f"/api/badge/{badge_id}/svg/")
+        self.assertEqual(svg.status_code, 200)
+        self.assertIn("64%", svg.content.decode("utf-8"))
+
+    # -- rotating ----------------------------------------------------------
+
+    def test_rotate_issues_a_new_url_and_kills_the_old_one(self):
+        self.analysis_for(self.user, 77)
+        self.client.force_authenticate(self.user)
+        before = self.client.get("/api/badge/").data
+        old_id = before["badge_id"]
+
+        response = self.client.post("/api/badge/", {"rotate": True}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(response.data["badge_id"], old_id)
+        self.assertNotEqual(response.data["badge_url"], before["badge_url"])
+        self.assertEqual(self.client.get(f"/api/badge/{old_id}/svg/").status_code, 404)
+        self.assertEqual(
+            self.client.get(f"/api/badge/{response.data['badge_id']}/svg/").status_code,
+            200,
+        )
+
+    def test_rotate_alone_leaves_the_badge_enabled(self):
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+
+        response = self.client.post("/api/badge/", {"rotate": True}, format="json")
+
+        self.assertTrue(response.data["enabled"])
+
+    def test_rotate_and_disable_in_one_request(self):
+        """What someone wants when they have just realised where they pasted it."""
+        self.client.force_authenticate(self.user)
+        old_id = self.client.get("/api/badge/").data["badge_id"]
+
+        response = self.client.post(
+            "/api/badge/", {"enabled": False, "rotate": True}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["enabled"])
+        self.assertNotEqual(response.data["badge_id"], old_id)
+        self.assertEqual(self.client.get(f"/api/badge/{old_id}/svg/").status_code, 404)
+        self.assertEqual(
+            self.client.get(f"/api/badge/{response.data['badge_id']}/svg/").status_code,
+            404,
+        )
+
+    def test_rotating_a_disabled_badge_does_not_re_enable_it(self):
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+        self.client.delete("/api/badge/")
+
+        response = self.client.post("/api/badge/", {"rotate": True}, format="json")
+
+        self.assertFalse(response.data["enabled"])
+
+    # -- request validation ------------------------------------------------
+
+    def test_string_booleans_are_accepted(self):
+        """A form post sends "false", not False."""
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+
+        response = self.client.post("/api/badge/", {"enabled": "false"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["enabled"])
+        self.assertFalse(self.badge_for(self.user).enabled)
+
+    def test_a_non_boolean_is_rejected_rather_than_treated_as_truthy(self):
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+
+        response = self.client.post("/api/badge/", {"enabled": "maybe"}, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue(self.badge_for(self.user).enabled)
+
+    def test_an_empty_body_is_rejected(self):
+        """A no-op that returns 200 reads like it worked."""
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+
+        response = self.client.post("/api/badge/", {}, format="json")
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_a_misspelled_field_is_rejected_rather_than_ignored(self):
+        """`{"enable": false}` must not answer 200 and leave the badge up."""
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+
+        response = self.client.post("/api/badge/", {"enable": False}, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("enable", response.data["detail"])
+        self.assertTrue(self.badge_for(self.user).enabled)
+
+    # -- authorisation -----------------------------------------------------
+
+    def test_the_endpoint_only_ever_touches_the_caller_s_own_badge(self):
+        self.client.force_authenticate(self.other)
+        self.client.get("/api/badge/")
+        other_badge = self.badge_for(self.other)
+
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+        self.client.post("/api/badge/", {"enabled": False, "rotate": True}, format="json")
+
+        other_badge.refresh_from_db()
+        self.assertTrue(other_badge.enabled)
+        self.assertEqual(other_badge.badge_id, self.badge_for(self.other).badge_id)
+
+    def test_writes_require_authentication(self):
+        self.assertEqual(self.client.post("/api/badge/", {"enabled": False}).status_code, 401)
+        self.assertEqual(self.client.delete("/api/badge/").status_code, 401)
+
+    # -- payload -----------------------------------------------------------
+
+    def test_the_payload_reports_enabled_and_when_it_last_changed(self):
+        self.client.force_authenticate(self.user)
+
+        created = self.client.get("/api/badge/").data
+        self.assertTrue(created["enabled"])
+        self.assertIsNotNone(created["updated_at"])
+
+        disabled = self.client.delete("/api/badge/").data
+        self.assertFalse(disabled["enabled"])
+        self.assertGreater(disabled["updated_at"], created["updated_at"])
+
+    def test_markdown_tracks_a_rotated_url(self):
+        self.client.force_authenticate(self.user)
+        self.client.get("/api/badge/")
+
+        rotated = self.client.post("/api/badge/", {"rotate": True}, format="json").data
+
+        self.assertIn(rotated["badge_id"], rotated["markdown"])
+        self.assertEqual(rotated["markdown"], f"![ATS Score]({rotated['badge_url']})")

--- a/frontend/src/components/ShareResult.badge.test.tsx
+++ b/frontend/src/components/ShareResult.badge.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ShareResult } from './ShareResult'
+
+vi.mock('../api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+
+const mockedApi = vi.mocked(api, true)
+
+const shareState = {
+  share_id: 'abc',
+  share_enabled: false,
+  share_created_at: null,
+  share_expires_at: null,
+  share_view_count: 0,
+  is_live: false,
+  share_url: null,
+}
+
+const badgeState = (overrides = {}) => ({
+  badge_id: '11111111-1111-1111-1111-111111111111',
+  enabled: true,
+  badge_url: 'https://example.test/api/badge/11111111-1111-1111-1111-111111111111/svg/',
+  markdown:
+    '![ATS Score](https://example.test/api/badge/11111111-1111-1111-1111-111111111111/svg/)',
+  updated_at: '2026-08-26T10:00:00Z',
+  ...overrides,
+})
+
+const renderWithBadge = async (badge = badgeState()) => {
+  mockedApi.get.mockImplementation((url: string) =>
+    url === '/api/badge/'
+      ? Promise.resolve({ data: badge })
+      : Promise.resolve({ data: shareState })
+  )
+  render(<ShareResult analysisId={7} />)
+  await screen.findByText('Latest ATS Score Badge')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ShareResult badge controls (#865)', () => {
+  it('says the badge is public and offers a way to stop', async () => {
+    await renderWithBadge()
+
+    expect(screen.getByRole('status')).toHaveTextContent('Public')
+    expect(screen.getByAltText('Latest ATS score badge')).toHaveAttribute(
+      'src',
+      badgeState().badge_url
+    )
+    expect(screen.getByRole('button', { name: /stop publishing/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /new badge url/i })).toBeInTheDocument()
+  })
+
+  it('unpublishes with DELETE and adopts the response', async () => {
+    const user = userEvent.setup()
+    await renderWithBadge()
+
+    mockedApi.delete.mockResolvedValue({ data: badgeState({ enabled: false }) })
+
+    await user.click(screen.getByRole('button', { name: /stop publishing/i }))
+
+    await waitFor(() => expect(mockedApi.delete).toHaveBeenCalledWith('/api/badge/'))
+    expect(screen.getByRole('status')).toHaveTextContent('Not published')
+    // The preview and the copy fields go with it -- they would be a broken
+    // image and two URLs that 404.
+    expect(screen.queryByAltText('Latest ATS score badge')).toBeNull()
+    expect(screen.queryByLabelText('ATS score badge URL')).toBeNull()
+  })
+
+  it('offers to publish again once it is off, and the URL is the same one', async () => {
+    const user = userEvent.setup()
+    await renderWithBadge(badgeState({ enabled: false }))
+
+    expect(screen.getByRole('status')).toHaveTextContent('Not published')
+
+    mockedApi.post.mockResolvedValue({ data: badgeState({ enabled: true }) })
+
+    await user.click(screen.getByRole('button', { name: /publish badge/i }))
+
+    await waitFor(() =>
+      expect(mockedApi.post).toHaveBeenCalledWith('/api/badge/', { enabled: true })
+    )
+    expect(screen.getByAltText('Latest ATS score badge')).toHaveAttribute(
+      'src',
+      badgeState().badge_url
+    )
+  })
+
+  it('rotates to whatever URL the server returns rather than guessing', async () => {
+    const user = userEvent.setup()
+    await renderWithBadge()
+
+    const rotated = badgeState({
+      badge_id: '22222222-2222-2222-2222-222222222222',
+      badge_url: 'https://example.test/api/badge/22222222-2222-2222-2222-222222222222/svg/',
+      markdown:
+        '![ATS Score](https://example.test/api/badge/22222222-2222-2222-2222-222222222222/svg/)',
+    })
+    mockedApi.post.mockResolvedValue({ data: rotated })
+
+    await user.click(screen.getByRole('button', { name: /new badge url/i }))
+
+    await waitFor(() =>
+      expect(mockedApi.post).toHaveBeenCalledWith('/api/badge/', { rotate: true })
+    )
+    expect(screen.getByLabelText('ATS score badge URL')).toHaveValue(rotated.badge_url)
+    expect(screen.getByLabelText('ATS score badge Markdown')).toHaveValue(rotated.markdown)
+  })
+
+  it('leaves the badge alone and says so when the request fails', async () => {
+    const user = userEvent.setup()
+    await renderWithBadge()
+
+    mockedApi.delete.mockRejectedValue(new Error('offline'))
+
+    await user.click(screen.getByRole('button', { name: /stop publishing/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not reach the server. The badge was not changed.'
+    )
+    expect(screen.getByRole('status')).toHaveTextContent('Public')
+  })
+
+  it('renders nothing for the badge when the endpoint is unavailable', async () => {
+    mockedApi.get.mockImplementation((url: string) =>
+      url === '/api/badge/'
+        ? Promise.reject(new Error('no badge'))
+        : Promise.resolve({ data: shareState })
+    )
+
+    render(<ShareResult analysisId={7} />)
+
+    await screen.findByText('Share this analysis')
+    expect(screen.queryByText('Latest ATS Score Badge')).toBeNull()
+  })
+})

--- a/frontend/src/components/ShareResult.css
+++ b/frontend/src/components/ShareResult.css
@@ -138,3 +138,59 @@
   color: var(--danger-color, #b91c1c);
   margin: 8px 0 0;
 }
+
+/* Score badge panel ---------------------------------------------------------
+ *
+ * These rules were inline `style={{ ... }}` objects on the badge container.
+ * The panel gained an on/off state (#865), which needs a status pill and two
+ * more buttons, and pushing that much presentation through inline objects
+ * means none of it can respond to the theme or to `:hover`.
+ */
+
+.share-badge-panel {
+  padding: 16px;
+  border: 1px solid var(--surface-border, rgba(255, 255, 255, 0.12));
+  border-radius: 12px;
+  background: var(--surface-soft-bg, rgba(255, 255, 255, 0.03));
+}
+
+.share-badge-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+/* The pill carries a word, not just a colour: "Public" and "Not published"
+ * are the whole point of the panel and must not depend on hue to be read. */
+.share-badge-status {
+  margin-left: auto;
+  padding: 2px 10px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--color-success, #16a34a);
+}
+
+.share-badge-status.is-off {
+  color: var(--text-secondary, #94a3b8);
+}
+
+.share-badge-blurb {
+  margin-bottom: 12px;
+}
+
+.share-badge-preview {
+  margin-bottom: 12px;
+}
+
+.share-badge-preview img {
+  vertical-align: middle;
+  max-width: 100%;
+}
+
+.share-badge-row {
+  margin-bottom: 8px;
+}

--- a/frontend/src/components/ShareResult.tsx
+++ b/frontend/src/components/ShareResult.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Share2, Check, Copy, Link2Off, RefreshCw, ShieldCheck, Eye } from 'lucide-react'
+import { Share2, Check, Copy, Link2Off, RefreshCw, ShieldCheck, Eye, EyeOff } from 'lucide-react'
 import { api } from '../api/client'
 import {
   DEFAULT_LIFETIME_DAYS,
@@ -22,8 +22,16 @@ interface Loaded {
 interface BadgeState {
   badge_id: string
   enabled: boolean
+  /**
+   * Present whether or not the badge is enabled.
+   *
+   * Unlike a revoked share link, a disabled badge keeps its URL and starts
+   * working again the moment it is switched back on — it is paused, not dead.
+   * Rotating is what invalidates a badge URL, and rotating returns the new one.
+   */
   badge_url: string
   markdown: string
+  updated_at: string | null
 }
 
 export const ShareResult: React.FC<ShareResultProps> = ({ analysisId }) => {
@@ -34,6 +42,8 @@ export const ShareResult: React.FC<ShareResultProps> = ({ analysisId }) => {
   const [error, setError] = useState('')
   const [badge, setBadge] = useState<BadgeState | null>(null)
   const [badgeCopied, setBadgeCopied] = useState<'url' | 'markdown' | null>(null)
+  const [badgeBusy, setBadgeBusy] = useState(false)
+  const [badgeError, setBadgeError] = useState('')
 
   const endpoint = analysisId === null ? null : `/api/history/${analysisId}/share/`
 
@@ -102,6 +112,33 @@ export const ShareResult: React.FC<ShareResultProps> = ({ analysisId }) => {
     run(() => api.post<ShareState>(endpoint, { lifetime_days: lifetimeDays, rotate: true }))
 
   const handleRevoke = () => endpoint && run(() => api.delete<ShareState>(endpoint))
+
+  /**
+   * Send a badge change and adopt whatever the server says the state now is.
+   *
+   * The response is the source of truth rather than an optimistic local flip:
+   * rotating changes `badge_id`, `badge_url` and `markdown` together, and
+   * guessing the new UUID client-side is not a thing that can be done.
+   */
+  const runBadge = useCallback(async (body: Record<string, boolean> | null) => {
+    setBadgeBusy(true)
+    setBadgeError('')
+    try {
+      const res =
+        body === null
+          ? await api.delete<BadgeState>('/api/badge/')
+          : await api.post<BadgeState>('/api/badge/', body)
+      setBadge(res.data)
+    } catch {
+      setBadgeError('Could not reach the server. The badge was not changed.')
+    } finally {
+      setBadgeBusy(false)
+    }
+  }, [])
+
+  const handleBadgePublish = () => runBadge({ enabled: true })
+  const handleBadgeRotate = () => runBadge({ rotate: true })
+  const handleBadgeUnpublish = () => runBadge(null)
 
   const copyBadge = async (kind: 'url' | 'markdown') => {
     if (!badge) return
@@ -216,54 +253,107 @@ export const ShareResult: React.FC<ShareResultProps> = ({ analysisId }) => {
       )}
 
       {badge && (
-        <div
-          className="mt-4"
-          style={{
-            padding: '16px',
-            border: '1px solid var(--surface-border, rgba(255,255,255,0.12))',
-            borderRadius: '12px',
-            background: 'var(--surface-soft-bg, rgba(255,255,255,0.03))',
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
+        <div className="share-badge-panel mt-4">
+          <div className="share-badge-title">
             <span aria-hidden="true">🏅</span>
             <strong>Latest ATS Score Badge</strong>
-          </div>
-          <p className="share-help-text" style={{ marginBottom: '12px' }}>
-            Embed this badge in your GitHub README, portfolio, or personal website. It keeps the same URL and refreshes to your latest ATS score.
-          </p>
-
-          <div style={{ marginBottom: '12px' }}>
-            <img src={badge.badge_url} alt="Latest ATS score badge" style={{ verticalAlign: 'middle' }} />
+            <span className={`share-badge-status${badge.enabled ? '' : ' is-off'}`} role="status">
+              {badge.enabled ? 'Public' : 'Not published'}
+            </span>
           </div>
 
-          <div className="share-input-group" style={{ marginBottom: '8px' }}>
-            <input
-              type="text"
-              value={badge.badge_url}
-              readOnly
-              className="share-url-input"
-              aria-label="ATS score badge URL"
-            />
-            <button className="share-copy-btn" onClick={() => copyBadge('url')}>
-              {badgeCopied === 'url' ? <Check size={14} /> : <Copy size={14} />}
-              {badgeCopied === 'url' ? 'Copied' : 'Copy URL'}
-            </button>
-          </div>
+          {badge.enabled ? (
+            <>
+              <p className="share-help-text share-badge-blurb">
+                Embed this badge in your GitHub README, portfolio, or personal website. It keeps the
+                same URL and refreshes to your latest ATS score — including scores from analyses you
+                have not run yet.
+              </p>
 
-          <div className="share-input-group">
-            <input
-              type="text"
-              value={badge.markdown}
-              readOnly
-              className="share-url-input"
-              aria-label="ATS score badge Markdown"
-            />
-            <button className="share-copy-btn" onClick={() => copyBadge('markdown')}>
-              {badgeCopied === 'markdown' ? <Check size={14} /> : <Copy size={14} />}
-              {badgeCopied === 'markdown' ? 'Copied' : 'Copy Markdown'}
-            </button>
-          </div>
+              <div className="share-badge-preview">
+                <img src={badge.badge_url} alt="Latest ATS score badge" />
+              </div>
+
+              <div className="share-input-group share-badge-row">
+                <input
+                  type="text"
+                  value={badge.badge_url}
+                  readOnly
+                  className="share-url-input"
+                  aria-label="ATS score badge URL"
+                />
+                <button className="share-copy-btn" onClick={() => copyBadge('url')}>
+                  {badgeCopied === 'url' ? <Check size={14} /> : <Copy size={14} />}
+                  {badgeCopied === 'url' ? 'Copied' : 'Copy URL'}
+                </button>
+              </div>
+
+              <div className="share-input-group">
+                <input
+                  type="text"
+                  value={badge.markdown}
+                  readOnly
+                  className="share-url-input"
+                  aria-label="ATS score badge Markdown"
+                />
+                <button className="share-copy-btn" onClick={() => copyBadge('markdown')}>
+                  {badgeCopied === 'markdown' ? <Check size={14} /> : <Copy size={14} />}
+                  {badgeCopied === 'markdown' ? 'Copied' : 'Copy Markdown'}
+                </button>
+              </div>
+
+              <div className="share-actions">
+                <button
+                  className="share-secondary-btn"
+                  onClick={handleBadgeRotate}
+                  disabled={badgeBusy}
+                >
+                  <RefreshCw size={13} /> New badge URL
+                </button>
+                <button
+                  className="share-danger-btn"
+                  onClick={handleBadgeUnpublish}
+                  disabled={badgeBusy}
+                >
+                  <EyeOff size={13} /> Stop publishing
+                </button>
+              </div>
+
+              <p className="share-help-text">
+                <strong>New badge URL</strong> stops every copy of the current one from working, so
+                anywhere you have already embedded it will show a broken image until you replace it.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="share-help-text share-badge-blurb">
+                Your badge is not published. Nobody can load it, and the URL below stays reserved
+                for you — publishing again brings the same address back to life.
+              </p>
+
+              <div className="share-actions">
+                <button
+                  className="share-copy-btn"
+                  onClick={handleBadgePublish}
+                  disabled={badgeBusy}
+                >
+                  <Eye size={14} /> Publish badge
+                </button>
+              </div>
+
+              <p className="share-help-text">
+                A published badge is readable by anyone who has the URL, with no sign-in. It shows
+                your most recent ATS score and nothing else — no file name, no skills, no resume
+                text.
+              </p>
+            </>
+          )}
+
+          {badgeError && (
+            <p className="share-error-text" role="alert">
+              {badgeError}
+            </p>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #865.

## The problem

`GET /api/badge/` mints a permanent, unauthenticated public URL reporting the signed-in user's newest ATS score, and there was no way to withdraw it. `ShareResult` calls that endpoint as soon as an analysis is on screen, so anyone who has ever looked at their own result already has one — and it is not a snapshot, it re-reads the latest analysis on every request.

Every piece needed to switch it off was already in the codebase, and none of it was reachable:

- `ResumeBadge.enabled` has existed since the model was added.
- `resume_score_badge` filters on `enabled=True` and 404s otherwise.
- `_badge_payload` reports `"enabled"` to the client.
- `tests_badge.py::test_disabled_badge_returns_404` covers the disabled path — by setting the column directly in the ORM, because no request could produce that state.

`manage_resume_badge` was registered for `["GET", "POST"]` and ran identical code for both, never reading `request.data`.

It is also out of step with the share link in the same panel, which was deliberately built opt-in with an expiry, a rotate and a revoke (#705). Someone who revokes their share link reasonably believes they have stopped publishing, and the badge stays up.

## Backend

**`POST /api/badge/`** takes `enabled` and `rotate`, independently or together. `{"enabled": false, "rotate": true}` is what someone actually wants when they have just realised where they pasted the URL.

**`DELETE /api/badge/`** disables, matching the verb the share endpoint uses for the same meaning.

DELETE *disables* rather than destroying the row, deliberately. `badge_id` is the user's published identifier; deleting it would mean the next `GET` mints a different one, so a badge somebody had switched off would quietly come back pointing somewhere else. Rotation is the explicit way to change the URL.

**A serializer instead of `request.data.get(...)`.** `BooleanField` normalises the `"false"` a form post sends and the `False` JSON sends, rejects `"maybe"` with a 400 instead of treating it as truthy, and an unrecognised field name is a 400 rather than being ignored. For this endpoint specifically, "I turned it off and it stayed on" is the one outcome that must not be possible, so `{"enable": false}` has to fail loudly. An empty body is rejected too — a no-op that answers 200 reads like it worked.

**`badge_url` and `markdown` are returned whether or not the badge is enabled**, which is the opposite of what `ShareStateSerializer` does with `share_url`. The cases differ: a revoked share link is dead, whereas a disabled badge keeps its URL and works again the moment it is re-enabled. It is paused, not gone. The payload also carries `updated_at`.

## Frontend

The badge panel in `ShareResult` gains:

- a status pill reading **Public** or **Not published** — in words, not by colour
- **Publish badge** / **Stop publishing**
- **New badge URL**
- when the badge is off, the preview image and both copy fields are hidden; they would be a broken image and two URLs that 404
- an error line that says the badge was *not* changed, so a failed request is not mistaken for a successful one

Every action adopts the server's response rather than flipping local state optimistically — rotating changes `badge_id`, `badge_url` and `markdown` together, and the new UUID cannot be guessed client-side. The panel's inline `style={{ ... }}` objects move into `ShareResult.css`.

## Tests

16 new backend tests: disabling via both verbs, re-enabling, that DELETE keeps the row and identifier, rotation invalidating the old URL, rotate-and-disable in one request, rotating a disabled badge not re-enabling it, string booleans, non-boolean rejection, empty body rejection, misspelled field rejection, that one user's request cannot touch another user's badge, that writes need authentication, and the payload's `enabled`/`updated_at`/`markdown` contents.

6 new frontend tests for the panel's two states, both mutations, error handling, and the endpoint being unavailable.

## Out of scope, deliberately

`GET` still creates the row on first call, and still creates it enabled. Flipping the default to opt-in is the more correct design, but the badge is created on any view of an analysis, so essentially every existing user has one — changing the default would retroactively break every badge already embedded in a README. Worth doing as its own change with its own migration and announcement, not as a side effect of this one.

## Verification

```
Backend:  Ran 666 tests   (1 pre-existing failure)
Frontend: 304 tests       (1 pre-existing failure)
```

Both pre-existing failures are on `main` and unrelated: `analyzer.tests_migrations` is #862 (fixed in #867) and `CompareVersions` is #863 (fixed in #868).

⚠️ **The backend CI job on this PR will be red until #867 merges.** `main`'s migration graph has three leaf nodes, so `manage.py test` cannot create a test database at all — it fails before collecting anything, on every PR. I verified this branch locally with #867's two file deletions applied.
