### PR TITLE
fix: read a bullet the way a person wrote it (#915)

### DIFF
--- a/backend/analyzer/bullet_optimizer.py
+++ b/backend/analyzer/bullet_optimizer.py
@@ -1,11 +1,139 @@
 """
 Core NLP logic to parse, evaluate, and rewrite resume bullet points
 using the STAR (Situation, Task, Action, Result) framework.
+
+Everything here reads one line of resume text as a human wrote it, which is
+what the previous implementation did not do. It took ``bullet.lower().split()``
+and compared ``words[0]`` against a 15-word verb list, so a line that opened
+with the bullet character the parser preserved — "• Spearheaded ..." — had
+``words[0] == "•"`` and was told to start with an action verb. So did
+"Developed, tested and shipped ...", whose first token is ``"developed,"``.
 """
 
 import re
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 from dataclasses import dataclass
+
+from .scoring import ACTION_VERBS as SCORING_ACTION_VERBS
+
+#: Characters that open a bullet, matching ``scoring.BULLET_PATTERN``.
+#:
+#: The en dash and em dash matter: Word and Google Docs autoformat a leading
+#: "-" into "–", so the glyph in the file is usually not the one that was
+#: typed. ``-`` is first in the class so it is a literal rather than a range.
+BULLET_MARKER = re.compile(r"^\s*(?:[-–—*•▪▫▸▹●○◦‣∙·]|\d+[.)])\s*")
+
+#: Trailing and leading punctuation to peel off a word before matching it.
+WORD_EDGES = "\"'“”‘’(),.;:!?-–—"
+
+#: Percentages: "40%", "40 %", "40 percent".
+_PERCENT = r"\d+(?:\.\d+)?\s*(?:%|percent\b|per cent\b)"
+
+#: Money, with or without a magnitude suffix: "$1.5M", "£250k", "€2 million".
+_CURRENCY = (
+    r"[$£€¥]\s?\d[\d,]*(?:\.\d+)?\s*"
+    r"(?:[kKmMbB]\b|thousand\b|million\b|billion\b)?"
+)
+
+#: A number carrying a unit that makes it a measurement rather than a label.
+#: This is the list that separates "5 engineers" from "Python 3".
+_UNITS = (
+    r"(?:k\b|m\b|bn\b|thousand|million|billion|"
+    r"hrs?|hours?|mins?|minutes?|secs?|seconds?|ms|days?|weeks?|months?|years?|"
+    r"users?|customers?|clients?|accounts?|subscribers?|"
+    r"requests?|queries?|calls?|transactions?|records?|rows?|events?|"
+    r"engineers?|developers?|people|reports?|teams?|"
+    r"projects?|releases?|deploys?|deployments?|services?|endpoints?|"
+    r"tests?|bugs?|tickets?|incidents?|"
+    r"gb|tb|mb|qps|rps|req/s)"
+)
+_MEASUREMENT = rf"\d[\d,]*(?:\.\d+)?\s*{_UNITS}"
+
+#: "3x", "2.5×" — a multiplier is always a claim about magnitude.
+_MULTIPLIER = r"\d+(?:\.\d+)?\s*[x×]\b"
+
+#: A count introduced by a quantifier: "a team of 12", "over 500", "40+".
+_QUANTIFIED_COUNT = (
+    r"(?:\b(?:team|group|cohort|portfolio|backlog|fleet|suite)\s+of\s+\d[\d,]*"
+    r"|\b(?:over|under|more than|less than|up to|at least|around|approximately|~)\s*\d[\d,]*"
+    r"|\b\d[\d,]*\+)"
+)
+
+#: What counts as a quantified achievement.
+#:
+#: Positive patterns only, deliberately. The previous pattern alternated
+#: ``\b\d+%?\b`` with ``\b\d{1,3}(?:,\d{3})*(?:\.\d+)?\b``, which matches every
+#: digit in the language: "Wrote services in Python 3 during 2021" read as a
+#: quantified achievement and was told it needed no metric. Listing the shapes
+#: a metric actually takes means a version number and a year match nothing.
+METRIC_PATTERN = re.compile(
+    "|".join((_PERCENT, _CURRENCY, _MEASUREMENT, _MULTIPLIER, _QUANTIFIED_COUNT)),
+    re.IGNORECASE,
+)
+
+#: Forms of "to be" that introduce a passive construction.
+COPULAS = ("is", "are", "am", "was", "were", "be", "been", "being")
+
+#: Past participles that do not end in -ed or -en.
+IRREGULAR_PARTICIPLES = {
+    "built", "brought", "bought", "dealt", "done", "found", "held", "kept",
+    "led", "left", "lost", "made", "met", "paid", "put", "read", "run",
+    "sent", "set", "sold", "spent", "split", "taught", "told", "won",
+}
+
+#: A copula followed by a participle: "was completed", "are being tracked".
+PASSIVE_PATTERN = re.compile(
+    r"\b(?:{copulas})\b\s+(?:\w+ly\s+)?(?:being\s+)?(\w+)\b".format(
+        copulas="|".join(COPULAS)
+    ),
+    re.IGNORECASE,
+)
+
+#: A result introduced by a participial or prepositional clause.
+RESULT_CLAUSE_PATTERN = re.compile(
+    r"\b(?:resulting in|leading to|which (?:led|resulted) in|"
+    r"achieving|saving|generating|driving|delivering|yielding|enabling|"
+    r"cutting|reducing|increasing|improving|boosting|raising|lowering|"
+    r"eliminating|accelerating)\s+([^.;]+)",
+    re.IGNORECASE,
+)
+
+#: A result stated as a quantified change: "by 40%", "to under 200ms".
+#:
+#: The optional hedge between the preposition and the number is what makes
+#: "reduced p99 latency **to under** 200ms" a stated result rather than nothing.
+RESULT_DELTA_PATTERN = re.compile(
+    rf"\b(?:by|to|from)\s+"
+    rf"(?:(?:under|over|below|above|less than|more than|approximately|around|about|~)\s*)?"
+    rf"((?:{_PERCENT}|{_CURRENCY}|{_MEASUREMENT}|{_MULTIPLIER})[^.;]*)",
+    re.IGNORECASE,
+)
+
+#: Where the work happened. ``\b`` on every alternative, or "in" matches inside
+#: "within" and "during" inside nothing useful at all — the old pattern
+#: returned "legacy storage" as the *situation* of "Migrated the data into
+#: legacy storage", having matched the "to" inside "into".
+CONTEXT_PATTERN = re.compile(
+    r"\b(?:in|at|for|across|within|during|throughout)\s+"
+    r"((?:the\s+)?[A-Z][\w&.-]*(?:\s+[A-Z][\w&.-]*)*)"
+)
+
+#: The objective. Same word-boundary problem, same fix.
+OBJECTIVE_PATTERN = re.compile(
+    r"\b(?:to|in order to)\s+([a-zA-Z][a-zA-Z\s]+?)(?:\s*[,.;]|\s+by\b|$)"
+)
+
+#: Points per dimension. They sum to 100 for a bullet that has an action verb,
+#: a metric, active voice and a stated result — the four things the suggestion
+#: list asks for. A bullet with none of them scores 0 rather than the flat 50
+#: the old base score handed out unconditionally.
+SCORE_WEIGHTS = {
+    "action_verb": 30,
+    "metric": 25,
+    "result": 20,
+    "active_voice": 15,
+    "situation": 10,
+}
 
 
 @dataclass
@@ -23,44 +151,33 @@ class BulletAnalysis:
 class BulletOptimizer:
     """Evaluates and optimizes resume bullet points."""
 
-    ACTION_VERBS = {
-        "achieved",
-        "improved",
-        "trained",
-        "managed",
-        "created",
-        "resolved",
-        "volunteered",
-        "influenced",
-        "increased",
-        "decreased",
-        "launched",
-        "spearheaded",
-        "orchestrated",
-        "developed",
-        "engineered",
-    }
+    #: The same vocabulary ``analyzer.scoring`` grades resumes against.
+    #:
+    #: There were two lists. This one held 15 verbs, so "built", "led",
+    #: "designed", "migrated", "reduced", "owned" and "shipped" all scored
+    #: zero and were told to open with a strong action verb — by the module
+    #: whose sibling already recognised every one of them.
+    ACTION_VERBS = frozenset(SCORING_ACTION_VERBS)
 
-    PASSIVE_INDICATORS = ["was", "were", "been", "being", "is", "are", "am"]
+    PASSIVE_INDICATORS = list(COPULAS)
 
-    METRIC_PATTERN = re.compile(r"\b\d+%?\b|\b\d{1,3}(?:,\d{3})*(?:\.\d+)?\b|\$\d+")
+    METRIC_PATTERN = METRIC_PATTERN
 
     @classmethod
     def analyze(cls, bullet: str) -> BulletAnalysis:
         """Analyze a single bullet point for STAR compliance and quality."""
-        words = bullet.lower().split()
-        first_word = words[0] if words else ""
+        text = cls._strip_marker(bullet)
 
-        has_action = first_word in cls.ACTION_VERBS
-        has_metric = bool(cls.METRIC_PATTERN.search(bullet))
-        is_passive = any(word in cls.PASSIVE_INDICATORS for word in words[:3])
+        has_action = cls._opens_with_action_verb(text)
+        has_metric = bool(cls.METRIC_PATTERN.search(text))
+        is_passive = cls._is_passive(text)
 
-        star = cls._extract_star_components(bullet)
+        star = cls._extract_star_components(text)
         score = cls._calculate_score(has_action, has_metric, is_passive, star)
         suggestions = cls._generate_suggestions(
             has_action, has_metric, is_passive, star
         )
-        rewrites = cls._generate_rewrites(bullet, has_action, has_metric, is_passive)
+        rewrites = cls._generate_rewrites(text, has_action, has_metric, is_passive)
 
         return BulletAnalysis(
             original=bullet,
@@ -74,6 +191,53 @@ class BulletOptimizer:
         )
 
     @classmethod
+    def _strip_marker(cls, bullet: str) -> str:
+        """The bullet's text, without the glyph or number that introduces it."""
+        return BULLET_MARKER.sub("", bullet or "").strip()
+
+    @classmethod
+    def _first_word(cls, text: str) -> str:
+        """The opening word, lowercased and stripped of attached punctuation."""
+        for token in text.split():
+            word = token.strip(WORD_EDGES).lower()
+            if word:
+                return word
+        return ""
+
+    @classmethod
+    def _opens_with_action_verb(cls, text: str) -> bool:
+        return cls._first_word(text) in cls.ACTION_VERBS
+
+    @classmethod
+    def _looks_like_participle(cls, word: str) -> bool:
+        lowered = word.lower()
+        return lowered.endswith(("ed", "en")) or lowered in IRREGULAR_PARTICIPLES
+
+    @classmethod
+    def _is_passive(cls, text: str) -> bool:
+        """True when the bullet describes work as something that happened to it.
+
+        Two shapes, because the common resume passive is not the textbook one:
+
+        * A copula plus a participle anywhere in the line — "the migration
+          *was completed* by the team", "metrics *are tracked* daily". The old
+          check only looked at the first three words, which is precisely where
+          this construction is not.
+        * The line *opening* with a copula — "Was responsible for the team".
+          Not passive voice in the grammatical sense, but the same failure:
+          the sentence has no subject doing anything.
+        """
+        first = cls._first_word(text)
+        if first in COPULAS:
+            return True
+
+        for match in PASSIVE_PATTERN.finditer(text):
+            if cls._looks_like_participle(match.group(1)):
+                return True
+
+        return False
+
+    @classmethod
     def _extract_star_components(cls, bullet: str) -> Dict[str, Optional[str]]:
         """Heuristically extract Situation, Task, Action, Result."""
         return {
@@ -85,46 +249,69 @@ class BulletOptimizer:
 
     @classmethod
     def _find_context(cls, text: str) -> Optional[str]:
-        match = re.search(r"(?:in|at|for|during)\s+([A-Z][a-zA-Z\s]+)", text)
+        match = CONTEXT_PATTERN.search(text)
         return match.group(1).strip() if match else None
 
     @classmethod
     def _find_objective(cls, text: str) -> Optional[str]:
-        match = re.search(r"(?:to|for)\s+([a-zA-Z\s]+?)(?:,|\.|by|$)", text)
-        return match.group(1).strip() if match else None
+        match = OBJECTIVE_PATTERN.search(text)
+        if not match:
+            return None
+        objective = match.group(1).strip()
+        return objective or None
 
     @classmethod
     def _find_action(cls, text: str) -> Optional[str]:
+        """The verb phrase, from the first recognised verb onward.
+
+        Words are compared with their punctuation stripped, so a verb that ends
+        a clause — "Designed, built and shipped" — is still found.
+        """
         words = text.split()
-        for i, word in enumerate(words):
-            if word.lower() in cls.ACTION_VERBS:
-                return " ".join(words[i : i + 4])
+        for index, word in enumerate(words):
+            if word.strip(WORD_EDGES).lower() in cls.ACTION_VERBS:
+                return " ".join(words[index : index + 4])
         return None
 
     @classmethod
     def _find_result(cls, text: str) -> Optional[str]:
-        match = re.search(
-            r"(?:resulting in|achieving|leading to|saving|generating)\s+([a-zA-Z0-9\s%$]+)",
-            text,
-            re.IGNORECASE,
-        )
-        return match.group(1).strip() if match else None
+        """The outcome, stated either as a clause or as a quantified change.
+
+        The clause list alone missed the most common phrasing in a good bullet:
+        a trailing ", cutting latency by 40%" or a plain "by 15%". Both are a
+        result; only one of them announces itself with "resulting in".
+        """
+        match = RESULT_CLAUSE_PATTERN.search(text)
+        if match:
+            return match.group(1).strip(" .,;")
+
+        match = RESULT_DELTA_PATTERN.search(text)
+        if match:
+            return match.group(1).strip(" .,;")
+
+        return None
 
     @classmethod
     def _calculate_score(
         cls, has_action: bool, has_metric: bool, is_passive: bool, star: Dict
     ) -> int:
-        score = 50
+        """Points for what the bullet has, starting from nothing.
+
+        This used to start at 50 and add. A bullet with no verb, no metric, no
+        result and passive voice — the exact bullet the suggestions tell you to
+        rewrite entirely — still scored 50 out of 100, which reads as a pass.
+        """
+        score = 0
         if has_action:
-            score += 20
+            score += SCORE_WEIGHTS["action_verb"]
         if has_metric:
-            score += 20
+            score += SCORE_WEIGHTS["metric"]
+        if star.get("result"):
+            score += SCORE_WEIGHTS["result"]
         if not is_passive:
-            score += 10
-        if star["result"]:
-            score += 10
-        if star["situation"]:
-            score += 10
+            score += SCORE_WEIGHTS["active_voice"]
+        if star.get("situation"):
+            score += SCORE_WEIGHTS["situation"]
         return min(100, score)
 
     @classmethod
@@ -144,7 +331,7 @@ class BulletOptimizer:
             suggestions.append(
                 "Rewrite in active voice to demonstrate direct ownership."
             )
-        if not star["result"]:
+        if not star.get("result"):
             suggestions.append("Include the outcome or impact of your action.")
         return suggestions
 
@@ -152,20 +339,42 @@ class BulletOptimizer:
     def _generate_rewrites(
         cls, original: str, has_action: bool, has_metric: bool, is_passive: bool
     ) -> List[str]:
+        """Up to three rewrites, in a fixed order.
+
+        This returned ``list(set(rewrites))[:3]``. Set iteration order for
+        strings depends on ``PYTHONHASHSEED``, which Python randomises per
+        process, so two identical requests came back with the suggestions in a
+        different order — and with more than three candidates, with *different*
+        suggestions. Nothing downstream sorts them, so the panel reordered
+        under the user between one click and the next.
+
+        Deduplicated by first appearance instead, which keeps the order the
+        checks run in: the most important fix first.
+        """
         rewrites = []
         base = original.strip()
 
         if not has_action:
             rewrites.append(f"Spearheaded initiative: {base}")
         if not has_metric:
-            rewrites.append(f"{base}, resulting in a 25% improvement in efficiency.")
+            rewrites.append(f"{base.rstrip('.')}, resulting in a 25% improvement in efficiency.")
         if is_passive:
             active_base = re.sub(
-                r"was\s+([a-zA-Z]+ed)", r"successfully \1", base, flags=re.IGNORECASE
+                r"\b(?:was|were)\s+([a-zA-Z]+(?:ed|en))\b",
+                r"successfully \1",
+                base,
+                flags=re.IGNORECASE,
             )
             rewrites.append(active_base)
 
         if not rewrites:
             rewrites.append(f"Optimized: {base} to drive measurable business outcomes.")
 
-        return list(set(rewrites))[:3]
+        seen = set()
+        ordered = []
+        for rewrite in rewrites:
+            if rewrite not in seen:
+                seen.add(rewrite)
+                ordered.append(rewrite)
+
+        return ordered[:3]

--- a/backend/analyzer/tests_bullet_quality.py
+++ b/backend/analyzer/tests_bullet_quality.py
@@ -1,0 +1,266 @@
+"""How ``BulletOptimizer`` reads a bullet a person actually wrote.
+
+A flat ``tests_*.py`` module because that is the layout Django's discovery
+reaches in this app; ``analyzer/tests/test_bullet_optimizer.py`` covers part of
+this and has never been collected (#913).
+
+Every case here is a line that a resume produces and the previous
+implementation misread — a leading bullet glyph, a comma stuck to the verb, a
+year mistaken for a metric, a passive construction past the third word.
+"""
+
+from django.test import TestCase
+
+from analyzer.bullet_optimizer import BulletOptimizer
+from analyzer.scoring import ACTION_VERBS
+
+
+class BulletMarkerTests(TestCase):
+    """`words[0]` was the marker, not the verb.
+
+    pdfplumber preserves the glyph, and the serializer accepts whatever the
+    user pasted, so a bullet arriving with its marker is the common case.
+    """
+
+    STRONG = "Spearheaded a caching layer, cutting API latency by 40%."
+
+    MARKERS = ["- ", "* ", "• ", "– ", "— ", "▪ ", "1. ", "2) ", "  - ", ""]
+
+    def test_the_verb_is_found_behind_every_marker(self):
+        for marker in self.MARKERS:
+            with self.subTest(marker=repr(marker)):
+                analysis = BulletOptimizer.analyze(marker + self.STRONG)
+                self.assertTrue(
+                    analysis.has_action_verb,
+                    f"the marker {marker!r} hid the verb behind it",
+                )
+
+    def test_the_marker_does_not_change_the_score(self):
+        scores = {
+            BulletOptimizer.analyze(marker + self.STRONG).score
+            for marker in self.MARKERS
+        }
+        self.assertEqual(
+            len(scores),
+            1,
+            f"the same bullet scored differently depending on its marker: {scores}",
+        )
+
+    def test_the_original_is_returned_with_its_marker_intact(self):
+        """The user's line comes back as they wrote it; only matching is normalised."""
+        bullet = "• " + self.STRONG
+        self.assertEqual(BulletOptimizer.analyze(bullet).original, bullet)
+
+    def test_an_empty_bullet_does_not_raise(self):
+        for text in ("", "   ", "•", "- "):
+            with self.subTest(text=repr(text)):
+                analysis = BulletOptimizer.analyze(text)
+                self.assertFalse(analysis.has_action_verb)
+                self.assertEqual(analysis.score, 15)  # active voice only
+
+
+class ActionVerbTests(TestCase):
+    def test_punctuation_attached_to_the_verb_is_ignored(self):
+        analysis = BulletOptimizer.analyze("Developed, tested and shipped the service.")
+        self.assertTrue(analysis.has_action_verb)
+
+    def test_the_vocabulary_is_the_one_scoring_uses(self):
+        """Two lists meant `built`, `led` and `designed` scored zero here."""
+        self.assertEqual(set(BulletOptimizer.ACTION_VERBS), set(ACTION_VERBS))
+
+    def test_common_resume_verbs_are_recognised(self):
+        for verb in ("Built", "Led", "Designed", "Migrated", "Reduced", "Shipped"):
+            with self.subTest(verb=verb):
+                analysis = BulletOptimizer.analyze(f"{verb} the internal billing tool.")
+                self.assertTrue(
+                    analysis.has_action_verb,
+                    f'"{verb}" is a verb this tool tells people to use',
+                )
+
+    def test_a_noun_opening_is_not_an_action_verb(self):
+        analysis = BulletOptimizer.analyze("Responsibilities included the billing tool.")
+        self.assertFalse(analysis.has_action_verb)
+
+
+class MetricDetectionTests(TestCase):
+    """`\\b\\d+\\b` matched every digit in the language."""
+
+    QUANTIFIED = [
+        "Reduced latency by 40%.",
+        "Cut spend by 20 percent.",
+        "Increased revenue by $1.5M.",
+        "Saved £250k across the portfolio.",
+        "Handled 12,000 requests per second.",
+        "Mentored 6 engineers.",
+        "Cut build time from 45 minutes to 4 minutes.",
+        "Improved throughput 3x.",
+        "Owned a team of 12.",
+        "Resolved over 300 tickets.",
+        "Closed 40+ incidents.",
+    ]
+
+    NOT_QUANTIFIED = [
+        "Wrote services in Python 3 during 2021.",
+        "Migrated the platform to Django 4.",
+        "Worked on the team from 2019 to 2023.",
+        "Shipped version 2 of the mobile app.",
+        "Studied at university between 2015 and 2019.",
+    ]
+
+    def test_a_real_metric_is_recognised(self):
+        for bullet in self.QUANTIFIED:
+            with self.subTest(bullet=bullet):
+                self.assertTrue(
+                    BulletOptimizer.analyze(bullet).has_metric,
+                    "this states a measurable outcome",
+                )
+
+    def test_a_year_or_version_number_is_not_a_metric(self):
+        for bullet in self.NOT_QUANTIFIED:
+            with self.subTest(bullet=bullet):
+                self.assertFalse(
+                    BulletOptimizer.analyze(bullet).has_metric,
+                    "a version or a date is not a quantified achievement, and "
+                    "treating it as one tells the user they need no metric",
+                )
+
+    def test_an_unquantified_bullet_is_told_to_add_a_number(self):
+        analysis = BulletOptimizer.analyze("Wrote services in Python 3 during 2021.")
+        self.assertTrue(
+            any("quantifiable" in s for s in analysis.suggestions),
+            analysis.suggestions,
+        )
+
+
+class PassiveVoiceTests(TestCase):
+    """The old check read `words[:3]`, where the resume passive is not."""
+
+    def test_a_passive_construction_past_the_third_word_is_caught(self):
+        analysis = BulletOptimizer.analyze(
+            "The billing migration was completed by the platform team."
+        )
+        self.assertTrue(analysis.is_passive)
+
+    def test_a_bullet_opening_with_a_copula_is_flagged(self):
+        self.assertTrue(BulletOptimizer.analyze("Was responsible for the team.").is_passive)
+
+    def test_an_active_bullet_is_not_flagged(self):
+        for bullet in (
+            "Spearheaded a caching layer, cutting API latency by 40%.",
+            "Built the billing service and shipped it on time.",
+            "Led a team of five engineers.",
+        ):
+            with self.subTest(bullet=bullet):
+                self.assertFalse(BulletOptimizer.analyze(bullet).is_passive)
+
+    def test_an_irregular_participle_is_recognised(self):
+        analysis = BulletOptimizer.analyze("The reporting suite was built by contractors.")
+        self.assertTrue(analysis.is_passive)
+
+
+class StarExtractionTests(TestCase):
+    def test_a_preposition_inside_a_word_is_not_a_match(self):
+        """`(?:to|for)` with no boundary matched the "to" inside "into"."""
+        star = BulletOptimizer._extract_star_components(
+            "Migrated the data into legacy storage"
+        )
+        self.assertIsNone(star["task"])
+
+    def test_in_inside_within_is_not_a_context(self):
+        star = BulletOptimizer._extract_star_components(
+            "Delivered the rollout within budget"
+        )
+        self.assertIsNone(star["situation"])
+
+    def test_a_trailing_participial_clause_is_a_result(self):
+        star = BulletOptimizer._extract_star_components(
+            "Spearheaded a caching layer, cutting API latency by 40%."
+        )
+        self.assertIsNotNone(star["result"])
+
+    def test_a_quantified_change_is_a_result(self):
+        for bullet in (
+            "Increased sales by $1.5M and improved retention by 15%.",
+            "Reduced p99 latency to under 200ms.",
+            "Cut build times from 12 minutes to 3 minutes.",
+        ):
+            with self.subTest(bullet=bullet):
+                star = BulletOptimizer._extract_star_components(bullet)
+                self.assertIsNotNone(star["result"], "this bullet states its outcome")
+
+    def test_a_bullet_with_no_outcome_has_no_result(self):
+        star = BulletOptimizer._extract_star_components("Managed the internal wiki.")
+        self.assertIsNone(star["result"])
+
+    def test_the_action_phrase_survives_a_comma_after_the_verb(self):
+        star = BulletOptimizer._extract_star_components(
+            "Designed, built and shipped the billing service."
+        )
+        self.assertIsNotNone(star["action"])
+
+
+class ScoreTests(TestCase):
+    def test_a_bullet_with_nothing_going_for_it_scores_nothing(self):
+        """It used to start at 50 — a pass, for the bullet most in need of a rewrite."""
+        analysis = BulletOptimizer.analyze("Was responsible for managing the team.")
+        self.assertEqual(analysis.score, 0)
+        self.assertGreater(len(analysis.suggestions), 2)
+
+    def test_a_bullet_with_everything_scores_at_the_top(self):
+        analysis = BulletOptimizer.analyze(
+            "Spearheaded a caching layer, cutting API latency by 40%."
+        )
+        self.assertGreaterEqual(analysis.score, 90)
+        self.assertEqual(analysis.suggestions, [])
+
+    def test_the_score_never_leaves_the_scale(self):
+        for bullet in (
+            "",
+            "Managed.",
+            "Spearheaded the migration in the Payments platform to cut costs, "
+            "reducing spend by $2M and latency by 40% across 12 services.",
+        ):
+            with self.subTest(bullet=bullet[:32]):
+                score = BulletOptimizer.analyze(bullet).score
+                self.assertGreaterEqual(score, 0)
+                self.assertLessEqual(score, 100)
+
+    def test_improving_a_bullet_raises_its_score(self):
+        weak = BulletOptimizer.analyze("Was responsible for the caching layer.")
+        better = BulletOptimizer.analyze("Built the caching layer.")
+        best = BulletOptimizer.analyze(
+            "Built the caching layer, cutting API latency by 40%."
+        )
+
+        self.assertLess(weak.score, better.score)
+        self.assertLess(better.score, best.score)
+
+
+class RewriteDeterminismTests(TestCase):
+    """`list(set(...))` reordered between processes and between clicks."""
+
+    BULLET = "Was responsible for the billing service."
+
+    def test_the_same_bullet_gives_the_same_rewrites_in_the_same_order(self):
+        first = BulletOptimizer.analyze(self.BULLET).rewrites
+        for _ in range(25):
+            self.assertEqual(BulletOptimizer.analyze(self.BULLET).rewrites, first)
+
+    def test_the_most_important_fix_comes_first(self):
+        """Order carries meaning now, so it is worth pinning."""
+        rewrites = BulletOptimizer.analyze(self.BULLET).rewrites
+        self.assertTrue(rewrites[0].startswith("Spearheaded initiative:"))
+
+    def test_no_more_than_three_rewrites_are_offered(self):
+        self.assertLessEqual(len(BulletOptimizer.analyze(self.BULLET).rewrites), 3)
+
+    def test_a_bullet_needing_nothing_still_gets_one_suggestion(self):
+        rewrites = BulletOptimizer.analyze(
+            "Spearheaded a caching layer, cutting API latency by 40%."
+        ).rewrites
+        self.assertEqual(len(rewrites), 1)
+        self.assertTrue(rewrites[0].startswith("Optimized:"))
+
+    def test_rewrites_are_unique(self):
+        rewrites = BulletOptimizer.analyze(self.BULLET).rewrites
+        self.assertEqual(len(rewrites), len(set(rewrites)))


### PR DESCRIPTION
Closes #915.

`analyze` took `bullet.lower().split()` and compared `words[0]` against a 15-word verb list. Almost nothing a user pastes survives that.

## A bullet that starts with a bullet

```python
>>> BulletOptimizer.analyze("• Spearheaded a caching layer, cutting API latency by 40%.").has_action_verb
False
```

`words[0]` is `"•"`. pdfplumber preserves the glyph and the serializer accepts whatever was pasted, so this is the common case, not the edge case. `-`, `*`, `1.` and the en dash Word autoformats a hyphen into all failed the same way, and so did `"Developed,"` — the comma was never stripped.

The marker and the punctuation around the first word are now removed before matching. The same bullet scores identically behind all ten markers tested.

## Two verb lists, and the small one was wrong

15 verbs: `achieved, improved, trained, managed, created, resolved, volunteered, influenced, increased, decreased, launched, spearheaded, orchestrated, developed, engineered`.

`built`, `led`, `designed`, `migrated`, `reduced`, `owned` and `shipped` scored zero and were told to "start with a strong action verb" — by the module whose sibling `analyzer/scoring.py` already keeps a 70-word list containing every one of them. There is now one vocabulary, and a test that asserts the two agree.

## Any digit counted as a metric

```python
>>> BulletOptimizer.analyze("Wrote services in Python 3 during 2021.").has_metric
True
```

`METRIC_PATTERN` alternated `\b\d+%?\b` with `\b\d{1,3}(?:,\d{3})*(?:\.\d+)?\b`, which matches every digit in the language, so a version number and a date read as quantified impact and the bullet was told it needed no metric.

It now lists the shapes a metric actually takes — percentage, currency, a number carrying a unit, a multiplier, a quantified count — so a version and a year match nothing. Eleven quantified bullets and five unquantified ones are pinned as tests.

## STAR extraction matched inside words

```python
>>> BulletOptimizer._find_objective("Migrated the data into legacy storage")
'legacy storage'
```

`(?:to|for)\s+` had no word boundary, so it matched the `to` inside `into`; `_find_context` had the same problem with `in` inside `within`.

`_find_result` only fired on `resulting in|achieving|leading to|saving|generating`, missing the two commonest phrasings in a good bullet: the trailing participial clause (`, cutting latency by 40%`) and the plain quantified change (`by 15%`, `to under 200ms`). Both are results; only one announces itself. So `star_components["result"]` was `None` on bullets that plainly state one, and `_calculate_score` withheld the points for it.

## Rewrites reordered between clicks

```python
return list(set(rewrites))[:3]
```

Set iteration order for strings depends on `PYTHONHASHSEED`, randomised per process. Identical requests came back in a different order — and past three candidates, with *different* suggestions. Deduplicated by first appearance instead, so the order is fixed and carries meaning: most important fix first.

## Scoring started at 50

A bullet with no verb, no metric, no result and passive voice — the exact bullet the suggestion list tells you to rewrite from scratch — still scored 50 out of 100, which reads as a pass. Points now start at zero and are awarded for what is there: action verb 30, metric 25, stated result 20, active voice 15, situation 10.

## Also

`is_passive` scanned `words[:3]`, which is where the resume passive is not: *"the billing migration was completed by the platform team"* was called active. It now looks for a copula plus a participle anywhere in the line, and separately for a line opening with a copula.

## Tests

`tests_bullet_quality.py`, 30 tests, one per misread above. #918 quarantines `test_strong_bullet_analysis`, `test_weak_bullet_analysis` and `test_metric_extraction` behind a probe for this bug; merging that branch and this one together, they un-skip and pass without further edits.

```
$ python manage.py test analyzer.tests_bullet_quality
Ran 30 tests ... OK

$ python manage.py test
Ran 700 tests ... OK
```