### PR TITLE
feat: implement interactive interview question generator based on resume gaps

### DIFF
--- a/backend/analyzer/interview_generator.py
+++ b/backend/analyzer/interview_generator.py
@@ -1,0 +1,118 @@
+"""
+Advanced logic to identify missing skills and experience gaps,
+then construct targeted interview questions with expected answer guidelines.
+"""
+
+import re
+from typing import List, Dict, Any
+from dataclasses import dataclass, field
+
+
+@dataclass
+class InterviewQuestion:
+    category: str
+    difficulty: str
+    question: str
+    guidelines: str
+    is_practiced: bool = False
+    is_saved: bool = False
+
+
+class InterviewGenerator:
+    """Generates tailored interview questions based on resume and JD gaps."""
+
+    COMMON_TECHNICAL_SKILLS = [
+        "python",
+        "java",
+        "react",
+        "aws",
+        "docker",
+        "sql",
+        "machine learning",
+        "agile",
+        "kubernetes",
+        "graphql",
+    ]
+    COMMON_BEHAVIORAL_KEYWORDS = [
+        "led",
+        "managed",
+        "collaborated",
+        "resolved",
+        "improved",
+        "mentored",
+    ]
+
+    @classmethod
+    def generate_questions(
+        cls, resume_text: str, skills: List[str], job_description: str
+    ) -> List[InterviewQuestion]:
+        """
+        Analyzes the gap between resume and JD, then generates questions.
+        """
+        questions = []
+        jd_lower = job_description.lower()
+        resume_lower = resume_text.lower()
+
+        # 1. Gap Analysis: Identify missing technical skills
+        missing_skills = []
+        for skill in cls.COMMON_TECHNICAL_SKILLS:
+            if skill in jd_lower and skill not in resume_lower:
+                missing_skills.append(skill)
+
+        # Fallback if no specific skills are found but JD is substantial
+        if not missing_skills and len(jd_lower) > 200:
+            missing_skills = ["system design", "scalability"]
+
+        # 2. Generate Technical Questions based on gaps
+        for skill in missing_skills[:2]:
+            questions.append(
+                InterviewQuestion(
+                    category="Technical",
+                    difficulty="Medium",
+                    question=f"Can you explain your experience with {skill.title()} and how it relates to the requirements of this role?",
+                    guidelines=f"Discuss specific projects where you used {skill.title()}. Mention challenges faced and how you overcame them. If you lack direct experience, explain how your skills in similar technologies translate to this requirement.",
+                )
+            )
+
+        # 3. Generate Gap-Focused Questions
+        if missing_skills:
+            questions.append(
+                InterviewQuestion(
+                    category="Gap-Focused",
+                    difficulty="Hard",
+                    question=f"This role requires strong expertise in {missing_skills[0].title()}. How would you approach getting up to speed quickly if hired?",
+                    guidelines="Show a proactive learning mindset. Mention specific resources (courses, documentation, open-source projects) you would use. Highlight your past ability to learn new technologies quickly with a concrete example.",
+                )
+            )
+
+        # 4. Generate Behavioral Questions based on resume content
+        if any(kw in resume_lower for kw in cls.COMMON_BEHAVIORAL_KEYWORDS):
+            questions.append(
+                InterviewQuestion(
+                    category="Behavioral",
+                    difficulty="Medium",
+                    question="Tell me about a time you had to resolve a conflict or a critical issue within your team. What was the outcome?",
+                    guidelines="Use the STAR method (Situation, Task, Action, Result). Focus on your specific actions and the positive resolution. Avoid blaming others and emphasize teamwork and communication.",
+                )
+            )
+        else:
+            questions.append(
+                InterviewQuestion(
+                    category="Behavioral",
+                    difficulty="Easy",
+                    question="Describe a project you are particularly proud of. What was your specific role and contribution?",
+                    guidelines="Clearly define your specific contributions. Use metrics to quantify the impact. Explain why you are proud of it and what you learned from the experience.",
+                )
+            )
+
+        # 5. Add a generic hard architectural/system question
+        questions.append(
+            InterviewQuestion(
+                category="Technical",
+                difficulty="Hard",
+                question="How do you ensure the scalability, security, and maintainability of the systems you build?",
+                guidelines="Discuss architectural patterns (microservices, modular design), testing strategies (TDD, CI/CD), and code review practices. Mention specific tools and methodologies you rely on.",
+            )
+        )
+
+        return questions

--- a/backend/analyzer/interview_serializers.py
+++ b/backend/analyzer/interview_serializers.py
@@ -1,0 +1,48 @@
+"""
+DRF serializers for structuring the generated questions, categories, and difficulty levels.
+"""
+
+from rest_framework import serializers
+
+
+class InterviewQuestionSerializer(serializers.Serializer):
+    category = serializers.CharField(
+        help_text="Category of the question (Technical, Behavioral, Gap-Focused)."
+    )
+    difficulty = serializers.CharField(
+        help_text="Difficulty level (Easy, Medium, Hard)."
+    )
+    question = serializers.CharField(help_text="The interview question text.")
+    guidelines = serializers.CharField(help_text="Expected answer guidelines and tips.")
+    is_practiced = serializers.BooleanField(
+        default=False, help_text="User progress tracking."
+    )
+    is_saved = serializers.BooleanField(
+        default=False, help_text="User bookmark status."
+    )
+
+
+class InterviewGenerationRequestSerializer(serializers.Serializer):
+    resume_text = serializers.CharField(
+        max_length=50000, help_text="The full text of the user's resume."
+    )
+    skills = serializers.ListField(
+        child=serializers.CharField(max_length=100),
+        required=False,
+        default=[],
+        help_text="List of extracted skills from the resume.",
+    )
+    job_description = serializers.CharField(
+        max_length=50000, help_text="The full text of the target job description."
+    )
+
+
+class InterviewGenerationResponseSerializer(serializers.Serializer):
+    questions = InterviewQuestionSerializer(many=True)
+    total_questions = serializers.IntegerField(
+        help_text="Total number of questions generated."
+    )
+    categories = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Unique categories present in the generated questions.",
+    )

--- a/backend/analyzer/interview_views.py
+++ b/backend/analyzer/interview_views.py
@@ -1,0 +1,58 @@
+"""
+API endpoints to generate, fetch, and manage interview questions.
+"""
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from rest_framework import status
+from drf_spectacular.utils import extend_schema, OpenApiResponse
+from .interview_serializers import (
+    InterviewGenerationRequestSerializer,
+    InterviewGenerationResponseSerializer,
+)
+from .interview_generator import InterviewGenerator
+from rest_framework.throttling import UserRateThrottle
+
+
+class InterviewQuestionThrottle(UserRateThrottle):
+    rate = "5/minute"
+
+
+class InterviewQuestionGenerateView(APIView):
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [InterviewQuestionThrottle]
+
+    @extend_schema(
+        request=InterviewGenerationRequestSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=InterviewGenerationResponseSerializer,
+                description="Successful generation",
+            ),
+            400: OpenApiResponse(description="Invalid input data"),
+        },
+        summary="Generate interview questions based on resume and job description gaps",
+    )
+    def post(self, request):
+        serializer = InterviewGenerationRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        resume_text = serializer.validated_data["resume_text"]
+        skills = serializer.validated_data.get("skills", [])
+        job_description = serializer.validated_data["job_description"]
+
+        questions = InterviewGenerator.generate_questions(
+            resume_text, skills, job_description
+        )
+
+        categories = list(set(q.category for q in questions))
+
+        response_data = {
+            "questions": [q.__dict__ for q in questions],
+            "total_questions": len(questions),
+            "categories": categories,
+        }
+
+        return Response(response_data, status=status.HTTP_200_OK)

--- a/backend/analyzer/tests/test_interview_generator.py
+++ b/backend/analyzer/tests/test_interview_generator.py
@@ -1,0 +1,64 @@
+"""
+Unit tests validating the gap analysis logic and question generation consistency.
+"""
+
+from django.test import TestCase
+from analyzer.interview_generator import InterviewGenerator, InterviewQuestion
+
+
+class InterviewGeneratorTestCase(TestCase):
+    def test_generate_questions_with_technical_gap(self):
+        resume_text = "I have 3 years of experience in Python and Django."
+        skills = ["Python", "Django"]
+        job_description = "Looking for a senior developer with strong React, AWS, and Kubernetes skills."
+
+        questions = InterviewGenerator.generate_questions(
+            resume_text, skills, job_description
+        )
+
+        self.assertGreater(len(questions), 0)
+        categories = [q.category for q in questions]
+        self.assertIn("Gap-Focused", categories)
+        self.assertIn("Technical", categories)
+
+        # Check if missing skills are addressed
+        gap_questions = [q for q in questions if q.category == "Gap-Focused"]
+        self.assertTrue(
+            any(
+                "React" in q.question
+                or "Aws" in q.question
+                or "Kubernetes" in q.question
+                for q in gap_questions
+            )
+        )
+
+    def test_generate_questions_behavioral(self):
+        resume_text = "I led a team of 5 engineers and collaborated with product managers to resolve critical bugs."
+        skills = []
+        job_description = "Standard job description for a software engineer."
+
+        questions = InterviewGenerator.generate_questions(
+            resume_text, skills, job_description
+        )
+
+        behavioral_qs = [q for q in questions if q.category == "Behavioral"]
+        self.assertGreater(len(behavioral_qs), 0)
+        # Should trigger the conflict/resolution question based on keywords
+        self.assertTrue(
+            any(
+                "conflict" in q.question.lower() or "issue" in q.question.lower()
+                for q in behavioral_qs
+            )
+        )
+
+    def test_question_structure_and_difficulty(self):
+        questions = InterviewGenerator.generate_questions(
+            "resume text", [], "job description text"
+        )
+        for q in questions:
+            self.assertIsInstance(q, InterviewQuestion)
+            self.assertIn(q.category, ["Technical", "Behavioral", "Gap-Focused"])
+            self.assertIn(q.difficulty, ["Easy", "Medium", "Hard"])
+            self.assertTrue(len(q.guidelines) > 20)
+            self.assertFalse(q.is_practiced)
+            self.assertFalse(q.is_saved)

--- a/frontend/src/components/InterviewPrepModule.tsx
+++ b/frontend/src/components/InterviewPrepModule.tsx
@@ -1,0 +1,169 @@
+/**
+ * Interactive flashcard-style UI for displaying, filtering by category, 
+ * and practicing the generated questions. Supports glassmorphic theme.
+ */
+import React, { useState } from 'react';
+import { useInterviewQuestions } from '../hooks/useInterviewQuestions';
+
+interface InterviewPrepModuleProps {
+    resumeText: string;
+    skills: string[];
+    jobDescription: string;
+}
+
+const InterviewPrepModule: React.FC<InterviewPrepModuleProps> = ({
+    resumeText,
+    skills,
+    jobDescription
+}) => {
+    const { data, isLoading, error, generateQuestions, updateQuestionState } = useInterviewQuestions();
+
+    const [activeCategory, setActiveCategory] = useState<string>('All');
+    const [revealedGuidelines, setRevealedGuidelines] = useState<Set<string>>(new Set());
+
+    const handleGenerate = () => {
+        generateQuestions(resumeText, skills, jobDescription);
+        setRevealedGuidelines(new Set());
+        setActiveCategory('All');
+    };
+
+    const toggleGuideline = (id: string) => {
+        const newRevealed = new Set(revealedGuidelines);
+        if (newRevealed.has(id)) {
+            newRevealed.delete(id);
+        } else {
+            newRevealed.add(id);
+        }
+        setRevealedGuidelines(newRevealed);
+    };
+
+    const filteredQuestions = data?.questions.filter(q =>
+        activeCategory === 'All' || q.category === activeCategory
+    ) || [];
+
+    const getDifficultyColor = (difficulty: string) => {
+        switch (difficulty) {
+            case 'Easy': return 'bg-success';
+            case 'Medium': return 'bg-warning text-dark';
+            case 'Hard': return 'bg-danger';
+            default: return 'bg-secondary';
+        }
+    };
+
+    return (
+        <div className="card glassmorphic-card p-4 shadow-sm border-0 mb-4">
+            <div className="d-flex justify-content-between align-items-center mb-4">
+                <div>
+                    <h3 className="h4 mb-1 fw-bold">Interview Prep Generator</h3>
+                    <p className="text-muted mb-0 small">Tailored questions based on your resume and job description gaps.</p>
+                </div>
+                <button
+                    className="btn btn-primary d-flex align-items-center"
+                    onClick={handleGenerate}
+                    disabled={isLoading || !resumeText || !jobDescription}
+                >
+                    {isLoading ? (
+                        <>
+                            <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                            Generating...
+                        </>
+                    ) : (
+                        <>
+                            <i className="bi bi-magic me-2"></i>
+                            Generate Questions
+                        </>
+                    )}
+                </button>
+            </div>
+
+            {error && (
+                <div className="alert alert-danger border-0 shadow-sm d-flex align-items-center">
+                    <i className="bi bi-exclamation-triangle-fill me-2"></i>
+                    {error}
+                </div>
+            )}
+
+            {data && data.questions.length > 0 && (
+                <>
+                    <div className="d-flex gap-2 mb-4 flex-wrap">
+                        <button
+                            className={`btn btn-sm ${activeCategory === 'All' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                            onClick={() => setActiveCategory('All')}
+                        >
+                            All ({data.questions.length})
+                        </button>
+                        {data.categories.map(cat => (
+                            <button
+                                key={cat}
+                                className={`btn btn-sm ${activeCategory === cat ? 'btn-primary' : 'btn-outline-secondary'}`}
+                                onClick={() => setActiveCategory(cat)}
+                            >
+                                {cat} ({data.questions.filter(q => q.category === cat).length})
+                            </button>
+                        ))}
+                    </div>
+
+                    <div className="row g-3">
+                        {filteredQuestions.map((q) => (
+                            <div key={q.id} className="col-md-6">
+                                <div className={`card h-100 bg-dark bg-opacity-50 border-secondary ${q.is_practiced ? 'border-success border-2' : ''}`}>
+                                    <div className="card-body d-flex flex-column">
+                                        <div className="d-flex justify-content-between align-items-center mb-2">
+                                            <span className={`badge ${getDifficultyColor(q.difficulty)}`}>{q.difficulty}</span>
+                                            <span className="badge bg-light text-dark">{q.category}</span>
+                                        </div>
+
+                                        <p className="card-text text-light fw-semibold flex-grow-1">{q.question}</p>
+
+                                        <div className="mt-auto">
+                                            {revealedGuidelines.has(q.id) && (
+                                                <div className="alert alert-info bg-opacity-10 border-0 p-2 mt-2 mb-3">
+                                                    <small className="text-info">
+                                                        <i className="bi bi-lightbulb-fill me-1"></i>
+                                                        <strong>Guidelines:</strong> {q.guidelines}
+                                                    </small>
+                                                </div>
+                                            )}
+
+                                            <div className="d-flex gap-2 mt-2">
+                                                <button
+                                                    className="btn btn-sm btn-outline-info flex-grow-1"
+                                                    onClick={() => toggleGuideline(q.id)}
+                                                >
+                                                    {revealedGuidelines.has(q.id) ? 'Hide Guidelines' : 'Show Guidelines'}
+                                                </button>
+                                                <button
+                                                    className={`btn btn-sm ${q.is_practiced ? 'btn-success' : 'btn-outline-success'}`}
+                                                    onClick={() => updateQuestionState(q.id, { is_practiced: !q.is_practiced })}
+                                                    title="Mark as practiced"
+                                                >
+                                                    <i className="bi bi-check-circle-fill"></i>
+                                                </button>
+                                                <button
+                                                    className={`btn btn-sm ${q.is_saved ? 'btn-warning' : 'btn-outline-warning'}`}
+                                                    onClick={() => updateQuestionState(q.id, { is_saved: !q.is_saved })}
+                                                    title="Save for later"
+                                                >
+                                                    <i className="bi bi-bookmark-fill"></i>
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </>
+            )}
+
+            {!data && !isLoading && !error && (
+                <div className="text-center text-muted py-5">
+                    <i className="bi bi-chat-dots fs-1 d-block mb-3 opacity-50"></i>
+                    <p>Click "Generate Questions" to create tailored interview prep based on your resume and target job.</p>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default InterviewPrepModule;

--- a/frontend/src/hooks/useInterviewQuestions.ts
+++ b/frontend/src/hooks/useInterviewQuestions.ts
@@ -1,0 +1,114 @@
+/**
+ * Custom React hook to manage question state, API fetching, and user progress tracking.
+ */
+import { useState } from 'react';
+import api from '../api/client';
+
+export interface InterviewQuestion {
+    id: string; // Added for React key and local state tracking
+    category: string;
+    difficulty: string;
+    question: string;
+    guidelines: string;
+    is_practiced: boolean;
+    is_saved: boolean;
+}
+
+export interface InterviewData {
+    questions: InterviewQuestion[];
+    total_questions: number;
+    categories: string[];
+}
+
+export const useInterviewQuestions = () => {
+    const [data, setData] = useState<InterviewData | null>(null);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const generateQuestions = async (resumeText: string, skills: string[], jobDescription: string) => {
+        if (!resumeText || !jobDescription) {
+            setError("Resume text and job description are required to generate questions.");
+            return;
+        }
+
+        setIsLoading(true);
+        setError(null);
+
+        try {
+            const response = await api.post<InterviewData>('/api/analyzer/generate-interview-questions/', {
+                resume_text: resumeText,
+                skills: skills,
+                job_description: jobDescription,
+            });
+
+            // Add unique IDs to questions for local state management and React keys
+            const questionsWithIds = response.data.questions.map((q, index) => ({
+                ...q,
+                id: `q_${index}_${Date.now()}`,
+            }));
+
+            const newData = {
+                ...response.data,
+                questions: questionsWithIds,
+            };
+
+            setData(newData);
+
+            // Load any previously saved progress for these specific questions
+            loadProgress(newData.questions);
+
+        } catch (err) {
+            console.error('Failed to generate interview questions:', err);
+            setError('Failed to generate questions. Please check your inputs and try again.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const updateQuestionState = (id: string, updates: Partial<InterviewQuestion>) => {
+        if (!data) return;
+
+        const updatedQuestions = data.questions.map(q =>
+            q.id === id ? { ...q, ...updates } : q
+        );
+
+        const newData = {
+            ...data,
+            questions: updatedQuestions,
+        };
+
+        setData(newData);
+
+        // Persist progress to localStorage
+        const progressToSave = updatedQuestions.map(({ id, question, is_practiced, is_saved }) => ({
+            question, is_practiced, is_saved
+        }));
+        localStorage.setItem('interview_progress', JSON.stringify(progressToSave));
+    };
+
+    const loadProgress = (currentQuestions: InterviewQuestion[]) => {
+        const savedProgress = localStorage.getItem('interview_progress');
+        if (savedProgress) {
+            try {
+                const parsed = JSON.parse(savedProgress) as { question: string, is_practiced: boolean, is_saved: boolean }[];
+
+                const mergedQuestions = currentQuestions.map(q => {
+                    const savedQ = parsed.find(sq => sq.question === q.question);
+                    return savedQ ? { ...q, is_practiced: savedQ.is_practiced, is_saved: savedQ.is_saved } : q;
+                });
+
+                setData(prev => prev ? { ...prev, questions: mergedQuestions } : null);
+            } catch (e) {
+                console.error('Failed to parse saved interview progress:', e);
+            }
+        }
+    };
+
+    return {
+        data,
+        isLoading,
+        error,
+        generateQuestions,
+        updateQuestionState,
+    };
+};


### PR DESCRIPTION
## 📝 Description
Implements a dedicated module that analyzes the gap between a user's resume and a target job description to generate tailored technical, behavioral, and gap-focused interview questions. The backend engine identifies missing skills and experience areas, assigning difficulty levels and expected answer guidelines. The frontend features an interactive, flashcard-style UI with category filtering, guideline reveal toggles, and persistent progress tracking (practiced/saved), fully styled with the existing glassmorphic theme.

## 🔗 Related Issue
Closes #887

## ✅ Type of Change
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [x] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?
- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer.tests.test_interview_generator`)
- [x] Manually tested in the browser with various resume and JD combinations

## 📋 Checklist
- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)