### PR TITLE
Add useUserPreferences hook for user settings

### DIFF
--- a/frontend/components/CareerTrackSelector.jsx
+++ b/frontend/components/CareerTrackSelector.jsx
@@ -1,0 +1,55 @@
+// src/components/CareerTrackSelector.jsx
+
+import React from 'react';
+import { useUserPreferences } from '../hooks/useUserPreferences';
+
+export default function CareerTrackSelector({ currentUser }) {
+    const { careerTrack, experienceLevel, savePreferences } = useUserPreferences(currentUser);
+
+    const tracks = ['Frontend Developer', 'Backend Developer', 'Full Stack Engineer', 'Data Scientist', 'AI/ML Engineer'];
+    const levels = ['Entry-Level', 'Mid-Level', 'Senior', 'Lead / Principal'];
+
+    const handleTrackChange = (e) => {
+        savePreferences(e.target.value, experienceLevel);
+    };
+
+    const handleLevelChange = (e) => {
+        savePreferences(careerTrack, e.target.value);
+    };
+
+    return (
+        <div className="bg-white p-6 rounded-xl shadow-md max-w-xl mx-auto space-y-4">
+            <h3 className="text-lg font-bold text-gray-800">Resume Analysis Settings</h3>
+            
+            <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Career Track</label>
+                <select 
+                    value={careerTrack} 
+                    onChange={handleTrackChange}
+                    className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:ring-2 focus:ring-blue-500"
+                >
+                    {tracks.map(track => (
+                        <option key={track} value={track}>{track}</option>
+                    ))}
+                </select>
+            </div>
+
+            <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Experience Level</label>
+                <select 
+                    value={experienceLevel} 
+                    onChange={handleLevelChange}
+                    className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:ring-2 focus:ring-blue-500"
+                >
+                    {levels.map(level => (
+                        <option key={level} value={level}>{level}</option>
+                    ))}
+                </select>
+            </div>
+
+            <p className="text-xs text-gray-500 italic">
+                Your last-used selections are automatically saved for your next visit.
+            </p>
+        </div>
+    );
+}

--- a/frontend/hooks/useUserPreferences.js
+++ b/frontend/hooks/useUserPreferences.js
@@ -1,0 +1,59 @@
+// src/hooks/useUserPreferences.js
+
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY_TRACK = 'ai_resume_last_career_track';
+const STORAGE_KEY_LEVEL = 'ai_resume_last_experience_level';
+
+const DEFAULT_TRACK = 'Frontend Developer';
+const DEFAULT_LEVEL = 'Mid-Level';
+
+export function useUserPreferences(user = null) {
+    const [careerTrack, setCareerTrack] = useState(() => {
+        return localStorage.getItem(STORAGE_KEY_TRACK) || DEFAULT_TRACK;
+    });
+
+    const [experienceLevel, setExperienceLevel] = useState(() => {
+        return localStorage.getItem(STORAGE_KEY_LEVEL) || DEFAULT_LEVEL;
+    });
+
+    // Synchronize or fetch account-based preferences if user is logged in
+    useEffect(() => {
+        if (user && user.preferences) {
+            if (user.preferences.careerTrack) {
+                setCareerTrack(user.preferences.careerTrack);
+            }
+            if (user.preferences.experienceLevel) {
+                setExperienceLevel(user.preferences.experienceLevel);
+            }
+        }
+    }, [user]);
+
+    const savePreferences = async (newTrack, newLevel) => {
+        setCareerTrack(newTrack);
+        setExperienceLevel(newLevel);
+
+        // Always save to localStorage for fallback/anonymous users
+        localStorage.setItem(STORAGE_KEY_TRACK, newTrack);
+        localStorage.setItem(STORAGE_KEY_LEVEL, newLevel);
+
+        // If user is logged in, sync with backend API
+        if (user && user.id) {
+            try {
+                await fetch('/api/user/preferences', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ careerTrack: newTrack, experienceLevel: newLevel }),
+                });
+            } catch (err) {
+                console.error('Failed to sync user preferences to account:', err);
+            }
+        }
+    };
+
+    return {
+        careerTrack,
+        experienceLevel,
+        savePreferences,
+    };
+}


### PR DESCRIPTION
feat: Remember and pre-select last-used Career Track and Experience Level (#753)

Description
This pull request resolves issue #753, ensuring that returning users do not encounter generic default selections upon every visit. Selections are persisted via localStorage for anonymous visitors and synchronized with user account profiles for logged-in users.

Key Features Added
Custom Preference Hook (src/hooks/useUserPreferences.js): Handles local storage persistence and optional backend account synchronization.

Smart Pre-selection: Automatically populates the user's last-used Career Track and Experience Level on return visits while preserving sensible defaults for first-time visitors.

Updated UI Component (src/components/CareerTrackSelector.jsx): Seamlessly binds dropdown selections to persistent user state.

Files Added / Modified
frontend/hooks/useUserPreferences.js (State management and persistence logic)

frontend/components/CareerTrackSelector.jsx (Interactive dropdown selector component)

Assignees
@Muskankr


Closing Statement
This PR successfully closes #753, improving user experience and workflow efficiency within the AI Resume Analyzer platform.