### PR TITLE
fix: find section headings instead of matching words inside sentences (#916)

### DIFF
--- a/backend/analyzer/formatting_checker.py
+++ b/backend/analyzer/formatting_checker.py
@@ -10,12 +10,15 @@ Performs structural checks beyond keyword matching:
 import re
 from typing import Dict, List, Any, Optional
 
+from .section_headings import SECTION_KEYS, SECTIONS, find_headings
+
+#: Derived from :mod:`analyzer.section_headings` rather than hand-maintained.
+#: This was one of three copies of the same list, and they had already drifted
+#: — ``qualifications`` was in two of them, ``toolkit`` in one, ``degrees``
+#: plural here and singular there.
 STANDARD_SECTIONS = [
-    {"key": "summary", "name": "Summary / Objective", "variants": ["summary", "professional summary", "about me", "objective", "profile"]},
-    {"key": "experience", "name": "Work Experience", "variants": ["experience", "work experience", "employment", "work history", "professional experience"]},
-    {"key": "education", "name": "Education", "variants": ["education", "academic", "qualifications", "degree"]},
-    {"key": "skills", "name": "Skills", "variants": ["skills", "technical skills", "technologies", "competencies", "core competencies", "tools"]},
-    {"key": "projects", "name": "Projects", "variants": ["projects", "personal projects", "portfolio", "key projects"]},
+    {"key": key, "name": SECTIONS[key][0], "variants": list(SECTIONS[key][1])}
+    for key in SECTION_KEYS
 ]
 
 ESTIMATED_WORDS_PER_PAGE = 450
@@ -60,30 +63,29 @@ def check_resume_formatting(
         )
 
     # 2. Section order & presence check
-    lowered_text = text.lower()
-    found_sections = []
-    missing_sections = []
+    #
+    # This built a heading-anchored regex and then threw the result away with
+    # `or variant in lowered_text`, which matches a substring of any paragraph.
+    # The regex was dead code and every section was "found": "years of
+    # experience" counted as an Experience heading, "improved my skills" as a
+    # Skills heading, and a resume with no headings at all was told it had all
+    # five and scored 80 for structure.
+    headings = {heading.key: heading for heading in find_headings(text)}
 
-    for section in STANDARD_SECTIONS:
-        matched_variant = None
-        for variant in section["variants"]:
-            # Match heading either standalone line or early in line
-            pattern = re.compile(rf"(?:^|\n)\s*{re.escape(variant)}\s*(?::|$|\n)", re.IGNORECASE)
-            if pattern.search(text) or variant in lowered_text:
-                matched_variant = variant
-                break
-
-        if matched_variant:
-            found_sections.append({
-                "key": section["key"],
-                "name": section["name"],
-                "detected_as": matched_variant,
-            })
-        else:
-            missing_sections.append({
-                "key": section["key"],
-                "name": section["name"],
-            })
+    found_sections = [
+        {
+            "key": key,
+            "name": headings[key].name,
+            "detected_as": headings[key].detected_as,
+        }
+        for key in SECTION_KEYS
+        if key in headings
+    ]
+    missing_sections = [
+        {"key": key, "name": SECTIONS[key][0]}
+        for key in SECTION_KEYS
+        if key not in headings
+    ]
 
     section_tips = []
     required_core = {"experience", "education", "skills"}

--- a/backend/analyzer/scoring.py
+++ b/backend/analyzer/scoring.py
@@ -20,6 +20,8 @@ import re
 from dataclasses import dataclass, asdict
 from typing import Dict, List, Optional, Sequence
 
+from .section_headings import SECTIONS, find_section_keys
+
 #: Factor weights, in points out of 100.
 WEIGHTS = {
     "keyword_match": 40,
@@ -44,19 +46,14 @@ FACTOR_LABELS = {
     "length_format": "Length & formatting",
 }
 
-#: Headings we expect to find, and the words that introduce them. Resumes label
-#: these inconsistently, so each section lists its common variants.
+#: Headings we expect to find. The variants live in
+#: :mod:`analyzer.section_headings` alongside the two other copies of this list
+#: they were drifting from — see the module docstring there.
+EXPECTED_SECTION_KEYS = ("experience", "education", "skills", "projects")
+
+#: Kept for callers that read it. Derived rather than hand-maintained.
 EXPECTED_SECTIONS = {
-    "experience": (
-        "experience",
-        "employment",
-        "work history",
-        "professional background",
-        "career history",
-    ),
-    "education": ("education", "academic", "qualification", "degree"),
-    "skills": ("skills", "technical skills", "technologies", "competencies", "toolkit"),
-    "projects": ("projects", "portfolio", "personal projects", "selected work"),
+    key: SECTIONS[key][1] for key in EXPECTED_SECTION_KEYS
 }
 
 #: Verbs that open a strong accomplishment bullet. Deliberately overlapping
@@ -281,22 +278,34 @@ def score_keyword_match(matched: Sequence[str], required: Sequence[str],
 
 
 def score_sections(text: str) -> FactorScore:
-    """Points for having the sections a recruiter scans for."""
-    lowered = text.lower()
-    found = [
-        name
-        for name, variants in EXPECTED_SECTIONS.items()
-        if any(variant in lowered for variant in variants)
-    ]
-    missing = [name for name in EXPECTED_SECTIONS if name not in found]
+    """Points for having the sections a recruiter scans for.
 
-    earned = (len(found) / len(EXPECTED_SECTIONS)) * WEIGHTS["sections"]
+    This asked ``variant in text.lower()``, which is a question about the whole
+    document rather than about its headings. A resume with no headings at all
+    scored the full 15: "years of experience" supplied *experience*, "improved
+    my skills" supplied *skills*, "a degree from a good academic program"
+    supplied *education*, and "a portfolio of small projects" supplied
+    *projects*.
+
+    That is the worst way for this factor to be wrong. Adding headings is the
+    single cheapest thing most people can do to get past an ATS, and they were
+    being told it was already done.
+    """
+    present = set(find_section_keys(text))
+    found = [key for key in EXPECTED_SECTION_KEYS if key in present]
+    missing = [key for key in EXPECTED_SECTION_KEYS if key not in present]
+
+    earned = (len(found) / len(EXPECTED_SECTION_KEYS)) * WEIGHTS["sections"]
 
     if not missing:
         detail = "All four expected sections are present: experience, education, skills and projects."
     else:
         readable = ", ".join(sorted(missing))
-        detail = f"Found {len(found)} of 4 expected sections. Missing: {readable}."
+        detail = (
+            f"Found {len(found)} of 4 expected section headings. Missing: {readable}. "
+            "An ATS splits a resume on its headings — text under no heading at "
+            "all often lands in the wrong field or is dropped."
+        )
 
     return _make_factor("sections", earned, detail)
 

--- a/backend/analyzer/section_headings.py
+++ b/backend/analyzer/section_headings.py
@@ -1,0 +1,320 @@
+"""Where a resume's sections actually start.
+
+Three modules used to answer this question and all three got it wrong, in
+opposite directions.
+
+``scoring.score_sections`` and ``formatting_checker.check_resume_formatting``
+asked ``variant in text.lower()``. A substring of a paragraph is not a heading,
+so a resume with none at all scored full marks for section coverage:
+"years of experience" supplied *experience*, "improved my skills" supplied
+*skills*, "a degree from a good academic program" supplied *education*, and
+"a portfolio of small projects" supplied *projects*. The person was told the
+single change that would most improve their resume was already done.
+
+``semantic_differ`` had the right idea — line-anchored heading patterns — and
+then ran them against text whose newlines its own normaliser had already
+replaced with spaces, so ``^`` could only match at offset zero. Any resume
+opening with the candidate's name, which is every resume, had no sections at
+all.
+
+So: one module, one vocabulary, one definition of what a heading is. A heading
+is a short line that names a section — not a phrase buried in a sentence about
+one.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+#: The section vocabulary, in the order a resume conventionally presents them.
+#:
+#: One table, because there were three and they had already drifted:
+#: ``qualifications`` was in two of them, ``toolkit`` and ``core competencies``
+#: in one each, and ``degrees`` was plural in one place and singular in
+#: another. Adding a heading variant should not mean remembering which of three
+#: lists to add it to.
+#:
+#: Longer variants come first within each section so that "professional
+#: experience" is matched as a whole rather than as "experience" with a stray
+#: word in front of it.
+SECTION_VOCABULARY: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
+    (
+        "summary",
+        "Summary / Objective",
+        (
+            "professional summary",
+            "career summary",
+            "executive summary",
+            "personal statement",
+            "about me",
+            "summary",
+            "objective",
+            "profile",
+            "overview",
+        ),
+    ),
+    (
+        "experience",
+        "Work Experience",
+        (
+            "professional experience",
+            "professional background",
+            "work experience",
+            "employment history",
+            "employment",
+            "work history",
+            "career history",
+            "experience",
+        ),
+    ),
+    (
+        "education",
+        "Education",
+        (
+            "education and training",
+            "academic background",
+            "academic",
+            "education",
+            "qualifications",
+            "qualification",
+            "degrees",
+            "degree",
+        ),
+    ),
+    (
+        "skills",
+        "Skills",
+        (
+            "core competencies",
+            "technical skills",
+            "technical proficiencies",
+            "key skills",
+            "competencies",
+            "technologies",
+            "toolkit",
+            "tools",
+            "skills",
+        ),
+    ),
+    (
+        "projects",
+        "Projects",
+        (
+            "personal projects",
+            "selected work",
+            "key projects",
+            "side projects",
+            "portfolio",
+            "projects",
+        ),
+    ),
+)
+
+#: Lookup by key, so callers can ask for the sections they care about.
+SECTIONS: Dict[str, Tuple[str, Tuple[str, ...]]] = {
+    key: (name, variants) for key, name, variants in SECTION_VOCABULARY
+}
+
+#: Every section key, in conventional resume order.
+SECTION_KEYS: Tuple[str, ...] = tuple(key for key, _, _ in SECTION_VOCABULARY)
+
+#: A heading is a label, not a sentence. Six words covers "Education, Training
+#: and Professional Certifications" without admitting a clause.
+MAX_HEADING_WORDS = 6
+
+#: Decoration people put around a heading: "=== EXPERIENCE ===", "## Skills",
+#: "--- Projects ---".
+DECORATION = " \t#*=_~-–—|•●▪<>[]{}"
+
+#: Sentence punctuation at the end of a line means it is a sentence. A colon
+#: does not, so it is excluded here and handled separately.
+SENTENCE_ENDINGS = ".,;!?"
+
+#: Words that may stay lowercase inside a title-cased heading.
+#:
+#: Conjunctions and "of" only. Prepositions such as "in" and "for" are left out
+#: deliberately: "Skills in Python" and "Experience for the platform team" read
+#: as fragments, and allowing a lowercase preposition would admit both.
+_MINOR_WORDS = {"and", "or", "of", "&", "/", "+"}
+
+
+@dataclass(frozen=True)
+class SectionHeading:
+    """One heading found in a resume."""
+
+    key: str
+    #: The display name for the section, e.g. ``"Work Experience"``.
+    name: str
+    #: The variant that matched, as written in the resume.
+    detected_as: str
+    #: Index into ``text.splitlines()``.
+    line_index: int
+    #: The heading line as it appears, stripped of surrounding whitespace.
+    line: str
+    #: Anything written after a colon on the same line — "Skills: Python, Django".
+    inline_content: str = ""
+
+
+def _normalise(candidate: str) -> str:
+    """Lowercased, decoration removed, internal whitespace collapsed."""
+    return re.sub(r"\s+", " ", candidate.strip(DECORATION)).strip().lower()
+
+
+def _is_title_or_upper_case(candidate: str) -> bool:
+    """True when the line is written the way headings are written.
+
+    "Employment History" and "EMPLOYMENT HISTORY" are headings. "Experience
+    building internal tools" is a sentence fragment that happens to start with
+    a section word, and the lowercase second word is what separates them.
+    """
+    words = [word for word in candidate.split() if word]
+    if not words:
+        return False
+
+    for index, word in enumerate(words):
+        if index and word.lower() in _MINOR_WORDS:
+            continue
+        first_letter = next((char for char in word if char.isalpha()), "")
+        if first_letter and not first_letter.isupper():
+            return False
+    return True
+
+
+def _match_variant(candidate: str) -> Optional[Tuple[str, str]]:
+    """``(key, variant)`` when ``candidate`` names a section, else ``None``."""
+    normalised = _normalise(candidate)
+    if not normalised:
+        return None
+
+    # An exact match needs no case test: "Work history" is unambiguously a
+    # heading, and requiring title case would reject a perfectly ordinary one.
+    for key, _, variants in SECTION_VOCABULARY:
+        for variant in variants:
+            if normalised == variant:
+                return key, variant
+
+    # A heading with extra words — "Employment History", "Academic Background",
+    # "Technical Skills & Tools". Here the case test does the work of telling a
+    # heading apart from a sentence that starts with the same word.
+    if len(normalised.split()) > MAX_HEADING_WORDS:
+        return None
+    if not _is_title_or_upper_case(candidate.strip(DECORATION)):
+        return None
+
+    for key, _, variants in SECTION_VOCABULARY:
+        for variant in variants:
+            if re.match(rf"{re.escape(variant)}\b", normalised):
+                return key, variant
+
+    return None
+
+
+def classify_line(line: str) -> Optional[Tuple[str, str, str]]:
+    """``(key, variant, inline_content)`` when ``line`` is a section heading.
+
+    Handles the two ways a heading is written: alone on its line, and as a
+    label with its content after a colon.
+    """
+    stripped = (line or "").strip()
+    if not stripped:
+        return None
+
+    label, separator, inline = stripped.partition(":")
+
+    if separator:
+        matched = _match_variant(label)
+        if matched:
+            return matched[0], matched[1], inline.strip()
+        # No colon interpretation available; fall through and try the whole
+        # line, which covers "Skills / Tools: ..." style labels.
+
+    if stripped.rstrip(DECORATION).endswith(tuple(SENTENCE_ENDINGS)):
+        return None
+
+    matched = _match_variant(stripped)
+    if matched:
+        return matched[0], matched[1], ""
+
+    return None
+
+
+def find_headings(text: str) -> List[SectionHeading]:
+    """Every section heading in ``text``, in the order it appears.
+
+    A section repeated — some resumes split "Experience" across pages and
+    repeat the heading — is reported once, at its first occurrence, because
+    every caller wants "does this resume have an experience section" rather
+    than "how many times is the word printed".
+    """
+    headings: List[SectionHeading] = []
+    seen = set()
+
+    for index, line in enumerate((text or "").splitlines()):
+        classified = classify_line(line)
+        if classified is None:
+            continue
+
+        key, variant, inline = classified
+        if key in seen:
+            continue
+
+        seen.add(key)
+        name, _ = SECTIONS[key]
+        headings.append(
+            SectionHeading(
+                key=key,
+                name=name,
+                detected_as=variant,
+                line_index=index,
+                line=line.strip(),
+                inline_content=inline,
+            )
+        )
+
+    return headings
+
+
+def find_section_keys(text: str) -> List[str]:
+    """The keys of the sections present, in document order."""
+    return [heading.key for heading in find_headings(text)]
+
+
+def has_section(text: str, key: str) -> bool:
+    """Whether ``text`` carries a heading for the named section."""
+    return key in find_section_keys(text)
+
+
+def missing_section_keys(text: str, expected: Sequence[str] = SECTION_KEYS) -> List[str]:
+    """Which of ``expected`` are absent, in the order ``expected`` gives them."""
+    present = set(find_section_keys(text))
+    return [key for key in expected if key not in present]
+
+
+def section_body(text: str, key: str) -> str:
+    """The lines under ``key``'s heading, up to the next heading of any kind.
+
+    Includes anything written after a colon on the heading line itself, so
+    "Skills: Python, Django" and a "Skills" heading with the list underneath
+    both return the list.
+    """
+    lines = (text or "").splitlines()
+    headings = find_headings(text)
+
+    target = next((heading for heading in headings if heading.key == key), None)
+    if target is None:
+        return ""
+
+    # The next heading *by position*, which is not necessarily the next one in
+    # `headings` if a resume orders its sections unconventionally.
+    following = [
+        heading.line_index
+        for heading in headings
+        if heading.line_index > target.line_index
+    ]
+    end = min(following) if following else len(lines)
+
+    body = lines[target.line_index + 1 : end]
+    if target.inline_content:
+        body = [target.inline_content, *body]
+
+    return "\n".join(body).strip()

--- a/backend/analyzer/semantic_differ.py
+++ b/backend/analyzer/semantic_differ.py
@@ -9,6 +9,8 @@ import difflib
 from typing import List, Dict, Any, Set, Tuple
 from dataclasses import dataclass, field
 
+from .section_headings import section_body
+
 
 @dataclass
 class SemanticChange:
@@ -26,16 +28,13 @@ class SemanticDiffer:
     Extracts structured data and compares it semantically rather than just textually.
     """
 
-    SECTION_PATTERNS = {
-        "experience": re.compile(
-            r"(?im)^(experience|work history|employment|professional background)"
-        ),
-        "education": re.compile(r"(?im)^(education|academic|qualifications|degrees)"),
-        "skills": re.compile(
-            r"(?im)^(skills|technologies|competencies|technical skills)"
-        ),
-        "summary": re.compile(r"(?im)^(summary|profile|objective|about me)"),
-    }
+    #: The sections this differ compares.
+    #:
+    #: The heading vocabulary itself lives in
+    #: :mod:`analyzer.section_headings`, which is also what
+    #: ``scoring.py`` and ``formatting_checker.py`` use. There were three
+    #: hand-maintained copies of it and they had already drifted.
+    COMPARED_SECTIONS = ("experience", "education", "skills", "summary")
 
     STRONG_ACTION_VERBS = {
         "spearheaded",
@@ -102,35 +101,48 @@ class SemanticDiffer:
 
     @classmethod
     def _normalize_text(cls, text: str) -> str:
-        """Removes excessive whitespace and normalizes line breaks."""
-        text = re.sub(r"\s+", " ", text)
-        text = re.sub(r"\n+", "\n", text)
-        return text.strip()
+        r"""Collapse runs of whitespace without destroying the line structure.
+
+        The old version ran ``re.sub(r"\s+", " ", text)`` first, which replaces
+        every newline with a space, and then ``re.sub(r"\n+", "\n", text)``,
+        which by that point had nothing left to match. Section detection is
+        line-anchored — headings sit on their own line — so after normalisation
+        there were no headings to find, and any resume that opens with the
+        candidate's name (which is every resume) compared as having no sections
+        at all:
+
+            >>> SemanticDiffer._extract_section(
+            ...     SemanticDiffer._normalize_text("Jane Doe\\n\\nEXPERIENCE\\nAcme"),
+            ...     "experience",
+            ... )
+            ''
+
+        Runs of spaces and tabs inside a line are still collapsed, and runs of
+        blank lines still become one, which is all "ignore trivial whitespace
+        changes" ever needed.
+        """
+        lines = [re.sub(r"[^\S\n]+", " ", line).strip() for line in (text or "").splitlines()]
+
+        collapsed = []
+        for line in lines:
+            if not line and (not collapsed or not collapsed[-1]):
+                continue
+            collapsed.append(line)
+
+        return "\n".join(collapsed).strip()
 
     @classmethod
     def _extract_section(cls, text: str, section_name: str) -> str:
-        """Extracts the content of a specific section from the resume text."""
-        pattern = cls.SECTION_PATTERNS.get(section_name)
-        if not pattern:
+        """The content under a section's heading, up to the next heading.
+
+        Delegates to :func:`analyzer.section_headings.section_body`, which also
+        handles the label-with-content form — "Skills: Python, Django" — that
+        the previous character-offset walk returned with the colon still
+        attached.
+        """
+        if section_name not in cls.COMPARED_SECTIONS:
             return ""
-
-        match = pattern.search(text)
-        if not match:
-            return ""
-
-        start_idx = match.end()
-        # Find the next section header to determine the end of this section
-        next_section_match = None
-        for name, pat in cls.SECTION_PATTERNS.items():
-            if name != section_name:
-                m = pat.search(text, start_idx)
-                if m and (
-                    not next_section_match or m.start() < next_section_match.start()
-                ):
-                    next_section_match = m
-
-        end_idx = next_section_match.start() if next_section_match else len(text)
-        return text[start_idx:end_idx].strip()
+        return section_body(text, section_name)
 
     @classmethod
     def _extract_skills(cls, text: str) -> Set[str]:
@@ -139,12 +151,18 @@ class SemanticDiffer:
         if not skills_section:
             return set()
 
-        # Split by common delimiters
-        raw_skills = re.split(r"[,•\-\n;|]", skills_section)
+        # Split by common delimiters. The leading colon of "Skills: Python" is
+        # gone by the time we get here — `section_body` returns the content, not
+        # the label — but a stray one on a sub-list is still stripped, along
+        # with the bullet glyphs and trailing punctuation that survive a split.
+        raw_skills = re.split(r"[,•·▪●;|/\n]|\s+[-–—]\s+", skills_section)
         return {
-            s.strip().lower()
-            for s in raw_skills
-            if len(s.strip()) > 1 and len(s.strip()) < 50
+            skill
+            for skill in (
+                candidate.strip().strip(":-–—*• \t").lower()
+                for candidate in raw_skills
+            )
+            if 1 < len(skill) < 50
         }
 
     @classmethod

--- a/backend/analyzer/tests_section_detection.py
+++ b/backend/analyzer/tests_section_detection.py
@@ -1,0 +1,289 @@
+"""Where a resume's sections start, and what the three callers do with it.
+
+The case that matters most is the first one: a resume with no headings at all
+used to score full marks for section coverage, because every module asked
+``variant in text.lower()`` and got its answer from the middle of a sentence.
+"""
+
+from django.test import TestCase
+
+from analyzer.formatting_checker import check_resume_formatting
+from analyzer.scoring import WEIGHTS, score_sections
+from analyzer.section_headings import (
+    SECTION_KEYS,
+    classify_line,
+    find_headings,
+    find_section_keys,
+    has_section,
+    missing_section_keys,
+    section_body,
+)
+from analyzer.semantic_differ import SemanticDiffer
+
+#: Prose that mentions every section word and carries no heading whatsoever.
+#: Each line is the phrase that used to supply a section: "experience" from
+#: "years of experience", "skills" from "improved my skills", and so on.
+HEADINGLESS_RESUME = """Jane Doe
+jane@example.com | +1 415 555 0132
+I am a backend engineer. I have five years of experience building tools.
+Built internal tools for the data team and improved my skills in Go.
+I hold a degree from a good academic program and enjoy tutoring.
+Worked on a profile page and a portfolio of small projects.
+"""
+
+STRUCTURED_RESUME = """Jane Doe
+jane@example.com
+
+Summary
+Backend engineer with six years building payment systems.
+
+PROFESSIONAL EXPERIENCE
+Acme Corp, Senior Engineer
+Built the billing service and cut invoice errors by 42%.
+
+Education
+B.S. Computer Science, State University
+
+Technical Skills
+Python, Django, PostgreSQL, Docker
+
+Portfolio
+An open-source rate limiter used by 400+ repositories.
+"""
+
+
+class HeadingClassificationTests(TestCase):
+    def test_a_heading_on_its_own_line_is_a_heading(self):
+        for line in (
+            "Experience",
+            "EXPERIENCE",
+            "Work history",
+            "Employment History",
+            "PROFESSIONAL EXPERIENCE",
+            "## Skills",
+            "=== Education ===",
+            "Skills:",
+        ):
+            with self.subTest(line=line):
+                self.assertIsNotNone(classify_line(line), f"{line!r} is a heading")
+
+    def test_a_sentence_that_mentions_a_section_is_not_a_heading(self):
+        for line in (
+            "I have five years of experience building tools.",
+            "Built internal tools and improved my skills in Go.",
+            "I hold a degree from a good academic program.",
+            "Worked on a profile page and a portfolio of small projects.",
+            "Experience building internal tools",
+            "Skills in Python",
+            "Delivered the education platform rewrite.",
+        ):
+            with self.subTest(line=line):
+                self.assertIsNone(
+                    classify_line(line),
+                    f"{line!r} is prose, not a heading — counting it is how a "
+                    "resume with no headings scored full marks",
+                )
+
+    def test_a_label_with_its_content_on_the_same_line(self):
+        classified = classify_line("Skills: Python, Django, React")
+        self.assertIsNotNone(classified)
+        key, _, inline = classified
+        self.assertEqual(key, "skills")
+        self.assertEqual(inline, "Python, Django, React")
+
+    def test_a_blank_line_is_not_a_heading(self):
+        for line in ("", "   ", "\t"):
+            self.assertIsNone(classify_line(line))
+
+
+class FindHeadingsTests(TestCase):
+    def test_a_resume_with_no_headings_reports_none(self):
+        self.assertEqual(find_section_keys(HEADINGLESS_RESUME), [])
+
+    def test_a_structured_resume_reports_its_sections_in_order(self):
+        self.assertEqual(
+            find_section_keys(STRUCTURED_RESUME),
+            ["summary", "experience", "education", "skills", "projects"],
+        )
+
+    def test_a_repeated_heading_is_reported_once(self):
+        """Some resumes repeat the heading across a page break."""
+        text = "Experience\nAcme\n\nExperience (continued)\nBeta Corp"
+        self.assertEqual(find_section_keys(text), ["experience"])
+
+    def test_the_variant_that_matched_is_reported(self):
+        headings = {h.key: h for h in find_headings(STRUCTURED_RESUME)}
+        self.assertEqual(headings["experience"].detected_as, "professional experience")
+        self.assertEqual(headings["skills"].detected_as, "technical skills")
+
+    def test_has_section_and_missing_section_keys_agree(self):
+        missing = missing_section_keys(HEADINGLESS_RESUME)
+        self.assertEqual(missing, list(SECTION_KEYS))
+        for key in SECTION_KEYS:
+            self.assertFalse(has_section(HEADINGLESS_RESUME, key))
+
+    def test_section_body_stops_at_the_next_heading(self):
+        body = section_body(STRUCTURED_RESUME, "education")
+        self.assertEqual(body, "B.S. Computer Science, State University")
+
+    def test_section_body_includes_content_written_after_a_colon(self):
+        self.assertEqual(
+            section_body("Jane Doe\nSkills: Python, Django", "skills"),
+            "Python, Django",
+        )
+
+    def test_section_body_of_an_absent_section_is_empty(self):
+        self.assertEqual(section_body(HEADINGLESS_RESUME, "skills"), "")
+
+    def test_the_last_section_runs_to_the_end_of_the_document(self):
+        body = section_body(STRUCTURED_RESUME, "projects")
+        self.assertIn("rate limiter", body)
+
+
+class ScoreSectionsTests(TestCase):
+    def test_a_headingless_resume_scores_nothing_for_sections(self):
+        """The regression this was filed for.
+
+        Full marks and "all four expected sections are present" for a document
+        an ATS cannot segment — so the reader never added the headings.
+        """
+        factor = score_sections(HEADINGLESS_RESUME)
+
+        self.assertEqual(factor.earned, 0)
+        self.assertEqual(factor.status, "weak")
+        for name in ("experience", "education", "skills", "projects"):
+            self.assertIn(name, factor.detail)
+
+    def test_a_structured_resume_scores_full_marks(self):
+        self.assertEqual(
+            score_sections(STRUCTURED_RESUME).earned, WEIGHTS["sections"]
+        )
+
+    def test_partial_coverage_scores_proportionally(self):
+        factor = score_sections("Experience\nAcme Corp\n\nSkills\nPython")
+        self.assertEqual(factor.earned, round(WEIGHTS["sections"] * 0.5))
+
+    def test_the_detail_says_what_is_missing(self):
+        factor = score_sections("Experience\nAcme Corp\n\nSkills\nPython")
+        self.assertIn("education", factor.detail)
+        self.assertIn("projects", factor.detail)
+
+
+class FormattingCheckerSectionTests(TestCase):
+    def test_a_headingless_resume_is_told_its_headings_are_missing(self):
+        result = check_resume_formatting(HEADINGLESS_RESUME)
+
+        self.assertEqual(result["found_sections"], [])
+        self.assertIn("Work Experience", result["missing_sections"])
+        self.assertIn(
+            "Missing essential ATS section header(s)", result["tips"]["sections"][0]
+        )
+
+    def test_a_headingless_resume_does_not_score_as_structurally_sound(self):
+        headingless = check_resume_formatting(HEADINGLESS_RESUME)["score"]
+        structured = check_resume_formatting(STRUCTURED_RESUME)["score"]
+        self.assertLess(headingless, structured)
+
+    def test_a_structured_resume_finds_every_section(self):
+        result = check_resume_formatting(STRUCTURED_RESUME)
+        self.assertEqual(result["missing_sections"], [])
+
+    def test_the_variant_reported_is_the_one_in_the_document(self):
+        """`detected_as` used to name whichever variant matched a substring."""
+        result = check_resume_formatting(STRUCTURED_RESUME)
+        self.assertIn("Work Experience", result["found_sections"])
+
+
+class SemanticDifferNormalizationTests(TestCase):
+    def test_normalization_keeps_the_line_structure(self):
+        normalized = SemanticDiffer._normalize_text("Jane Doe\n\nEXPERIENCE\nAcme")
+        self.assertIn("\n", normalized)
+
+    def test_normalization_still_collapses_runs_of_spaces(self):
+        self.assertEqual(
+            SemanticDiffer._normalize_text("Python    Django\t\tReact"),
+            "Python Django React",
+        )
+
+    def test_normalization_still_collapses_runs_of_blank_lines(self):
+        self.assertEqual(
+            SemanticDiffer._normalize_text("Skills\n\n\n\nPython"),
+            "Skills\n\nPython",
+        )
+
+    def test_a_section_after_the_first_line_is_found(self):
+        """`^` could only match at offset zero, so every real resume had none."""
+        text = SemanticDiffer._normalize_text(
+            "Jane Doe\n\nEXPERIENCE\nBackend engineer at Acme\nBuilt billing\n\n"
+            "EDUCATION\nBSc Computer Science"
+        )
+
+        self.assertEqual(
+            SemanticDiffer._extract_section(text, "experience"),
+            "Backend engineer at Acme\nBuilt billing",
+        )
+        self.assertEqual(
+            SemanticDiffer._extract_section(text, "education"), "BSc Computer Science"
+        )
+
+    def test_skills_are_extracted_from_a_real_resume_shape(self):
+        text = SemanticDiffer._normalize_text("Jane Doe\n\nSKILLS\nPython, Django, AWS")
+        self.assertEqual(
+            SemanticDiffer._extract_skills(text), {"python", "django", "aws"}
+        )
+
+    def test_the_label_colon_is_not_returned_as_a_skill(self):
+        """`re.split` on "Skills: Python" left ": python" in the set."""
+        text = SemanticDiffer._normalize_text("Skills: Python, Django, React")
+        self.assertEqual(
+            SemanticDiffer._extract_skills(text), {"python", "django", "react"}
+        )
+
+    def test_bullet_glyphs_are_not_returned_as_skills(self):
+        text = SemanticDiffer._normalize_text("Skills\n- Python\n- Django\n- AWS")
+        self.assertEqual(
+            SemanticDiffer._extract_skills(text), {"python", "django", "aws"}
+        )
+
+
+class SemanticDifferComparisonTests(TestCase):
+    """The endpoint returned an all-zero summary for every real resume."""
+
+    V1 = (
+        "Jane Doe\n\nExperience\nAcme Corp, engineer\nBuilt the billing service\n\n"
+        "Skills\nPython, Django, React, SQL\n"
+    )
+    V2 = (
+        "Jane Doe\n\nExperience\nAcme Corp, engineer\nBuilt the billing service\n"
+        "Led the payments migration\nMentored two engineers\nOwned the on-call rota\n\n"
+        "Skills\nPython, Django, React, AWS, Docker\n"
+    )
+
+    def test_added_and_removed_skills_are_reported(self):
+        summary = SemanticDiffer.compare(self.V1, self.V2)["summary"]
+
+        self.assertEqual(summary["skills_added"], 2)  # AWS, Docker
+        self.assertEqual(summary["skills_removed"], 1)  # SQL
+
+    def test_an_expanded_experience_section_is_reported(self):
+        summary = SemanticDiffer.compare(self.V1, self.V2)["summary"]
+        self.assertEqual(summary["experience_expanded"], 1)
+
+    def test_an_added_education_section_is_reported(self):
+        with_education = self.V1 + "\nEducation\nBSc Computer Science\n"
+        changes = SemanticDiffer.compare(self.V1, with_education)["changes"]
+
+        education = [c for c in changes if c["category"] == "education"]
+        self.assertEqual(len(education), 1)
+        self.assertEqual(education[0]["change_type"], "added")
+
+    def test_comparing_a_resume_with_itself_reports_nothing(self):
+        result = SemanticDiffer.compare(self.V1, self.V1)
+        self.assertEqual(result["changes"], [])
+
+    def test_whitespace_only_changes_are_ignored(self):
+        spaced = self.V1.replace("\n", "\n\n").replace(", ", ",   ")
+        result = SemanticDiffer.compare(self.V1, spaced)
+
+        self.assertEqual(result["summary"]["skills_added"], 0)
+        self.assertEqual(result["summary"]["skills_removed"], 0)


### PR DESCRIPTION
Closes #916.

Three modules decided where a resume's sections were. All three got it wrong, in opposite directions: two found headings that were not there, and the third found none at all.

## A resume with no headings scored full marks

```python
text = """Jane Doe
jane@example.com | +1 415 555 0132
I am a backend engineer. I have five years of experience building tools.
Built internal tools for the data team and improved my skills in Go.
I hold a degree from a good academic program and enjoy tutoring.
Worked on a profile page and a portfolio of small projects.
"""
```

| | before | after |
|---|---|---|
| `score_sections(...).earned` | **15 / 15** | 0 / 15 |
| `check_resume_formatting(...)["missing_sections"]` | **`[]`** | all five |
| structural score | **80** | 35 |

Both asked `variant in text.lower()`, which is a question about the whole document rather than about its headings. "years of experience" supplied Experience, "improved my skills" supplied Skills, "a degree from a good academic program" supplied Education, "a portfolio of small projects" supplied Projects, "a profile page" supplied Summary.

This is the worst way for this factor to be wrong. Adding headings is the cheapest thing most people can do to get past an ATS, and they were being told it was already done.

`formatting_checker` did build a heading-anchored regex first — and threw the result away with `or variant in lowered_text`, which matches unconditionally. The regex was dead code.

## The differ deleted the newlines its own patterns needed

`SECTION_PATTERNS` were line-anchored, which is right. `_normalize_text` ran first:

```python
text = re.sub(r"\s+", " ", text)   # every newline is now a space
text = re.sub(r"\n+", "\n", text)  # nothing left to match
```

After the first substitution `^` can only match at offset zero, so any resume that opens with the candidate's name — every resume — compared as having no sections:

```python
>>> SemanticDiffer._extract_section(
...     SemanticDiffer._normalize_text("Jane Doe\n\nEXPERIENCE\nAcme"), "experience")
''
```

`_compare_skills`, `_compare_experience` and `_compare_education` all returned nothing and `/api/analyzer/semantic-diff/` answered with an all-zero summary. `_compare_experience` was counting lines in a string that no longer had any. Its own tests passed only because their fixtures start with the heading at character zero.

## What this does

`section_headings.py` is now the one place that answers the question. A heading is a short line that names a section: it matches a known variant exactly, or it starts with one and is written in title or upper case.

- "Employment History" is a heading.
- "Experience building internal tools" is not — the lowercase second word is what separates them.
- "Skills in Python" is not; prepositions are deliberately excluded from the minor-word allowance that lets "Education and Training" through.

It also handles the label-with-content form, `Skills: Python, Django`, which the old character-offset walk returned with the colon still attached — `": python"` came back as a skill name.

`_normalize_text` now collapses runs of spaces within a line and runs of blank lines, which is all "ignore trivial whitespace changes" ever needed.

## Three lists become one

`scoring.EXPECTED_SECTIONS`, `formatting_checker.STANDARD_SECTIONS` and `semantic_differ.SECTION_PATTERNS` were three hand-maintained copies of the same vocabulary and had already drifted: `qualifications` in two of them, `toolkit` and `core competencies` in one each, `degrees` plural in one place and singular in another. Both public names are kept and derived, so nothing reading them breaks.

## Tests

`tests_section_detection.py`, 33 tests. The headingless resume above is the first of them. #918 quarantines `test_experience_section_expansion` behind a probe for this bug; merging that branch and this one together, it un-skips and passes without further edits.

```
$ python manage.py test analyzer.tests_section_detection
Ran 33 tests ... OK

$ python manage.py test
Ran 703 tests ... OK
```

The existing `tests_scoring.py` section tests pass unchanged — they always used real headings.