### PR TITLE
feat: implement advanced resume version comparison and semantic diffing tool

### DIFF
--- a/backend/analyzer/diff_serializers.py
+++ b/backend/analyzer/diff_serializers.py
@@ -1,0 +1,49 @@
+"""
+DRF serializers to structure the semantic diff output into actionable,
+categorized change sets and summary statistics.
+"""
+
+from rest_framework import serializers
+
+
+class SemanticChangeSerializer(serializers.Serializer):
+    category = serializers.CharField(
+        help_text="Category of the change (skill, experience, education, formatting, general)."
+    )
+    change_type = serializers.CharField(
+        help_text="Type of change (added, removed, modified, improved)."
+    )
+    description = serializers.CharField(
+        help_text="Human-readable description of the change."
+    )
+    details = serializers.DictField(
+        help_text="Additional structured data about the change.",
+        required=False,
+        default=dict,
+    )
+
+
+class DiffSummarySerializer(serializers.Serializer):
+    skills_added = serializers.IntegerField()
+    skills_removed = serializers.IntegerField()
+    experience_expanded = serializers.IntegerField()
+    experience_reduced = serializers.IntegerField()
+    phrasing_improved = serializers.IntegerField()
+    general_modifications = serializers.IntegerField()
+
+
+class SemanticDiffRequestSerializer(serializers.Serializer):
+    text_v1 = serializers.CharField(
+        max_length=100000, help_text="The original resume text (Version 1)."
+    )
+    text_v2 = serializers.CharField(
+        max_length=100000, help_text="The updated resume text (Version 2)."
+    )
+
+
+class SemanticDiffResponseSerializer(serializers.Serializer):
+    changes = SemanticChangeSerializer(many=True)
+    summary = DiffSummarySerializer()
+    word_count_v1 = serializers.IntegerField()
+    word_count_v2 = serializers.IntegerField()
+    error = serializers.CharField(required=False, allow_null=True)

--- a/backend/analyzer/diff_views.py
+++ b/backend/analyzer/diff_views.py
@@ -1,0 +1,50 @@
+"""
+API endpoints to accept two resume texts and return the structured semantic diff.
+"""
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from rest_framework import status
+from drf_spectacular.utils import extend_schema, OpenApiResponse
+from .diff_serializers import (
+    SemanticDiffRequestSerializer,
+    SemanticDiffResponseSerializer,
+)
+from .semantic_differ import SemanticDiffer
+from rest_framework.throttling import UserRateThrottle
+
+
+class SemanticDiffThrottle(UserRateThrottle):
+    rate = "10/minute"
+
+
+class SemanticDiffView(APIView):
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [SemanticDiffThrottle]
+
+    @extend_schema(
+        request=SemanticDiffRequestSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=SemanticDiffResponseSerializer,
+                description="Successful semantic diff",
+            ),
+            400: OpenApiResponse(description="Invalid input data"),
+        },
+        summary="Compare two resume versions and generate a semantic diff report",
+    )
+    def post(self, request):
+        serializer = SemanticDiffRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        text_v1 = serializer.validated_data["text_v1"]
+        text_v2 = serializer.validated_data["text_v2"]
+
+        result = SemanticDiffer.compare(text_v1, text_v2)
+
+        if "error" in result:
+            return Response(result, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(result, status=status.HTTP_200_OK)

--- a/backend/analyzer/semantic_differ.py
+++ b/backend/analyzer/semantic_differ.py
@@ -1,0 +1,333 @@
+"""
+NLP-based comparison logic that parses two resume texts and categorizes
+changes into skills, experience, education, and formatting improvements.
+Ignores trivial whitespace changes and focuses on semantic value.
+"""
+
+import re
+import difflib
+from typing import List, Dict, Any, Set, Tuple
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SemanticChange:
+    """Represents a single semantic change between two resume versions."""
+
+    category: str  # 'skill', 'experience', 'education', 'formatting', 'general'
+    change_type: str  # 'added', 'removed', 'modified', 'improved'
+    description: str
+    details: Dict[str, Any] = field(default_factory=dict)
+
+
+class SemanticDiffer:
+    """
+    Advanced resume comparison engine.
+    Extracts structured data and compares it semantically rather than just textually.
+    """
+
+    SECTION_PATTERNS = {
+        "experience": re.compile(
+            r"(?im)^(experience|work history|employment|professional background)"
+        ),
+        "education": re.compile(r"(?im)^(education|academic|qualifications|degrees)"),
+        "skills": re.compile(
+            r"(?im)^(skills|technologies|competencies|technical skills)"
+        ),
+        "summary": re.compile(r"(?im)^(summary|profile|objective|about me)"),
+    }
+
+    STRONG_ACTION_VERBS = {
+        "spearheaded",
+        "orchestrated",
+        "architected",
+        "optimized",
+        "accelerated",
+        "pioneered",
+        "maximized",
+        "streamlined",
+        "overhauled",
+        "championed",
+    }
+
+    WEAK_ACTION_VERBS = {
+        "helped",
+        "assisted",
+        "worked on",
+        "responsible for",
+        "tasked with",
+        "participated in",
+        "was involved in",
+    }
+
+    @classmethod
+    def compare(cls, text_v1: str, text_v2: str) -> Dict[str, Any]:
+        """
+        Main entry point for comparing two resume texts.
+        Returns a structured dictionary of semantic changes and summary statistics.
+        """
+        if not text_v1 or not text_v2:
+            return {
+                "error": "Both resume texts must be provided.",
+                "changes": [],
+                "summary": {},
+            }
+
+        # Normalize texts to ignore trivial whitespace differences
+        norm_v1 = cls._normalize_text(text_v1)
+        norm_v2 = cls._normalize_text(text_v2)
+
+        changes: List[SemanticChange] = []
+
+        # 1. Semantic Section Comparison
+        changes.extend(cls._compare_skills(norm_v1, norm_v2))
+        changes.extend(cls._compare_experience(norm_v1, norm_v2))
+        changes.extend(cls._compare_education(norm_v1, norm_v2))
+
+        # 2. Action Verb & Phrasing Improvements
+        changes.extend(cls._analyze_action_verbs(norm_v1, norm_v2))
+
+        # 3. General Text Diff (Fallback for unstructured changes)
+        changes.extend(cls._general_text_diff(norm_v1, norm_v2))
+
+        # 4. Generate Summary Statistics
+        summary = cls._generate_summary(changes)
+
+        return {
+            "changes": [c.__dict__ for c in changes],
+            "summary": summary,
+            "word_count_v1": len(norm_v1.split()),
+            "word_count_v2": len(norm_v2.split()),
+        }
+
+    @classmethod
+    def _normalize_text(cls, text: str) -> str:
+        """Removes excessive whitespace and normalizes line breaks."""
+        text = re.sub(r"\s+", " ", text)
+        text = re.sub(r"\n+", "\n", text)
+        return text.strip()
+
+    @classmethod
+    def _extract_section(cls, text: str, section_name: str) -> str:
+        """Extracts the content of a specific section from the resume text."""
+        pattern = cls.SECTION_PATTERNS.get(section_name)
+        if not pattern:
+            return ""
+
+        match = pattern.search(text)
+        if not match:
+            return ""
+
+        start_idx = match.end()
+        # Find the next section header to determine the end of this section
+        next_section_match = None
+        for name, pat in cls.SECTION_PATTERNS.items():
+            if name != section_name:
+                m = pat.search(text, start_idx)
+                if m and (
+                    not next_section_match or m.start() < next_section_match.start()
+                ):
+                    next_section_match = m
+
+        end_idx = next_section_match.start() if next_section_match else len(text)
+        return text[start_idx:end_idx].strip()
+
+    @classmethod
+    def _extract_skills(cls, text: str) -> Set[str]:
+        """Heuristically extracts a comma or bullet-separated list of skills."""
+        skills_section = cls._extract_section(text, "skills")
+        if not skills_section:
+            return set()
+
+        # Split by common delimiters
+        raw_skills = re.split(r"[,•\-\n;|]", skills_section)
+        return {
+            s.strip().lower()
+            for s in raw_skills
+            if len(s.strip()) > 1 and len(s.strip()) < 50
+        }
+
+    @classmethod
+    def _compare_skills(cls, text_v1: str, text_v2: str) -> List[SemanticChange]:
+        """Identifies added and removed skills."""
+        changes = []
+        skills_v1 = cls._extract_skills(text_v1)
+        skills_v2 = cls._extract_skills(text_v2)
+
+        added = skills_v2 - skills_v1
+        removed = skills_v1 - skills_v2
+
+        for skill in added:
+            changes.append(
+                SemanticChange(
+                    category="skill",
+                    change_type="added",
+                    description=f"Added skill: {skill.title()}",
+                    details={"skill": skill},
+                )
+            )
+
+        for skill in removed:
+            changes.append(
+                SemanticChange(
+                    category="skill",
+                    change_type="removed",
+                    description=f"Removed skill: {skill.title()}",
+                    details={"skill": skill},
+                )
+            )
+
+        return changes
+
+    @classmethod
+    def _compare_experience(cls, text_v1: str, text_v2: str) -> List[SemanticChange]:
+        """Checks for added or removed job entries based on line count and structure."""
+        changes = []
+        exp_v1 = cls._extract_section(text_v1, "experience")
+        exp_v2 = cls._extract_section(text_v2, "experience")
+
+        lines_v1 = [l for l in exp_v1.split("\n") if l.strip()]
+        lines_v2 = [l for l in exp_v2.split("\n") if l.strip()]
+
+        diff = len(lines_v2) - len(lines_v1)
+        if diff > 2:
+            changes.append(
+                SemanticChange(
+                    category="experience",
+                    change_type="added",
+                    description=f"Significant expansion in Experience section (+{diff} lines)",
+                    details={"line_diff": diff},
+                )
+            )
+        elif diff < -2:
+            changes.append(
+                SemanticChange(
+                    category="experience",
+                    change_type="removed",
+                    description=f"Significant reduction in Experience section ({diff} lines)",
+                    details={"line_diff": diff},
+                )
+            )
+
+        return changes
+
+    @classmethod
+    def _compare_education(cls, text_v1: str, text_v2: str) -> List[SemanticChange]:
+        """Checks for changes in the Education section."""
+        changes = []
+        edu_v1 = cls._extract_section(text_v1, "education")
+        edu_v2 = cls._extract_section(text_v2, "education")
+
+        if not edu_v1 and edu_v2:
+            changes.append(
+                SemanticChange(
+                    category="education",
+                    change_type="added",
+                    description="Education section was added.",
+                )
+            )
+        elif edu_v1 and not edu_v2:
+            changes.append(
+                SemanticChange(
+                    category="education",
+                    change_type="removed",
+                    description="Education section was removed.",
+                )
+            )
+
+        return changes
+
+    @classmethod
+    def _analyze_action_verbs(cls, text_v1: str, text_v2: str) -> List[SemanticChange]:
+        """Detects improvements in action verbs used in bullet points."""
+        changes = []
+
+        # Simple heuristic: count occurrences of strong vs weak verbs
+        words_v1 = set(re.findall(r"\b[a-z]+\b", text_v1.lower()))
+        words_v2 = set(re.findall(r"\b[a-z]+\b", text_v2.lower()))
+
+        strong_added = words_v2.intersection(cls.STRONG_ACTION_VERBS) - words_v1
+        weak_removed = words_v1.intersection(cls.WEAK_ACTION_VERBS) - words_v2
+
+        if strong_added:
+            changes.append(
+                SemanticChange(
+                    category="formatting",
+                    change_type="improved",
+                    description=f"Introduced stronger action verbs: {', '.join(strong_added)}",
+                    details={"verbs": list(strong_added)},
+                )
+            )
+
+        if weak_removed:
+            changes.append(
+                SemanticChange(
+                    category="formatting",
+                    change_type="improved",
+                    description=f"Removed weak phrasing: {', '.join(weak_removed)}",
+                    details={"verbs": list(weak_removed)},
+                )
+            )
+
+        return changes
+
+    @classmethod
+    def _general_text_diff(cls, text_v1: str, text_v2: str) -> List[SemanticChange]:
+        """Fallback general diff for unstructured text changes."""
+        changes = []
+        matcher = difflib.SequenceMatcher(None, text_v1.split(), text_v2.split())
+
+        added_words = 0
+        removed_words = 0
+
+        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+            if tag == "insert":
+                added_words += j2 - j1
+            elif tag == "delete":
+                removed_words += i2 - i1
+
+        # Only report if the general text change is substantial and not covered by sections
+        if added_words > 50 or removed_words > 50:
+            changes.append(
+                SemanticChange(
+                    category="general",
+                    change_type="modified",
+                    description=f"General text updated (+{added_words} words, -{removed_words} words)",
+                    details={
+                        "added_words": added_words,
+                        "removed_words": removed_words,
+                    },
+                )
+            )
+
+        return changes
+
+    @classmethod
+    def _generate_summary(cls, changes: List[SemanticChange]) -> Dict[str, int]:
+        """Aggregates changes into a high-level summary."""
+        summary = {
+            "skills_added": 0,
+            "skills_removed": 0,
+            "experience_expanded": 0,
+            "experience_reduced": 0,
+            "phrasing_improved": 0,
+            "general_modifications": 0,
+        }
+
+        for change in changes:
+            if change.category == "skill":
+                if change.change_type == "added":
+                    summary["skills_added"] += 1
+                elif change.change_type == "removed":
+                    summary["skills_removed"] += 1
+            elif change.category == "experience":
+                if change.change_type == "added":
+                    summary["experience_expanded"] += 1
+                elif change.change_type == "removed":
+                    summary["experience_reduced"] += 1
+            elif change.category == "formatting" and change.change_type == "improved":
+                summary["phrasing_improved"] += 1
+            elif change.category == "general":
+                summary["general_modifications"] += 1
+
+        return summary

--- a/backend/analyzer/tests/test_semantic_differ.py
+++ b/backend/analyzer/tests/test_semantic_differ.py
@@ -1,0 +1,49 @@
+"""
+Comprehensive tests ensuring accurate categorization of added, removed,
+and modified resume elements.
+"""
+
+from django.test import TestCase
+from analyzer.semantic_differ import SemanticDiffer, SemanticChange
+
+
+class SemanticDifferTestCase(TestCase):
+    def test_skill_extraction_and_comparison(self):
+        text_v1 = "Skills: Python, Django, React, SQL"
+        text_v2 = "Skills: Python, Django, React, AWS, Docker"
+
+        result = SemanticDiffer.compare(text_v1, text_v2)
+        summary = result["summary"]
+
+        self.assertEqual(summary["skills_added"], 2)  # AWS, Docker
+        self.assertEqual(summary["skills_removed"], 1)  # SQL
+
+    def test_action_verb_improvement(self):
+        text_v1 = "Responsible for managing the team and worked on the backend."
+        text_v2 = "Spearheaded the team and orchestrated the backend architecture."
+
+        result = SemanticDiffer.compare(text_v1, text_v2)
+        summary = result["summary"]
+
+        self.assertGreater(summary["phrasing_improved"], 0)
+
+    def test_experience_section_expansion(self):
+        text_v1 = "Experience\nJob 1\nDid things."
+        text_v2 = "Experience\nJob 1\nDid things.\nJob 2\nDid more things.\nJob 3\nEven more things.\nExtra line 1\nExtra line 2\nExtra line 3"
+
+        result = SemanticDiffer.compare(text_v1, text_v2)
+        summary = result["summary"]
+
+        self.assertEqual(summary["experience_expanded"], 1)
+
+    def test_empty_input_handling(self):
+        result = SemanticDiffer.compare("", "Some text")
+        self.assertIn("error", result)
+
+    def test_identical_texts(self):
+        text = "Skills: Python\nExperience: Job 1"
+        result = SemanticDiffer.compare(text, text)
+
+        self.assertEqual(result["summary"]["skills_added"], 0)
+        self.assertEqual(result["summary"]["skills_removed"], 0)
+        self.assertEqual(len(result["changes"]), 0)

--- a/frontend/src/components/ResumeDiffViewer.tsx
+++ b/frontend/src/components/ResumeDiffViewer.tsx
@@ -1,0 +1,211 @@
+/**
+ * Complex UI component providing a unified view of changes, 
+ * with color-coded badges for different change types and a high-level summary.
+ * Supports glassmorphic UI theme and dark/light modes.
+ */
+import React, { useState } from 'react';
+import api from '../api/client';
+import {
+    DiffData,
+    SemanticChange,
+    getNetWordChange,
+    getChangeColorClass,
+    getCategoryBadgeClass,
+    formatSummaryStats,
+    groupChangesByCategory
+} from '../utils/diffFormatter';
+
+interface ResumeDiffViewerProps {
+    initialTextV1?: string;
+    initialTextV2?: string;
+}
+
+const ResumeDiffViewer: React.FC<ResumeDiffViewerProps> = ({ initialTextV1 = '', initialTextV2 = '' }) => {
+    const [textV1, setTextV1] = useState<string>(initialTextV1);
+    const [textV2, setTextV2] = useState<string>(initialTextV2);
+    const [diffData, setDiffData] = useState<DiffData | null>(null);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleCompare = async () => {
+        if (!textV1.trim() || !textV2.trim()) {
+            setError('Please provide both Version 1 and Version 2 resume texts.');
+            return;
+        }
+
+        setIsLoading(true);
+        setError(null);
+        setDiffData(null);
+
+        try {
+            const response = await api.post<DiffData>('/api/analyzer/semantic-diff/', {
+                text_v1: textV1,
+                text_v2: textV2,
+            });
+            setDiffData(response.data);
+        } catch (err) {
+            console.error('Semantic diff failed:', err);
+            setError('Failed to compare resumes. Please check your inputs and try again.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const renderSummaryDashboard = () => {
+        if (!diffData) return null;
+
+        const stats = formatSummaryStats(diffData.summary);
+        const netWords = getNetWordChange(diffData.word_count_v1, diffData.word_count_v2);
+        const wordChangeColor = netWords >= 0 ? 'text-success' : 'text-danger';
+
+        return (
+            <div className="card bg-dark bg-opacity-50 border-secondary p-3 mb-4">
+                <h5 className="h6 fw-bold text-light mb-3">
+                    <i className="bi bi-bar-chart-fill me-2 text-primary"></i>
+                    High-Level Summary
+                </h5>
+                <div className="row g-3">
+                    <div className="col-md-4">
+                        <div className="p-2 rounded bg-dark border border-secondary text-center">
+                            <div className="text-muted small text-uppercase">Word Count Change</div>
+                            <div className={`h5 mb-0 fw-bold ${wordChangeColor}`}>
+                                {netWords >= 0 ? '+' : ''}{netWords}
+                            </div>
+                        </div>
+                    </div>
+                    <div className="col-md-8">
+                        <div className="p-2 rounded bg-dark border border-secondary">
+                            <div className="text-muted small text-uppercase mb-2">Key Improvements</div>
+                            <div className="d-flex flex-wrap gap-2">
+                                {stats.map((stat, idx) => (
+                                    <span key={idx} className="badge bg-primary bg-opacity-75 text-light px-2 py-1">
+                                        {stat}
+                                    </span>
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    };
+
+    const renderDetailedChanges = () => {
+        if (!diffData || diffData.changes.length === 0) {
+            return (
+                <div className="alert alert-info border-0 shadow-sm">
+                    <i className="bi bi-info-circle-fill me-2"></i>
+                    The resumes are semantically identical. No significant changes detected.
+                </div>
+            );
+        }
+
+        const grouped = groupChangesByCategory(diffData.changes);
+
+        return (
+            <div className="card bg-dark bg-opacity-50 border-secondary p-3">
+                <h5 className="h6 fw-bold text-light mb-3">
+                    <i className="bi bi-list-check me-2 text-success"></i>
+                    Detailed Semantic Changes
+                </h5>
+                {Object.entries(grouped).map(([category, changes]) => (
+                    <div key={category} className="mb-4">
+                        <h6 className={`fw-bold text-uppercase small mb-2 ${getChangeColorClass('modified')}`}>
+                            <span className={`badge ${getCategoryBadgeClass(category)} me-2`}>
+                                {category}
+                            </span>
+                            ({changes.length} change{changes.length > 1 ? 's' : ''})
+                        </h6>
+                        <ul className="list-group list-group-flush bg-transparent">
+                            {changes.map((change, idx) => (
+                                <li key={idx} className="list-group-item bg-transparent border-secondary px-0 py-2">
+                                    <div className="d-flex align-items-start">
+                                        <span className={`badge me-2 mt-1 ${change.change_type === 'added' || change.change_type === 'improved'
+                                                ? 'bg-success'
+                                                : change.change_type === 'removed'
+                                                    ? 'bg-danger'
+                                                    : 'bg-warning text-dark'
+                                            }`}>
+                                            {change.change_type}
+                                        </span>
+                                        <span className="text-light small">{change.description}</span>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                ))}
+            </div>
+        );
+    };
+
+    return (
+        <div className="card glassmorphic-card p-4 shadow-sm border-0">
+            <div className="d-flex justify-content-between align-items-center mb-4">
+                <div>
+                    <h3 className="h4 mb-1 fw-bold">Resume Version Comparison</h3>
+                    <p className="text-muted mb-0 small">Semantic diffing to highlight meaningful improvements.</p>
+                </div>
+            </div>
+
+            <div className="row g-3 mb-4">
+                <div className="col-md-6">
+                    <label htmlFor="textV1" className="form-label text-light fw-semibold">Version 1 (Original)</label>
+                    <textarea
+                        id="textV1"
+                        className="form-control bg-dark text-light border-secondary font-monospace small"
+                        rows={8}
+                        value={textV1}
+                        onChange={(e) => setTextV1(e.target.value)}
+                        placeholder="Paste original resume text here..."
+                    />
+                </div>
+                <div className="col-md-6">
+                    <label htmlFor="textV2" className="form-label text-light fw-semibold">Version 2 (Updated)</label>
+                    <textarea
+                        id="textV2"
+                        className="form-control bg-dark text-light border-secondary font-monospace small"
+                        rows={8}
+                        value={textV2}
+                        onChange={(e) => setTextV2(e.target.value)}
+                        placeholder="Paste updated resume text here..."
+                    />
+                </div>
+            </div>
+
+            <button
+                className="btn btn-primary w-100 mb-4 d-flex align-items-center justify-content-center"
+                onClick={handleCompare}
+                disabled={isLoading}
+            >
+                {isLoading ? (
+                    <>
+                        <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                        Analyzing Semantic Differences...
+                    </>
+                ) : (
+                    <>
+                        <i className="bi bi-file-earmark-diff me-2"></i>
+                        Compare Resumes
+                    </>
+                )}
+            </button>
+
+            {error && (
+                <div className="alert alert-danger border-0 shadow-sm d-flex align-items-center">
+                    <i className="bi bi-exclamation-triangle-fill me-2"></i>
+                    {error}
+                </div>
+            )}
+
+            {diffData && (
+                <>
+                    {renderSummaryDashboard()}
+                    {renderDetailedChanges()}
+                </>
+            )}
+        </div>
+    );
+};
+
+export default ResumeDiffViewer;

--- a/frontend/src/utils/diffFormatter.ts
+++ b/frontend/src/utils/diffFormatter.ts
@@ -1,0 +1,94 @@
+/**
+ * Utility functions to transform raw semantic diff data into readable, 
+ * formatted UI elements and summary statistics.
+ */
+
+export interface SemanticChange {
+    category: string;
+    change_type: string;
+    description: string;
+    details: Record<string, any>;
+}
+
+export interface DiffSummary {
+    skills_added: number;
+    skills_removed: number;
+    experience_expanded: number;
+    experience_reduced: number;
+    phrasing_improved: number;
+    general_modifications: number;
+}
+
+export interface DiffData {
+    changes: SemanticChange[];
+    summary: DiffSummary;
+    word_count_v1: number;
+    word_count_v2: number;
+}
+
+/**
+ * Calculates the net change in word count.
+ */
+export const getNetWordChange = (v1: number, v2: number): number => {
+    return v2 - v1;
+};
+
+/**
+ * Returns a Bootstrap color class based on the change type.
+ */
+export const getChangeColorClass = (changeType: string): string => {
+    switch (changeType) {
+        case 'added':
+        case 'improved':
+            return 'text-success';
+        case 'removed':
+            return 'text-danger';
+        case 'modified':
+            return 'text-warning';
+        default:
+            return 'text-secondary';
+    }
+};
+
+/**
+ * Returns a Bootstrap background class for badges based on category.
+ */
+export const getCategoryBadgeClass = (category: string): string => {
+    switch (category) {
+        case 'skill': return 'bg-primary';
+        case 'experience': return 'bg-info text-dark';
+        case 'education': return 'bg-secondary';
+        case 'formatting': return 'bg-success';
+        case 'general': return 'bg-dark border border-secondary';
+        default: return 'bg-light text-dark';
+    }
+};
+
+/**
+ * Formats the summary into a list of high-level stat strings for the dashboard.
+ */
+export const formatSummaryStats = (summary: DiffSummary): string[] => {
+    const stats: string[] = [];
+
+    if (summary.skills_added > 0) stats.push(`+${summary.skills_added} Skills Added`);
+    if (summary.skills_removed > 0) stats.push(`-${summary.skills_removed} Skills Removed`);
+    if (summary.experience_expanded > 0) stats.push(`Experience Expanded`);
+    if (summary.experience_reduced > 0) stats.push(`Experience Reduced`);
+    if (summary.phrasing_improved > 0) stats.push(`Phrasing Improved`);
+    if (summary.general_modifications > 0) stats.push(`General Text Modified`);
+
+    return stats.length > 0 ? stats : ['No significant semantic changes detected'];
+};
+
+/**
+ * Groups changes by their category for organized display.
+ */
+export const groupChangesByCategory = (changes: SemanticChange[]): Record<string, SemanticChange[]> => {
+    return changes.reduce((acc, change) => {
+        if (!acc[change.category]) {
+            acc[change.category] = [];
+        }
+        acc[change.category].push(change);
+        return acc;
+    }, {} as Record<string, SemanticChange[]>);
+};


### PR DESCRIPTION
## 📝 Description
Implements a sophisticated semantic diffing tool that compares two versions of a resume, highlighting meaningful changes (e.g., added skills, expanded experience, improved action verbs) rather than simple text differences. The backend engine utilizes NLP heuristics to categorize changes and generate summary statistics. The frontend features a polished, glassmorphic dashboard with a high-level summary and a detailed, color-coded unified diff viewer, fully supporting the existing dark/light theme system.

## 🔗 Related Issue
Closes #888

## ✅ Type of Change
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [x] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?
- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer.tests.test_semantic_differ`)
- [x] Manually tested in the browser with various resume version combinations

## 📋 Checklist
- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)