### PR TITLE
fix: route the six endpoints that were never given a path (#912)

### DIFF
--- a/backend/analyzer/bullet_views.py
+++ b/backend/analyzer/bullet_views.py
@@ -17,6 +17,13 @@ from rest_framework.throttling import UserRateThrottle
 
 
 class BulletOptimizationThrottle(UserRateThrottle):
+    # `scope` decides the cache key, and `UserRateThrottle` sets it to "user"
+    # for every subclass. Without an override each of these endpoints counted
+    # against one shared bucket keyed on the user id, so the tightest limit in
+    # the app applied to all of them: five interview questions a minute meant
+    # five bullet optimisations a minute too. Distinct scopes give each
+    # endpoint the rate its own class declares.
+    scope = "bullet_optimization"
     rate = "10/minute"
 
 

--- a/backend/analyzer/diff_views.py
+++ b/backend/analyzer/diff_views.py
@@ -16,6 +16,13 @@ from rest_framework.throttling import UserRateThrottle
 
 
 class SemanticDiffThrottle(UserRateThrottle):
+    # `scope` decides the cache key, and `UserRateThrottle` sets it to "user"
+    # for every subclass. Without an override each of these endpoints counted
+    # against one shared bucket keyed on the user id, so the tightest limit in
+    # the app applied to all of them: five interview questions a minute meant
+    # five bullet optimisations a minute too. Distinct scopes give each
+    # endpoint the rate its own class declares.
+    scope = "semantic_diff"
     rate = "10/minute"
 
 

--- a/backend/analyzer/interview_views.py
+++ b/backend/analyzer/interview_views.py
@@ -16,6 +16,13 @@ from rest_framework.throttling import UserRateThrottle
 
 
 class InterviewQuestionThrottle(UserRateThrottle):
+    # `scope` decides the cache key, and `UserRateThrottle` sets it to "user"
+    # for every subclass. Without an override each of these endpoints counted
+    # against one shared bucket keyed on the user id, so the tightest limit in
+    # the app applied to all of them: five interview questions a minute meant
+    # five bullet optimisations a minute too. Distinct scopes give each
+    # endpoint the rate its own class declares.
+    scope = "interview_questions"
     rate = "5/minute"
 
 

--- a/backend/analyzer/multilingual_views.py
+++ b/backend/analyzer/multilingual_views.py
@@ -1,0 +1,148 @@
+"""HTTP endpoints for language detection and translation.
+
+``language_detector.py``, ``translation_service.py`` and
+``multilingual_serializers.py`` were all written, and nothing was ever put
+between them and a URL. ``frontend/src/services/translationService.ts`` has
+been posting to ``/api/analyzer/detect-language/`` and ``/api/analyzer/translate/``
+since it was added; both returned 404.
+
+The two views are thin on purpose: they validate, call the module that does the
+work, and shape the result to the serializer that was already written for it.
+"""
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
+from rest_framework.views import APIView
+
+from .language_detector import LanguageDetector
+from .multilingual_serializers import (
+    LanguageDetectionRequestSerializer,
+    LanguageDetectionResponseSerializer,
+    TranslationRequestSerializer,
+    TranslationResponseSerializer,
+)
+from .translation_service import TranslationService
+
+
+class LanguageDetectionThrottle(UserRateThrottle):
+    """Detection is cheap, but it runs on every upload in the worst case."""
+
+    # A distinct scope, or this shares one cache bucket with every other
+    # `UserRateThrottle` in the app and inherits the tightest rate among them.
+    scope = "language_detection"
+    rate = "30/minute"
+
+
+class TranslationThrottle(UserRateThrottle):
+    """Translation is the expensive one — it fans out to a paid API per chunk."""
+
+    scope = "translation"
+    rate = "10/minute"
+
+
+class LanguageDetectionView(APIView):
+    """Report the primary language of a block of resume text."""
+
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [LanguageDetectionThrottle]
+
+    @extend_schema(
+        request=LanguageDetectionRequestSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=LanguageDetectionResponseSerializer,
+                description="Detected language, confidence and the method used.",
+            ),
+            400: OpenApiResponse(description="Invalid input data"),
+        },
+        summary="Detect the language of resume text",
+    )
+    def post(self, request):
+        serializer = LanguageDetectionRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        text = serializer.validated_data["text"]
+        result = LanguageDetector.detect(text)
+
+        return Response(
+            {
+                "language_code": result.language_code,
+                "language_name": result.language_name,
+                "confidence": result.confidence,
+                "method_used": result.method_used,
+                # Derived from the same result rather than a second `detect`
+                # call, so the flag and the code can never disagree.
+                "is_english": result.language_code == "en",
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class TranslationView(APIView):
+    """Translate resume text to English for the scoring engine.
+
+    ``source_language`` defaults to ``"auto"``, in which case the language is
+    detected here rather than being pushed onto the caller — the frontend has
+    the text, not a language code.
+    """
+
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [TranslationThrottle]
+
+    @extend_schema(
+        request=TranslationRequestSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=TranslationResponseSerializer,
+                description="Translated text, or the original when translation failed.",
+            ),
+            400: OpenApiResponse(description="Invalid input data"),
+        },
+        summary="Translate resume text to English",
+    )
+    def post(self, request):
+        serializer = TranslationRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        text = serializer.validated_data["text"]
+        source_language = serializer.validated_data.get("source_language", "auto")
+        target_language = serializer.validated_data.get("target_language", "en")
+
+        if target_language != "en":
+            return Response(
+                {
+                    "error": (
+                        "Only translation to English is supported. The scoring "
+                        "engine reads English, and translating away from it "
+                        "would leave nothing to score."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if source_language == "auto":
+            source_language = LanguageDetector.detect(text).language_code
+
+        # No translation provider is configured in this deployment, so the
+        # service falls back to returning the original text. `success` still
+        # reports honestly, and the frontend already renders that state.
+        result = TranslationService().translate_to_english(
+            text, source_lang=source_language
+        )
+
+        return Response(
+            {
+                "original_text": result.original_text,
+                "translated_text": result.translated_text,
+                "source_language": result.source_language,
+                "target_language": result.target_language,
+                "success": result.success,
+                "error_message": result.error_message,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/backend/analyzer/tests_api_routes.py
+++ b/backend/analyzer/tests_api_routes.py
@@ -20,6 +20,7 @@ When you add an endpoint the frontend calls, add it to ROUTES below.
 """
 
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import Resolver404, resolve
@@ -62,6 +63,19 @@ ROUTES = [
     ("/api/auth/refresh/", "api/client.ts"),
     ("/api/password-reset/", "AuthModal.tsx"),
     ("/api/password-reset-confirm/", "components/ResetPasswordConfirmPage.tsx"),
+    # Six features whose views, serializers and engines were all written and
+    # then never given a path. Every one of them 404'd from the day it shipped.
+    ("/api/analyzer/optimize-bullets/", "services/bulletOptimizationService.ts"),
+    ("/api/analyzer/semantic-diff/", "components/ResumeDiffViewer.tsx"),
+    (
+        "/api/analyzer/generate-interview-questions/",
+        "hooks/useInterviewQuestions.ts",
+    ),
+    ("/api/analyzer/detect-language/", "services/translationService.ts"),
+    ("/api/analyzer/translate/", "services/translationService.ts"),
+    # Not called from the frontend yet. Routed in the same pass rather than
+    # left as the next 404.
+    ("/api/analyzer/layout-analysis/", "components/LayoutAnalysisReport.tsx"),
 ]
 
 
@@ -298,3 +312,294 @@ class SharedResultEndpointTests(TestCase):
     def test_an_unknown_share_id_is_a_404(self):
         resp = self.client.get("/api/shared/2b0c9a1e-5f3d-4a7b-9c2e-8d1f0a6b4c33/")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class ViewModuleRoutingTests(TestCase):
+    """Every view class in the app must be reachable from a URL.
+
+    ``test_a_view_imported_into_urls_is_also_routed`` above catches a view that
+    ``urls.py`` imports and forgets to route. It cannot catch the larger
+    mistake: a whole feature module that ``urls.py`` never imports at all.
+
+    That is how six endpoints shipped dead. ``bullet_views.py``,
+    ``diff_views.py``, ``interview_views.py``, ``layout_views.py`` and
+    ``multilingual_views.py`` each had a view, a serializer, a throttle class
+    and a docstring describing the endpoint — and no ``path()`` anywhere. The
+    app imported cleanly, the checks passed, and the only symptom was a 404
+    that looks identical to a signed-out session from the browser.
+
+    So this walks the app for view modules and asserts each view class in them
+    is registered, without ``urls.py`` getting a say in which modules count.
+    """
+
+    #: Modules whose views are deliberately not routed here.
+    #:
+    #: ``views.py`` holds the function-based views plus a handful of DRF
+    #: generic base classes; it is already covered by the import/route check
+    #: above, and walking it would flag the bases.
+    EXEMPT_MODULES = {"views"}
+
+    @staticmethod
+    def _view_modules():
+        """Every ``*_views.py`` module in the app, imported."""
+        import importlib
+        from pathlib import Path
+
+        app_dir = Path(__file__).resolve().parent
+        for path in sorted(app_dir.glob("*_views.py")):
+            if path.stem in ViewModuleRoutingTests.EXEMPT_MODULES:
+                continue
+            yield importlib.import_module(f"analyzer.{path.stem}")
+
+    @staticmethod
+    def _view_classes(module):
+        """APIView subclasses *defined in* ``module``.
+
+        Defined in, not merely visible from: ``APIView`` itself and any base
+        imported for subclassing would otherwise be reported as unrouted.
+        """
+        import inspect
+
+        from rest_framework.views import APIView
+
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if not issubclass(obj, APIView) or obj is APIView:
+                continue
+            if obj.__module__ != module.__name__:
+                continue
+            yield obj
+
+    @staticmethod
+    def _routed_view_classes():
+        """Every view class registered in the project's URL configuration."""
+        from django.urls import get_resolver
+
+        routed = set()
+
+        def walk(patterns):
+            for pattern in patterns:
+                sub = getattr(pattern, "url_patterns", None)
+                if sub is not None:
+                    walk(sub)
+                    continue
+                callback = getattr(pattern, "callback", None)
+                # `as_view()` hangs the class off the callback as `cls`; this
+                # is the documented way back from a route to its view class.
+                view_class = getattr(callback, "cls", None) or getattr(
+                    callback, "view_class", None
+                )
+                if view_class is not None:
+                    routed.add(view_class)
+
+        walk(get_resolver().url_patterns)
+        return routed
+
+    def test_every_view_class_in_a_view_module_is_routed(self):
+        routed = self._routed_view_classes()
+
+        unrouted = []
+        for module in self._view_modules():
+            for view_class in self._view_classes(module):
+                if view_class not in routed:
+                    unrouted.append(f"{module.__name__}.{view_class.__name__}")
+
+        self.assertEqual(
+            sorted(unrouted),
+            [],
+            "These view classes are defined but no URL reaches them, so the "
+            "features they implement are dead on arrival:\n  "
+            + "\n  ".join(sorted(unrouted)),
+        )
+
+    def test_the_walk_actually_finds_view_modules(self):
+        """Guards the guard: an empty walk would pass the assertion above."""
+        modules = list(self._view_modules())
+        self.assertGreaterEqual(
+            len(modules),
+            5,
+            f"Expected the app to hold several *_views.py modules, found {len(modules)}.",
+        )
+
+
+class MultilingualEndpointTests(TestCase):
+    """Behaviour of the two endpoints that had no view module at all.
+
+    ``multilingual_serializers.py`` described this contract from the start.
+    Nothing implemented it.
+    """
+
+    def setUp(self):
+        # DRF keeps throttle history in the default cache, which persists
+        # across tests in the same process. Without this, the endpoint tested
+        # last inherits every earlier test's requests and 429s.
+        cache.clear()
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="polyglot", password="password123"
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_detection_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        resp = self.client.post("/api/analyzer/detect-language/", {"text": "Hello"})
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_detection_returns_the_documented_shape(self):
+        resp = self.client.post(
+            "/api/analyzer/detect-language/",
+            {"text": "Experienced backend engineer working with Python and Django."},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            sorted(resp.data),
+            ["confidence", "is_english", "language_code", "language_name", "method_used"],
+        )
+
+    def test_detection_flag_agrees_with_the_code_it_reports(self):
+        """`is_english` is derived from the same result, so it cannot contradict it."""
+        resp = self.client.post(
+            "/api/analyzer/detect-language/",
+            {"text": "Ingeniero de software con experiencia en sistemas distribuidos."},
+            format="json",
+        )
+
+        self.assertEqual(
+            resp.data["is_english"], resp.data["language_code"] == "en"
+        )
+
+    def test_detection_rejects_a_missing_text_field(self):
+        resp = self.client.post("/api/analyzer/detect-language/", {}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("text", resp.data)
+
+    def test_translation_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        resp = self.client.post("/api/analyzer/translate/", {"text": "Hola"})
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_translation_returns_the_documented_shape(self):
+        resp = self.client.post(
+            "/api/analyzer/translate/",
+            {"text": "Bonjour, je suis ingenieur.", "source_language": "fr"},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        for field in (
+            "original_text",
+            "translated_text",
+            "source_language",
+            "target_language",
+            "success",
+        ):
+            self.assertIn(field, resp.data)
+        self.assertEqual(resp.data["target_language"], "en")
+
+    def test_translation_detects_the_source_when_asked_to(self):
+        """`auto` is the serializer's default, so the common call must work."""
+        resp = self.client.post(
+            "/api/analyzer/translate/",
+            {"text": "Ingeniero de software con experiencia en sistemas."},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertNotEqual(resp.data["source_language"], "auto")
+
+    def test_translation_to_a_language_other_than_english_is_refused(self):
+        """The scoring engine reads English; translating away from it scores nothing."""
+        resp = self.client.post(
+            "/api/analyzer/translate/",
+            {"text": "Hello there.", "target_language": "fr"},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)
+
+    def test_translation_rejects_a_missing_text_field(self):
+        resp = self.client.post("/api/analyzer/translate/", {}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("text", resp.data)
+
+
+class RoutedFeatureEndpointTests(TestCase):
+    """The four modules that had a view but no path, now that they have one.
+
+    Shallow on purpose. Each engine has its own test file; what was missing was
+    any assertion that a request can reach one.
+    """
+
+    def setUp(self):
+        # DRF keeps throttle history in the default cache, which persists
+        # across tests in the same process. Without this, the endpoint tested
+        # last inherits every earlier test's requests and 429s.
+        cache.clear()
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="jobseeker", password="password123"
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_bullet_optimization_reaches_the_optimizer(self):
+        resp = self.client.post(
+            "/api/analyzer/optimize-bullets/",
+            {"bullets": ["Managed a team of five engineers."]},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["total_processed"], 1)
+        self.assertEqual(len(resp.data["results"]), 1)
+
+    def test_bullet_optimization_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        resp = self.client.post(
+            "/api/analyzer/optimize-bullets/", {"bullets": ["x"]}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_semantic_diff_reaches_the_differ(self):
+        resp = self.client.post(
+            "/api/analyzer/semantic-diff/",
+            {
+                "text_v1": "Skills\nPython, Django",
+                "text_v2": "Skills\nPython, Django, AWS",
+            },
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("summary", resp.data)
+        self.assertIn("changes", resp.data)
+
+    def test_interview_generation_reaches_the_generator(self):
+        resp = self.client.post(
+            "/api/analyzer/generate-interview-questions/",
+            {
+                "resume_text": "Backend engineer. Led a team. Built services in Python.",
+                "skills": ["python", "django"],
+                "job_description": "We need someone strong in Kubernetes and AWS.",
+            },
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertGreater(resp.data["total_questions"], 0)
+        self.assertEqual(len(resp.data["questions"]), resp.data["total_questions"])
+
+    def test_layout_analysis_rejects_a_request_with_no_file(self):
+        resp = self.client.post("/api/analyzer/layout-analysis/", {})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)
+
+    def test_layout_analysis_rejects_a_non_pdf(self):
+        upload = SimpleUploadedFile(
+            "resume.txt", b"plain text resume", content_type="text/plain"
+        )
+        resp = self.client.post("/api/analyzer/layout-analysis/", {"file": upload})
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -37,6 +37,15 @@ from .views import (
 )
 from .badge_views import manage_resume_badge, resume_score_badge
 
+# The feature modules below were written with views, serializers and tests, and
+# were never given a path. Everything under `analyzer/` matches the URLs the
+# frontend has been requesting all along — see `tests_api_routes.ROUTES`.
+from .bullet_views import BulletOptimizeView
+from .diff_views import SemanticDiffView
+from .interview_views import InterviewQuestionGenerateView
+from .layout_views import LayoutAnalysisView
+from .multilingual_views import LanguageDetectionView, TranslationView
+
 urlpatterns = [
     path("upload/", upload_resume),
     path("preview-level/", preview_experience_level_view),
@@ -79,4 +88,43 @@ urlpatterns = [
     path('password-reset/', PasswordResetRequestView.as_view(), name='password_reset_request'),
     path('password-reset-confirm/', PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     path("admin/stats/", admin_stats_view, name="admin_stats"),
+
+    # Resume-improvement tools.
+    #
+    # These sit under an `analyzer/` prefix rather than alongside the routes
+    # above. That is not a preference: `frontend/src/services/`,
+    # `frontend/src/hooks/useInterviewQuestions.ts` and
+    # `components/ResumeDiffViewer.tsx` already post to these exact paths, and
+    # moving the frontend instead would break any client already deployed
+    # against them.
+    path(
+        "analyzer/optimize-bullets/",
+        BulletOptimizeView.as_view(),
+        name="optimize_bullets",
+    ),
+    path(
+        "analyzer/semantic-diff/",
+        SemanticDiffView.as_view(),
+        name="semantic_diff",
+    ),
+    path(
+        "analyzer/generate-interview-questions/",
+        InterviewQuestionGenerateView.as_view(),
+        name="generate_interview_questions",
+    ),
+    path(
+        "analyzer/layout-analysis/",
+        LayoutAnalysisView.as_view(),
+        name="layout_analysis",
+    ),
+    path(
+        "analyzer/detect-language/",
+        LanguageDetectionView.as_view(),
+        name="detect_language",
+    ),
+    path(
+        "analyzer/translate/",
+        TranslationView.as_view(),
+        name="translate_resume_text",
+    ),
 ]


### PR DESCRIPTION
Closes #912.

`bullet_views.py`, `diff_views.py`, `interview_views.py` and `layout_views.py` each hold a view, a serializer, a throttle class and a docstring describing an endpoint. None of them was imported by `urls.py`. `detect-language/` and `translate/` had no view module at all — the serializers and the two engines behind them were written and never connected to anything.

The frontend has been posting to three of these since the components shipped:

```
services/bulletOptimizationService.ts:40  POST /api/analyzer/optimize-bullets/            → 404
components/ResumeDiffViewer.tsx:41        POST /api/analyzer/semantic-diff/               → 404
hooks/useInterviewQuestions.ts:38         POST /api/analyzer/generate-interview-questions/ → 404
services/translationService.ts:35,57      POST /api/analyzer/detect-language/, /translate/ → 404
```

From the browser a 404 here is indistinguishable from a signed-out session, which is why none of it was reported as a routing problem.

## What this does

- Routes all six, under the `analyzer/` prefix the frontend already requests. Moving the frontend instead would break any client already deployed against these paths.
- Adds `multilingual_views.py` over the serializers that were already written for the contract. `is_english` is derived from the same detection result rather than a second call, so the flag and the code cannot disagree. Translation to a target other than English is a 400 — the scoring engine reads English, so translating away from it leaves nothing to score.

## Why it could happen twice

`tests_api_routes.py` already had a check for this, added when `profile_avatar_view` shipped unrouted. It reads the names `urls.py` imports and compares them against the callbacks it registers — which cannot see a module `urls.py` never mentions at all.

`ViewModuleRoutingTests` closes that: it walks the app for `*_views.py`, collects the `APIView` subclasses defined in each (defined in, not merely visible from — otherwise the imported bases get reported), and asserts every one is reachable in the resolver. `urls.py` gets no say in which modules count. Removing any one of the six new paths fails it by name.

The six paths also join `ROUTES`, each annotated with the frontend file that calls it.

## One thing found while testing

The first `generate-interview-questions/` request in a fresh test came back 429. Every one of these throttles subclasses `UserRateThrottle` without overriding `scope`, so they all share the cache key `throttle_user_<pk>` and the tightest rate in the app applies to all of them — five interview questions a minute meant five bullet optimisations a minute. Harmless while the endpoints were unreachable; not harmless now. Each declares its own scope.

## Verification

```
$ python manage.py test analyzer.tests_api_routes
Ran 35 tests ... OK

$ python manage.py test
Ran 687 tests ... OK
```

+522 lines, no behaviour change to any existing endpoint.
