### PR TITLE
feat: add drag-and-drop resume upload functionality to compare tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Added drag-and-drop resume upload functionality to compare tools allowing drag-and-drop directly on the file inputs (#20).
 - Bulk resume analysis allowing multi-file upload (.pdf, .docx, .txt), candidate ranking summary table, and detailed inspection view per resume (#57).
 - Granular consent toggles in Account Settings and initial banner for optional data collection (analytics and AI resume roast mode), strictly opt-in and off by default (#536).
 - Auto-save Job Description text as a debounced draft in local storage to prevent accidental data loss upon page refresh or navigation (#533).

--- a/frontend/src/components/CompareVersions/CompareBulkJds.tsx
+++ b/frontend/src/components/CompareVersions/CompareBulkJds.tsx
@@ -36,6 +36,7 @@ const BULK_JD_DRAFT_KEY = 'bulk_jd_drafts'
 
 export const CompareBulkJds: React.FC<CompareBulkJdsProps> = ({onClose,username,isEmbed = false}) => {
   const [file, setFile] = useState<File | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
   const [resumeUrl, setResumeUrl] = useState('')
   const [jds, setJds] = useState<string[]>(() => {
     try {
@@ -214,12 +215,26 @@ export const CompareBulkJds: React.FC<CompareBulkJdsProps> = ({onClose,username,
             <h4 style={{ margin: 0, fontSize: '15px', fontWeight: '600' }}>1. Choose Resume</h4>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px' }}>
               <div
+                className={isDragging ? 'dragging' : ''}
                 style={{
                   flex: 1,
                   minWidth: '250px',
                   display: 'flex',
                   flexDirection: 'column',
                   gap: '6px',
+                  padding: '1rem',
+                  border: isDragging ? '2px dashed #4f46e5' : '1px solid transparent',
+                  borderRadius: '8px',
+                  transition: 'all 0.2s ease',
+                }}
+                onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+                onDragLeave={() => setIsDragging(false)}
+                onDrop={(e) => {
+                  e.preventDefault(); setIsDragging(false);
+                  if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                    setFile(e.dataTransfer.files[0]);
+                    setResumeUrl('');
+                  }
                 }}
               >
                 <label style={{ fontSize: '12px', fontWeight: '600', opacity: 0.8 }}>

--- a/frontend/src/components/CompareVersions/CompareUploads.tsx
+++ b/frontend/src/components/CompareVersions/CompareUploads.tsx
@@ -17,6 +17,8 @@ const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000'
 export const CompareUploads: React.FC<CompareUploadsProps> = ({ onClose, targetRole, jobDesc = '', isEmbed = false }) => {
   const [file1, setFile1] = useState<File | null>(null)
   const [file2, setFile2] = useState<File | null>(null)
+  const [isDragging1, setIsDragging1] = useState(false)
+  const [isDragging2, setIsDragging2] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [comparison, setComparison] = useState<VersionComparison | null>(null)
@@ -70,8 +72,16 @@ export const CompareUploads: React.FC<CompareUploadsProps> = ({ onClose, targetR
             }}
           >
             <div
-              className="compare-picker"
-              style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
+              className={`compare-picker ${isDragging1 ? 'dragging' : ''}`}
+              style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '1rem', border: isDragging1 ? '2px dashed #4f46e5' : '1px solid transparent', borderRadius: '8px', transition: 'all 0.2s ease' }}
+              onDragOver={(e) => { e.preventDefault(); setIsDragging1(true); }}
+              onDragLeave={() => setIsDragging1(false)}
+              onDrop={(e) => {
+                e.preventDefault(); setIsDragging1(false);
+                if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                  setFile1(e.dataTransfer.files[0]);
+                }
+              }}
             >
               <label>Older Version (File 1)</label>
               <input
@@ -82,8 +92,16 @@ export const CompareUploads: React.FC<CompareUploadsProps> = ({ onClose, targetR
               />
             </div>
             <div
-              className="compare-picker"
-              style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
+              className={`compare-picker ${isDragging2 ? 'dragging' : ''}`}
+              style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '1rem', border: isDragging2 ? '2px dashed #4f46e5' : '1px solid transparent', borderRadius: '8px', transition: 'all 0.2s ease' }}
+              onDragOver={(e) => { e.preventDefault(); setIsDragging2(true); }}
+              onDragLeave={() => setIsDragging2(false)}
+              onDrop={(e) => {
+                e.preventDefault(); setIsDragging2(false);
+                if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                  setFile2(e.dataTransfer.files[0]);
+                }
+              }}
             >
               <label>Newer Version (File 2)</label>
               <input


### PR DESCRIPTION
 ## 📝 Description

    Added drag-and-drop support for resume file uploads in the
  `CompareUploads` and `CompareBulkJds` components.
    - The drop zones visually highlight when a file is dragged over them.
    - Dropped files are correctly mapped to their respective inputs and
  undergo validation against accepted file types.
    - The default native file input is retained as a graceful fallback
  for unsupported browsers.
    - `CHANGELOG.md` has been updated with these changes under the
  Unreleased section.

    ## 🔗 Related Issue

    Closes #20

    ## ✅ Type of Change

    - [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
    - [x] ✨ New feature (non-breaking change that adds functionality)
    - [ ] 📚 Documentation update
    - [x] 💅 UI/UX improvement
    - [ ] ♻️ Refactor (no functional change)
    - [ ] ⚡ Performance improvement

    ## 🧪 How Has This Been Tested?

    - [x] Frontend builds (`npm run build`) and lints (`npm run lint`)
  clean
    - [x] Backend tests pass (`python manage.py test analyzer`)
    - [x] Manually tested in the browser / API client

    ## 📸 Screenshots (if applicable)



    ## 📋 Checklist

    - [x] My code follows the project's style and conventions
    - [x] I have linked the related issue above
    - [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
