### PR TITLE
feat: implement resume phrase cliche detector and modernizer (#923)

### DIFF
--- a/backend/analyzer/cliche_detector.py
+++ b/backend/analyzer/cliche_detector.py
@@ -1,0 +1,155 @@
+"""
+Resume Phrase Cliché Detector and Modernizer.
+
+This module identifies overused buzzwords, passive voice, and cliché phrases
+in resume bullet points, offering strong, action-oriented, and modern alternatives.
+"""
+
+import re
+from typing import List, Dict, Any, Tuple
+
+# Comprehensive dictionary of clichés mapped to strong alternatives
+CLICHE_DICTIONARY = {
+    r"\bresponsible for\b": "spearheaded",
+    r"\bduties included\b": "managed",
+    r"\bhelped with\b": "collaborated on",
+    r"\bworked on\b": "developed",
+    r"\btasked with\b": "executed",
+    r"\bassisted in\b": "supported",
+    r"\bparticipated in\b": "contributed to",
+    r"\bhandled\b": "orchestrated",
+    r"\bwas in charge of\b": "directed",
+    r"\bthink outside the box\b": "innovated",
+    r"\bgo-getter\b": "proactive",
+    r"\bteam player\b": "collaborative",
+    r"\bhard worker\b": "dedicated",
+    r"\bresults-driven\b": "impact-focused",
+    r"\bsynergy\b": "collaboration",
+    r"\bleverage\b": "utilized",
+    r"\butilize\b": "used",
+    r"\bparadigm shift\b": "transformation",
+    r"\bbest-in-class\b": "industry-leading",
+    r"\bworld-class\b": "exceptional",
+}
+
+# Passive voice indicators (simplified heuristic)
+PASSIVE_INDICATORS = [
+    r"\bwas\b",
+    r"\bwere\b",
+    r"\bbeen\b",
+    r"\bbeing\b",
+    r"\bis\b",
+    r"\bare\b",
+]
+
+
+def detect_cliches(text: str) -> List[Dict[str, Any]]:
+    """
+    Detects cliché phrases in the provided text.
+
+    Args:
+        text (str): The resume text or bullet point to analyze.
+
+    Returns:
+        List[Dict[str, Any]]: A list of detected clichés with their positions and suggestions.
+    """
+    detections = []
+    text_lower = text.lower()
+
+    for pattern, suggestion in CLICHE_DICTIONARY.items():
+        matches = re.finditer(pattern, text_lower)
+        for match in matches:
+            original_phrase = text[match.start() : match.end()]
+            detections.append(
+                {
+                    "phrase": original_phrase,
+                    "start": match.start(),
+                    "end": match.end(),
+                    "suggestion": suggestion,
+                    "type": "cliche",
+                }
+            )
+
+    return detections
+
+
+def detect_passive_voice(text: str) -> List[Dict[str, Any]]:
+    """
+    Heuristically detects potential passive voice constructions.
+
+    Args:
+        text (str): The resume text to analyze.
+
+    Returns:
+        List[Dict[str, Any]]: A list of potential passive voice indicators.
+    """
+    detections = []
+    words = text.split()
+
+    for i, word in enumerate(words):
+        word_lower = word.lower().strip(".,;:!?")
+        if word_lower in ["was", "were", "been", "being", "is", "are"]:
+            # Check if the next word is a past participle (simplified check)
+            if i + 1 < len(words):
+                next_word = words[i + 1].lower().strip(".,;:!?")
+                if next_word.endswith(("ed", "en", "t")):
+                    detections.append(
+                        {
+                            "phrase": f"{word} {words[i + 1]}",
+                            "start": text.lower().find(f"{word_lower} {next_word}"),
+                            "end": text.lower().find(f"{word_lower} {next_word}")
+                            + len(f"{word} {words[i + 1]}"),
+                            "suggestion": "Rewrite in active voice (e.g., 'Led', 'Built', 'Created')",
+                            "type": "passive",
+                        }
+                    )
+
+    return detections
+
+
+def analyze_and_suggest(text: str) -> Dict[str, Any]:
+    """
+    Main function to analyze text for clichés and passive voice, providing suggestions.
+
+    Args:
+        text (str): The resume text to analyze.
+
+    Returns:
+        Dict[str, Any]: Analysis results including detections and a modernized version.
+    """
+    if not text or not isinstance(text, str):
+        return {"detections": [], "modernized_text": "", "score": 100}
+
+    cliches = detect_cliches(text)
+    passive = detect_passive_voice(text)
+
+    # Combine and sort detections by start position
+    all_detections = sorted(cliches + passive, key=lambda x: x["start"])
+
+    # Generate modernized text by replacing clichés
+    modernized_text = text
+    # Sort in reverse to replace from end to start, preserving indices
+    for detection in sorted(all_detections, key=lambda x: x["start"], reverse=True):
+        if detection["type"] == "cliche":
+            # Preserve original casing of the first letter
+            original = detection["phrase"]
+            suggestion = detection["suggestion"]
+            if original[0].isupper():
+                suggestion = suggestion.capitalize()
+            modernized_text = (
+                modernized_text[: detection["start"]]
+                + suggestion
+                + modernized_text[detection["end"] :]
+            )
+
+    # Calculate a simple "impact score"
+    total_words = len(text.split())
+    issues_count = len(all_detections)
+    score = max(0, 100 - int((issues_count / max(total_words, 1)) * 500))
+
+    return {
+        "detections": all_detections,
+        "modernized_text": modernized_text,
+        "score": score,
+        "total_issues": issues_count,
+    }

--- a/backend/analyzer/cliche_serializers.py
+++ b/backend/analyzer/cliche_serializers.py
@@ -1,0 +1,38 @@
+"""
+Serializers for Cliché Detector.
+
+Handles validation of incoming text and structures the detection output.
+"""
+
+from rest_framework import serializers
+
+
+class ClicheDetectionRequestSerializer(serializers.Serializer):
+    """
+    Serializer to validate the incoming request for cliché detection.
+    """
+
+    text = serializers.CharField(required=True, allow_blank=False, max_length=5000)
+
+
+class DetectionItemSerializer(serializers.Serializer):
+    """
+    Serializer for a single detection item.
+    """
+
+    phrase = serializers.CharField()
+    start = serializers.IntegerField()
+    end = serializers.IntegerField()
+    suggestion = serializers.CharField()
+    type = serializers.CharField()
+
+
+class ClicheDetectionResponseSerializer(serializers.Serializer):
+    """
+    Serializer to structure the cliché detection output.
+    """
+
+    detections = DetectionItemSerializer(many=True)
+    modernized_text = serializers.CharField()
+    score = serializers.IntegerField()
+    total_issues = serializers.IntegerField()

--- a/backend/analyzer/cliche_views.py
+++ b/backend/analyzer/cliche_views.py
@@ -1,0 +1,52 @@
+"""
+Views for Cliché Detector.
+
+Exposes the POST /api/detect-cliches/ endpoint.
+"""
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from .cliche_detector import analyze_and_suggest
+from .cliche_serializers import (
+    ClicheDetectionRequestSerializer,
+    ClicheDetectionResponseSerializer,
+)
+
+
+class ClicheDetectorView(APIView):
+    """
+    API View to handle cliché detection and modernization requests.
+    """
+
+    def post(self, request, *args, **kwargs):
+        """
+        Process resume text and return cliché detections with suggestions.
+        """
+        request_serializer = ClicheDetectionRequestSerializer(data=request.data)
+        if not request_serializer.is_valid():
+            return Response(
+                {"errors": request_serializer.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        text = request_serializer.validated_data["text"]
+
+        try:
+            analysis_result = analyze_and_suggest(text)
+
+            response_serializer = ClicheDetectionResponseSerializer(
+                data=analysis_result
+            )
+            response_serializer.is_valid(raise_exception=True)
+
+            return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            return Response(
+                {
+                    "error": "An unexpected error occurred during analysis.",
+                    "details": str(e),
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/backend/analyzer/tests_cliche_detector.py
+++ b/backend/analyzer/tests_cliche_detector.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for the Cliché Detector module.
+
+Validates detection accuracy and suggestion generation across various edge cases.
+"""
+
+from django.test import TestCase
+from .cliche_detector import detect_cliches, detect_passive_voice, analyze_and_suggest
+
+
+class ClicheDetectorTests(TestCase):
+    """Test suite for cliché detection logic."""
+
+    def test_detect_cliches_finds_exact_match(self):
+        """Test that exact cliché phrases are detected."""
+        text = "I was responsible for managing the team."
+        detections = detect_cliches(text)
+        self.assertEqual(len(detections), 1)
+        self.assertEqual(detections[0]["phrase"], "responsible for")
+        self.assertEqual(detections[0]["suggestion"], "spearheaded")
+
+    def test_detect_cliches_case_insensitive(self):
+        """Test that detection is case-insensitive."""
+        text = "I Was Responsible For the project."
+        detections = detect_cliches(text)
+        self.assertEqual(len(detections), 1)
+        self.assertEqual(detections[0]["phrase"], "Was Responsible For")
+
+    def test_detect_cliches_no_false_positives(self):
+        """Test that legitimate technical terms are not flagged."""
+        text = "Utilized Python to build a robust backend system."
+        # Note: 'utilized' is in the dictionary, so it WILL be flagged.
+        # Let's test a truly safe phrase.
+        safe_text = (
+            "Developed a microservices architecture using Docker and Kubernetes."
+        )
+        detections = detect_cliches(safe_text)
+        self.assertEqual(len(detections), 0)
+
+    def test_detect_passive_voice_finds_indicators(self):
+        """Test that passive voice indicators are detected."""
+        text = "The project was completed by the team."
+        detections = detect_passive_voice(text)
+        self.assertGreater(len(detections), 0)
+        self.assertIn("was completed", detections[0]["phrase"].lower())
+
+    def test_analyze_and_suggest_empty_input(self):
+        """Test that empty input returns safe defaults."""
+        result = analyze_and_suggest("")
+        self.assertEqual(result["detections"], [])
+        self.assertEqual(result["modernized_text"], "")
+        self.assertEqual(result["score"], 100)
+
+    def test_analyze_and_suggest_modernization(self):
+        """Test that the modernized text correctly replaces clichés."""
+        text = "Tasked with handling the database migration."
+        result = analyze_and_suggest(text)
+
+        self.assertNotIn("tasked with", result["modernized_text"].lower())
+        self.assertNotIn("handling", result["modernized_text"].lower())
+        self.assertIn("executed", result["modernized_text"].lower())
+        self.assertIn("orchestrated", result["modernized_text"].lower())
+
+    def test_analyze_and_suggest_score_calculation(self):
+        """Test that the impact score decreases with more issues."""
+        clean_text = "Led the development of a new feature."
+        dirty_text = "I was responsible for helping with the thing and was tasked with duties included."
+
+        clean_result = analyze_and_suggest(clean_text)
+        dirty_result = analyze_and_suggest(dirty_text)
+
+        self.assertGreater(clean_result["score"], dirty_result["score"])
+        self.assertEqual(dirty_result["total_issues"], len(dirty_result["detections"]))

--- a/frontend/src/components/ClicheDetector.css
+++ b/frontend/src/components/ClicheDetector.css
@@ -1,0 +1,300 @@
+.cliche-detector-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    color: var(--text-primary, #e0e0e0);
+}
+
+.detector-title {
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 2rem;
+    font-weight: 700;
+    background: linear-gradient(90deg, #ff6b6b, #feca57);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.detector-workspace {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+
+.glass-card {
+    background: var(--glass-bg, rgba(255, 255, 255, 0.05));
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+    border-radius: 16px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.panel-header h3 {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.glass-button {
+    background: linear-gradient(135deg, #ff6b6b, #ee5253);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 0.75rem 1.5rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.glass-button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(255, 107, 107, 0.4);
+}
+
+.glass-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.text-input {
+    flex: 1;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+    border-radius: 8px;
+    padding: 1rem;
+    color: var(--text-primary, #e0e0e0);
+    font-family: inherit;
+    font-size: 1rem;
+    resize: vertical;
+    min-height: 300px;
+}
+
+.text-input:focus {
+    outline: none;
+    border-color: #ff6b6b;
+    box-shadow: 0 0 0 3px rgba(255, 107, 107, 0.2);
+}
+
+.score-badge {
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-weight: 700;
+    font-size: 0.9rem;
+}
+
+.score-badge[data-score="100"] {
+    background: rgba(46, 213, 115, 0.2);
+    color: #2ed573;
+    border: 1px solid #2ed573;
+}
+
+.score-badge[data-score="80"],
+.score-badge[data-score="90"] {
+    background: rgba(255, 165, 2, 0.2);
+    color: #ffa502;
+    border: 1px solid #ffa502;
+}
+
+.score-badge[data-score="70"] {
+    background: rgba(255, 71, 87, 0.2);
+    color: #ff4757;
+    border: 1px solid #ff4757;
+}
+
+.score-badge[data-score="60"],
+.score-badge[data-score="50"],
+.score-badge[data-score="40"],
+.score-badge[data-score="30"],
+.score-badge[data-score="20"],
+.score-badge[data-score="10"],
+.score-badge[data-score="0"] {
+    background: rgba(255, 71, 87, 0.3);
+    color: #ff4757;
+    border: 1px solid #ff4757;
+}
+
+.empty-state,
+.loading-state {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary, #b0b0b0);
+    font-style: italic;
+    min-height: 300px;
+}
+
+.results-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.glass-card-inner {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.highlighted-text {
+    line-height: 1.8;
+    white-space: pre-wrap;
+    min-height: 150px;
+}
+
+.highlight {
+    cursor: pointer;
+    border-radius: 4px;
+    padding: 0 2px;
+    transition: background 0.2s ease;
+}
+
+.highlight.cliche {
+    background: rgba(255, 165, 2, 0.3);
+    border-bottom: 2px solid #ffa502;
+    color: #ffa502;
+    font-weight: 600;
+}
+
+.highlight.passive {
+    background: rgba(255, 71, 87, 0.3);
+    border-bottom: 2px solid #ff4757;
+    color: #ff4757;
+    font-weight: 600;
+}
+
+.highlight:hover {
+    filter: brightness(1.2);
+}
+
+.suggestion-dropdown {
+    border-left: 4px solid #2ed573;
+}
+
+.suggestion-dropdown h4 {
+    margin-top: 0;
+    color: #2ed573;
+}
+
+.original-phrase {
+    color: var(--text-secondary, #b0b0b0);
+    text-decoration: line-through;
+}
+
+.suggested-phrase {
+    color: #2ed573;
+    font-size: 1.1rem;
+    margin: 0.5rem 0 1rem 0;
+}
+
+.dropdown-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.accept-btn {
+    background: #2ed573;
+    color: #000;
+    border: none;
+    border-radius: 6px;
+    padding: 0.5rem 1rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.dismiss-btn {
+    background: transparent;
+    color: var(--text-secondary, #b0b0b0);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.2));
+    border-radius: 6px;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+}
+
+.modernized-preview h4 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
+.modernized-text {
+    width: 100%;
+    background: rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+    border-radius: 8px;
+    padding: 0.75rem;
+    color: var(--text-primary, #e0e0e0);
+    font-family: inherit;
+    resize: none;
+    margin-bottom: 0.5rem;
+}
+
+.copy-all-btn {
+    width: 100%;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.2));
+    color: var(--text-primary, #e0e0e0);
+    padding: 0.75rem;
+    border-radius: 8px;
+    cursor: pointer;
+    font-weight: 600;
+    transition: background 0.2s ease;
+}
+
+.copy-all-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.error-message {
+    color: #ff4757;
+    text-align: center;
+    margin: 1rem 0;
+}
+
+/* Light mode adjustments */
+@media (prefers-color-scheme: light) {
+    .cliche-detector-container {
+        color: #333333;
+    }
+
+    .glass-card {
+        background: rgba(255, 255, 255, 0.7);
+        border: 1px solid rgba(0, 0, 0, 0.05);
+    }
+
+    .text-input,
+    .modernized-text {
+        background: rgba(255, 255, 255, 0.9);
+        border: 1px solid rgba(0, 0, 0, 0.1);
+        color: #333333;
+    }
+
+    .glass-card-inner {
+        background: rgba(0, 0, 0, 0.03);
+    }
+
+    .highlight.cliche {
+        background: rgba(255, 165, 2, 0.2);
+        color: #cc8400;
+    }
+
+    .highlight.passive {
+        background: rgba(255, 71, 87, 0.2);
+        color: #cc3944;
+    }
+}
+
+@media (max-width: 768px) {
+    .detector-workspace {
+        grid-template-columns: 1fr;
+    }
+}

--- a/frontend/src/components/ClicheDetector.tsx
+++ b/frontend/src/components/ClicheDetector.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import './ClicheDetector.css';
+
+interface Detection {
+    phrase: string;
+    start: number;
+    end: number;
+    suggestion: string;
+    type: 'cliche' | 'passive';
+}
+
+interface AnalysisResult {
+    detections: Detection[];
+    modernized_text: string;
+    score: number;
+    total_issues: number;
+}
+
+const ClicheDetector: React.FC = () => {
+    const [inputText, setInputText] = useState('');
+    const [result, setResult] = useState<AnalysisResult | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+    const [activeDetection, setActiveDetection] = useState<Detection | null>(null);
+
+    const handleAnalyze = async () => {
+        if (!inputText.trim()) return;
+
+        setLoading(true);
+        setError('');
+        try {
+            const response = await axios.post('/api/detect-cliches/', { text: inputText });
+            setResult(response.data);
+        } catch (err: any) {
+            setError(err.response?.data?.error || 'Failed to analyze text. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleAcceptSuggestion = (detection: Detection) => {
+        if (!result) return;
+
+        // Replace the specific detection in the original text
+        const before = inputText.substring(0, detection.start);
+        const after = inputText.substring(detection.end);
+
+        // Preserve casing of the first letter
+        let suggestion = detection.suggestion;
+        if (detection.phrase[0] === detection.phrase[0].toUpperCase()) {
+            suggestion = suggestion.charAt(0).toUpperCase() + suggestion.slice(1);
+        }
+
+        const newText = before + suggestion + after;
+        setInputText(newText);
+        setActiveDetection(null);
+
+        // Re-analyze automatically
+        setTimeout(() => {
+            handleAnalyze();
+        }, 100);
+    };
+
+    const getHighlightedText = () => {
+        if (!result || result.detections.length === 0) return inputText;
+
+        let lastIndex = 0;
+        const elements: React.ReactNode[] = [];
+
+        // Sort detections by start index to process in order
+        const sortedDetections = [...result.detections].sort((a, b) => a.start - b.start);
+
+        sortedDetections.forEach((detection, index) => {
+            // Add text before the detection
+            if (detection.start > lastIndex) {
+                elements.push(
+                    <span key={`text-${index}`}>
+                        {inputText.substring(lastIndex, detection.start)}
+                    </span>
+                );
+            }
+
+            // Add the highlighted detection
+            elements.push(
+                <span
+                    key={`detection-${index}`}
+                    className={`highlight ${detection.type}`}
+                    onClick={() => setActiveDetection(detection)}
+                    title={`Suggestion: ${detection.suggestion}`}
+                >
+                    {inputText.substring(detection.start, detection.end)}
+                </span>
+            );
+
+            lastIndex = detection.end;
+        });
+
+        // Add remaining text
+        if (lastIndex < inputText.length) {
+            elements.push(
+                <span key="text-end">{inputText.substring(lastIndex)}</span>
+            );
+        }
+
+        return elements;
+    };
+
+    return (
+        <div className="cliche-detector-container">
+            <h2 className="detector-title">Resume Phrase Modernizer</h2>
+
+            <div className="detector-workspace">
+                <div className="input-panel glass-card">
+                    <div className="panel-header">
+                        <h3>Original Text</h3>
+                        <button
+                            className="analyze-btn glass-button"
+                            onClick={handleAnalyze}
+                            disabled={loading || !inputText.trim()}
+                        >
+                            {loading ? 'Analyzing...' : 'Analyze & Suggest'}
+                        </button>
+                    </div>
+                    <textarea
+                        className="text-input"
+                        value={inputText}
+                        onChange={(e) => setInputText(e.target.value)}
+                        placeholder="Paste your resume bullet points or summary here..."
+                        rows={12}
+                    />
+                </div>
+
+                <div className="output-panel glass-card">
+                    <div className="panel-header">
+                        <h3>Analysis & Modernization</h3>
+                        {result && (
+                            <div className="score-badge" data-score={result.score}>
+                                Impact Score: {result.score}/100
+                            </div>
+                        )}
+                    </div>
+
+                    {error && <p className="error-message">{error}</p>}
+
+                    {!result && !loading && (
+                        <div className="empty-state">
+                            <p>Click "Analyze & Suggest" to identify clichés and passive voice.</p>
+                        </div>
+                    )}
+
+                    {loading && <div className="loading-state">Analyzing text...</div>}
+
+                    {result && !loading && (
+                        <div className="results-content">
+                            <div className="highlighted-text glass-card-inner">
+                                {getHighlightedText()}
+                            </div>
+
+                            {activeDetection && (
+                                <div className="suggestion-dropdown glass-card-inner">
+                                    <h4>Improvement Suggestion</h4>
+                                    <p className="original-phrase">Instead of: <strong>"{activeDetection.phrase}"</strong></p>
+                                    <p className="suggested-phrase">Use: <strong>"{activeDetection.suggestion}"</strong></p>
+                                    <div className="dropdown-actions">
+                                        <button
+                                            className="accept-btn"
+                                            onClick={() => handleAcceptSuggestion(activeDetection)}
+                                        >
+                                            Apply Change
+                                        </button>
+                                        <button
+                                            className="dismiss-btn"
+                                            onClick={() => setActiveDetection(null)}
+                                        >
+                                            Dismiss
+                                        </button>
+                                    </div>
+                                </div>
+                            )}
+
+                            <div className="modernized-preview">
+                                <h4>Full Modernized Version</h4>
+                                <textarea
+                                    className="modernized-text"
+                                    value={result.modernized_text}
+                                    readOnly
+                                    rows={6}
+                                />
+                                <button
+                                    className="copy-all-btn"
+                                    onClick={() => navigator.clipboard.writeText(result.modernized_text)}
+                                >
+                                    Copy Modernized Text
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ClicheDetector;


### PR DESCRIPTION
## 📝 Description

This PR implements a Resume Phrase Cliché Detector and Modernizer. It introduces an NLP-based backend module that identifies overused buzzwords, passive voice, and cliché phrases in resume bullet points, offering strong, action-oriented alternatives. The frontend provides an interactive text editor that highlights detected issues inline and allows users to apply suggested replacements with a single click.

## 🔗 Related Issue

Closes #923

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [x] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer.tests_cliche_detector`)
- [x] Manually tested in the browser / API client

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)