### PR TITLE
fix: route the seven endpoints the five newest features never published (#936)

### DIFF
--- a/backend/analyzer/ab_testing_views.py
+++ b/backend/analyzer/ab_testing_views.py
@@ -4,6 +4,8 @@ Views for A/B Testing Framework.
 Exposes POST /api/log-application/ and GET /api/ab-testing-stats/ endpoints.
 """
 
+import logging
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
@@ -14,6 +16,8 @@ from .ab_testing_serializers import (
     ABTestingStatsResponseSerializer,
 )
 from .models import ApplicationLog
+
+logger = logging.getLogger(__name__)
 
 
 class LogApplicationView(APIView):
@@ -57,11 +61,11 @@ class ABTestingStatsView(APIView):
 
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
+            logger.exception(
+                "A/B testing stats failed for user %s", request.user.pk
+            )
             return Response(
-                {
-                    "error": "An unexpected error occurred while calculating stats.",
-                    "details": str(e),
-                },
+                {"error": "An unexpected error occurred while calculating stats."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/backend/analyzer/accessibility_views.py
+++ b/backend/analyzer/accessibility_views.py
@@ -4,20 +4,43 @@ Views for Accessibility Checker.
 Exposes the POST /api/check-accessibility/ endpoint.
 """
 
+import logging
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.throttling import AnonRateThrottle
 from .accessibility_checker import check_accessibility, calculate_accessibility_score
 from .accessibility_serializers import (
     AccessibilityCheckRequestSerializer,
     AccessibilityReportResponseSerializer,
 )
 
+logger = logging.getLogger(__name__)
+
+
+class AccessibilityCheckThrottle(AnonRateThrottle):
+    """Caps /api/check-accessibility/.
+
+    ``DEFAULT_PERMISSION_CLASSES`` is ``AllowAny`` and this view does not
+    override it, so the endpoint is open. It runs five regex passes over a
+    body the caller controls the size of. Rate from
+    ``DEFAULT_THROTTLE_RATES["accessibility_check"]``.
+
+    ``scope`` is set explicitly: every ``AnonRateThrottle`` subclass inherits
+    the scope "anon" otherwise, which would put this endpoint in the same
+    bucket as unrelated ones.
+    """
+
+    scope = "accessibility_check"
+
 
 class AccessibilityCheckView(APIView):
     """
     API View to handle resume accessibility checking requests.
     """
+
+    throttle_classes = [AccessibilityCheckThrottle]
 
     def post(self, request, *args, **kwargs):
         """
@@ -49,11 +72,12 @@ class AccessibilityCheckView(APIView):
 
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
+            # `str(e)` used to go back in the response body. That hands the
+            # caller file paths, SQL and library internals on any unexpected
+            # failure; the operator wants that detail, the client does not.
+            logger.exception("Accessibility check failed")
             return Response(
-                {
-                    "error": "An unexpected error occurred during accessibility check.",
-                    "details": str(e),
-                },
+                {"error": "An unexpected error occurred during accessibility check."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/backend/analyzer/cliche_views.py
+++ b/backend/analyzer/cliche_views.py
@@ -4,20 +4,33 @@ Views for Cliché Detector.
 Exposes the POST /api/detect-cliches/ endpoint.
 """
 
+import logging
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.throttling import AnonRateThrottle
 from .cliche_detector import analyze_and_suggest
 from .cliche_serializers import (
     ClicheDetectionRequestSerializer,
     ClicheDetectionResponseSerializer,
 )
 
+logger = logging.getLogger(__name__)
+
+
+class ClicheDetectorThrottle(AnonRateThrottle):
+    """Caps /api/detect-cliches/, an open endpoint that scans caller-sized text."""
+
+    scope = "cliche_detection"
+
 
 class ClicheDetectorView(APIView):
     """
     API View to handle cliché detection and modernization requests.
     """
+
+    throttle_classes = [ClicheDetectorThrottle]
 
     def post(self, request, *args, **kwargs):
         """
@@ -42,11 +55,9 @@ class ClicheDetectorView(APIView):
 
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
+            logger.exception("Cliché analysis failed")
             return Response(
-                {
-                    "error": "An unexpected error occurred during analysis.",
-                    "details": str(e),
-                },
+                {"error": "An unexpected error occurred during analysis."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/backend/analyzer/linkedin_views.py
+++ b/backend/analyzer/linkedin_views.py
@@ -4,20 +4,33 @@ Views for LinkedIn Profile Optimization.
 Exposes the POST /api/optimize-linkedin/ endpoint.
 """
 
+import logging
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.throttling import AnonRateThrottle
 from .linkedin_optimizer import generate_linkedin_profile
 from .linkedin_serializers import (
     LinkedInOptimizationRequestSerializer,
     LinkedInOptimizationResponseSerializer,
 )
 
+logger = logging.getLogger(__name__)
+
+
+class LinkedInOptimizationThrottle(AnonRateThrottle):
+    """Caps /api/optimize-linkedin/, an open endpoint that rewrites caller-sized text."""
+
+    scope = "linkedin_optimization"
+
 
 class LinkedInOptimizationView(APIView):
     """
     API View to handle LinkedIn profile optimization requests.
     """
+
+    throttle_classes = [LinkedInOptimizationThrottle]
 
     def post(self, request, *args, **kwargs):
         """
@@ -45,11 +58,9 @@ class LinkedInOptimizationView(APIView):
 
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
+            logger.exception("LinkedIn optimization failed")
             return Response(
-                {
-                    "error": "An unexpected error occurred during optimization.",
-                    "details": str(e),
-                },
+                {"error": "An unexpected error occurred during optimization."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/backend/analyzer/sanitizer_views.py
+++ b/backend/analyzer/sanitizer_views.py
@@ -4,12 +4,14 @@ Views for Metadata Sanitizer.
 Exposes endpoints for GET /api/file-metadata/ and POST /api/sanitize-resume/.
 """
 
+import logging
 import os
 import tempfile
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.parsers import MultiPartParser, FormParser
+from rest_framework.throttling import AnonRateThrottle
 from .metadata_sanitizer import (
     extract_pdf_metadata,
     extract_docx_metadata,
@@ -25,6 +27,31 @@ from .sanitizer_serializers import (
     RedactionResponseSerializer,
 )
 
+#: The extensions this view knows how to read. Also the allowlist for the
+#: temp-file suffix, so a caller cannot steer that through the upload name.
+SUPPORTED_EXTENSIONS = ("pdf", "docx")
+
+logger = logging.getLogger(__name__)
+
+
+class FileMetadataThrottle(AnonRateThrottle):
+    """Caps /api/file-metadata/.
+
+    Of the endpoints routed in this pass this is the one that most needs a
+    ceiling: it is open (``AllowAny`` by default, not overridden here), it
+    accepts an arbitrary upload, and it writes every request body to the
+    server's disk before doing any work. Unlimited, that is a way to fill a
+    disk from off the internet.
+    """
+
+    scope = "file_metadata"
+
+
+class SanitizeResumeThrottle(AnonRateThrottle):
+    """Caps /api/sanitize-resume/, an open endpoint that regexes caller-sized text."""
+
+    scope = "sanitize_resume"
+
 
 class FileMetadataView(APIView):
     """
@@ -32,6 +59,7 @@ class FileMetadataView(APIView):
     """
 
     parser_classes = (MultiPartParser, FormParser)
+    throttle_classes = [FileMetadataThrottle]
 
     def post(self, request, *args, **kwargs):
         serializer = MetadataExtractionRequestSerializer(data=request.data)
@@ -44,28 +72,38 @@ class FileMetadataView(APIView):
         filename = uploaded_file.name
         filetype = filename.split(".")[-1].lower()
 
-        # Save to temp file for processing
-        with tempfile.NamedTemporaryFile(
-            delete=False, suffix=f".{filetype}"
-        ) as temp_file:
-            for chunk in uploaded_file.chunks():
-                temp_file.write(chunk)
-            temp_path = temp_file.name
+        # Checked before anything is written to disk. It used to run after
+        # the upload had already been streamed into a temp file, so an
+        # unsupported type still cost a full write.
+        if filetype not in SUPPORTED_EXTENSIONS:
+            return Response(
+                {"error": "Unsupported file type. Use PDF or DOCX."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Bound before the `with`: if writing the upload raises, the `finally`
+        # below would otherwise raise NameError on an unbound `temp_path` and
+        # bury the real error.
+        temp_path = None
 
         try:
+            # The suffix comes from the allowlist above, not straight from
+            # the client-supplied filename.
+            with tempfile.NamedTemporaryFile(
+                delete=False, suffix=f".{filetype}"
+            ) as temp_file:
+                for chunk in uploaded_file.chunks():
+                    temp_file.write(chunk)
+                temp_path = temp_file.name
+
             if filetype == "pdf":
                 metadata = extract_pdf_metadata(temp_path)
                 # For PII detection, we'd ideally extract text first.
                 # Simplified here to return structure.
                 pii_detections = []
-            elif filetype == "docx":
+            else:
                 metadata = extract_docx_metadata(temp_path)
                 pii_detections = []
-            else:
-                return Response(
-                    {"error": "Unsupported file type. Use PDF or DOCX."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
 
             response_data = {
                 "filename": filename,
@@ -80,7 +118,7 @@ class FileMetadataView(APIView):
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
         finally:
-            if os.path.exists(temp_path):
+            if temp_path and os.path.exists(temp_path):
                 os.remove(temp_path)
 
 
@@ -88,6 +126,8 @@ class SanitizeResumeView(APIView):
     """
     API View to redact PII from provided text.
     """
+
+    throttle_classes = [SanitizeResumeThrottle]
 
     def post(self, request, *args, **kwargs):
         serializer = PIIRedactionRequestSerializer(data=request.data)

--- a/backend/analyzer/tests_ab_testing.py
+++ b/backend/analyzer/tests_ab_testing.py
@@ -22,11 +22,21 @@ class ABTestingTests(TestCase):
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
 
+        # `ats_score` is not a field on ResumeAnalysis — the column is
+        # `score` — and `score` and `target_role` are both non-null with no
+        # default, so the original fixture raised in setUp and every test in
+        # this class errored before its first assertion.
         self.resume1 = ResumeAnalysis.objects.create(
-            user=self.user, file_name="resume_v1.pdf", ats_score=85
+            user=self.user,
+            file_name="resume_v1.pdf",
+            score=85,
+            target_role="Software Engineer",
         )
         self.resume2 = ResumeAnalysis.objects.create(
-            user=self.user, file_name="resume_v2.pdf", ats_score=90
+            user=self.user,
+            file_name="resume_v2.pdf",
+            score=90,
+            target_role="Software Engineer",
         )
 
     def test_log_application_success(self):
@@ -46,7 +56,10 @@ class ABTestingTests(TestCase):
         """Test that a user cannot log an application for another user's resume."""
         other_user = User.objects.create_user(username="otheruser", password="pass")
         other_resume = ResumeAnalysis.objects.create(
-            user=other_user, file_name="other.pdf"
+            user=other_user,
+            file_name="other.pdf",
+            score=70,
+            target_role="Software Engineer",
         )
 
         data = {
@@ -91,7 +104,10 @@ class ABTestingTests(TestCase):
             status="interviewed",
         )
 
-        # Resume 2: 1 applied, 1 offered (100% success)
+        # Resume 2: 2 applications, 1 of them an offer (50% success).
+        # The comment here used to read "1 applied, 1 offered (100% success)",
+        # which is two different counts of the same two rows; the assertion
+        # below was written against the wrong one.
         ApplicationLog.objects.create(
             user=self.user,
             resume_analysis=self.resume2,
@@ -112,9 +128,11 @@ class ABTestingTests(TestCase):
         self.assertEqual(stats["total_applications"], 5)
         self.assertEqual(len(stats["resume_stats"]), 2)
 
-        # Check sorting (Resume 2 should be first due to 100% success rate)
+        # Check sorting: resume 2 first, 50% beating resume 1's 33.33%.
         self.assertEqual(stats["resume_stats"][0]["resume_id"], self.resume2.id)
-        self.assertEqual(stats["resume_stats"][0]["success_rate"], 100.0)
+        self.assertEqual(stats["resume_stats"][0]["success_rate"], 50.0)
+        self.assertEqual(stats["resume_stats"][1]["resume_id"], self.resume1.id)
+        self.assertEqual(stats["resume_stats"][1]["success_rate"], 33.33)
         self.assertEqual(stats["best_performing_resume_id"], self.resume2.id)
 
     def test_ab_testing_stats_endpoint(self):

--- a/backend/analyzer/tests_api_routes.py
+++ b/backend/analyzer/tests_api_routes.py
@@ -76,7 +76,49 @@ ROUTES = [
     # Not called from the frontend yet. Routed in the same pass rather than
     # left as the next 404.
     ("/api/analyzer/layout-analysis/", "components/LayoutAnalysisReport.tsx"),
+    # And again, for the five features merged in #929-#933. Seven more view
+    # classes written, tested and never given a path. The React components
+    # below were merged calling these exact URLs.
+    ("/api/ab-testing-stats/", "components/ResumeABTesting.tsx"),
+    ("/api/log-application/", "components/ResumeABTesting.tsx"),
+    ("/api/check-accessibility/", "components/AccessibilityReport.tsx"),
+    ("/api/detect-cliches/", "components/ClicheDetector.tsx"),
+    ("/api/optimize-linkedin/", "components/LinkedInOptimizer.tsx"),
+    ("/api/file-metadata/", "components/PrivacyScrubber.tsx"),
+    ("/api/sanitize-resume/", "components/PrivacyScrubber.tsx"),
 ]
+
+#: Endpoints that are open by default and therefore must declare a throttle.
+#:
+#: ``DEFAULT_PERMISSION_CLASSES`` is ``AllowAny``. A view that neither
+#: overrides it nor sets ``throttle_classes`` is an unauthenticated endpoint
+#: with no ceiling, which settings.py already states the project does not
+#: ship. Asserting it here means the next such view fails the build instead of
+#: reaching production, which is how all five of these got in.
+THROTTLE_EXEMPT_VIEW_NAMES = frozenset(
+    {
+        # Authenticated: the user id is the natural bound.
+        "ABTestingStatsView",
+        "LogApplicationView",
+        # --- Pre-existing, not introduced by this pass ---
+        #
+        # The list below is a baseline, not an endorsement. The assertion's
+        # job is to stop the *next* unbounded open endpoint, and it can only
+        # do that if it is green today. Each of these deserves its own look;
+        # tightening them is a change to their own behaviour and belongs with
+        # whoever owns them, not bundled into a routing fix.
+        #
+        # Third-party views this project does not define:
+        "SpectacularAPIView",
+        "SpectacularSwaggerView",
+        "TokenRefreshView",
+        "CustomTokenObtainPairView",
+        # Project views that predate this check:
+        "preview_experience_level_view",
+        "resume_score_badge",
+        "unsubscribe_digest_view",
+    }
+)
 
 
 class FrontendRouteContractTests(TestCase):
@@ -603,3 +645,101 @@ class RoutedFeatureEndpointTests(TestCase):
 
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("error", resp.data)
+
+
+class OpenEndpointThrottleTests(TestCase):
+    """Every routed view that is open to anonymous callers declares a ceiling.
+
+    The five features merged in #929-#933 each shipped a view with no
+    ``permission_classes`` and no ``throttle_classes``. Routing them without
+    fixing that would have opened five unauthenticated endpoints with no
+    limit, one of which writes its request body to disk.
+
+    This walks what is actually routed rather than a hand-written list, so a
+    new open endpoint is covered the day it is added.
+    """
+
+    @staticmethod
+    def _routed_view_classes():
+        from django.urls import get_resolver
+
+        routed = {}
+
+        def walk(patterns):
+            for pattern in patterns:
+                sub = getattr(pattern, "url_patterns", None)
+                if sub is not None:
+                    walk(sub)
+                    continue
+                callback = getattr(pattern, "callback", None)
+                view_class = getattr(callback, "cls", None)
+                if view_class is not None:
+                    routed[view_class] = str(pattern.pattern)
+
+        walk(get_resolver().url_patterns)
+        return routed
+
+    def test_every_open_routed_view_declares_a_throttle(self):
+        from rest_framework.permissions import AllowAny
+
+        unlimited = []
+
+        for view_class, route in self._routed_view_classes().items():
+            if view_class.__name__ in THROTTLE_EXEMPT_VIEW_NAMES:
+                continue
+
+            permissions = getattr(view_class, "permission_classes", [])
+            is_open = not permissions or all(p is AllowAny for p in permissions)
+            if not is_open:
+                continue
+
+            if not getattr(view_class, "throttle_classes", []):
+                unlimited.append(f"{view_class.__name__}  ({route})")
+
+        self.assertEqual(
+            sorted(unlimited),
+            [],
+            "These views are reachable without authentication and declare no "
+            "throttle, so they are unbounded:\n  " + "\n  ".join(sorted(unlimited)),
+        )
+
+    def test_every_declared_throttle_scope_has_a_rate(self):
+        """A scope with no entry in DEFAULT_THROTTLE_RATES raises at request time.
+
+        ``ScopedRateThrottle``/``AnonRateThrottle`` look the scope up in
+        ``DEFAULT_THROTTLE_RATES`` and raise ``ImproperlyConfigured`` if it is
+        missing — but only when a request arrives, so a typo in either half of
+        the pair is invisible until the endpoint is called.
+        """
+        from django.conf import settings
+        from rest_framework.throttling import SimpleRateThrottle
+
+        rates = settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]
+        missing = []
+
+        for view_class in self._routed_view_classes():
+            for throttle_class in getattr(view_class, "throttle_classes", []):
+                scope = getattr(throttle_class, "scope", None)
+                if scope is None:
+                    continue
+                # A throttle that hardcodes `rate`, or overrides `get_rate` to
+                # read a setting of its own (UploadRateThrottle, and the two
+                # in views.py that size themselves), never consults
+                # DEFAULT_THROTTLE_RATES and so cannot be missing from it.
+                if getattr(throttle_class, "rate", None):
+                    continue
+                if throttle_class.get_rate is not SimpleRateThrottle.get_rate:
+                    continue
+                if scope not in rates:
+                    missing.append(
+                        f"{view_class.__name__} -> "
+                        f"{throttle_class.__name__}(scope={scope!r})"
+                    )
+
+        self.assertEqual(
+            sorted(missing),
+            [],
+            "These throttle scopes have no rate in DEFAULT_THROTTLE_RATES, so "
+            "the endpoint raises ImproperlyConfigured on its first request:\n  "
+            + "\n  ".join(sorted(missing)),
+        )

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -46,6 +46,16 @@ from .interview_views import InterviewQuestionGenerateView
 from .layout_views import LayoutAnalysisView
 from .multilingual_views import LanguageDetectionView, TranslationView
 
+# Same again, for the five features merged in #929-#933. Seven view classes,
+# no paths. These sit at the top level rather than under `analyzer/` because
+# that is where the frontend and the view docstrings already agree they are —
+# see the ROUTES table in tests_api_routes.py for who calls each one.
+from .ab_testing_views import ABTestingStatsView, LogApplicationView
+from .accessibility_views import AccessibilityCheckView
+from .cliche_views import ClicheDetectorView
+from .linkedin_views import LinkedInOptimizationView
+from .sanitizer_views import FileMetadataView, SanitizeResumeView
+
 urlpatterns = [
     path("upload/", upload_resume),
     path("preview-level/", preview_experience_level_view),
@@ -126,5 +136,50 @@ urlpatterns = [
         "analyzer/translate/",
         TranslationView.as_view(),
         name="translate_resume_text",
+    ),
+
+    # Resume A/B testing (#925).
+    path(
+        "log-application/",
+        LogApplicationView.as_view(),
+        name="log_application",
+    ),
+    path(
+        "ab-testing-stats/",
+        ABTestingStatsView.as_view(),
+        name="ab_testing_stats",
+    ),
+
+    # Screen-reader compliance (#926).
+    path(
+        "check-accessibility/",
+        AccessibilityCheckView.as_view(),
+        name="check_accessibility",
+    ),
+
+    # Cliché detection and modernisation.
+    path(
+        "detect-cliches/",
+        ClicheDetectorView.as_view(),
+        name="detect_cliches",
+    ),
+
+    # LinkedIn profile optimisation.
+    path(
+        "optimize-linkedin/",
+        LinkedInOptimizationView.as_view(),
+        name="optimize_linkedin",
+    ),
+
+    # Metadata sanitiser and privacy scrubber (#924).
+    path(
+        "file-metadata/",
+        FileMetadataView.as_view(),
+        name="file_metadata",
+    ),
+    path(
+        "sanitize-resume/",
+        SanitizeResumeView.as_view(),
+        name="sanitize_resume",
     ),
 ]

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -226,6 +226,22 @@ REST_FRAMEWORK = {
         'skills_leaderboard': os.environ.get(
             'SKILLS_LEADERBOARD_RATE', '100/hour'
         ),
+        # The five features merged in #929-#933 all default to AllowAny and
+        # none of them set permission_classes, so routing them (#936) opens
+        # five unauthenticated endpoints. Same rule as above: each gets a
+        # ceiling, and each gets its own scope so one does not eat another's
+        # budget.
+        'accessibility_check': os.environ.get(
+            'ACCESSIBILITY_CHECK_RATE', '60/hour'
+        ),
+        'cliche_detection': os.environ.get('CLICHE_DETECTION_RATE', '60/hour'),
+        'linkedin_optimization': os.environ.get(
+            'LINKEDIN_OPTIMIZATION_RATE', '30/hour'
+        ),
+        # Lower than the text endpoints on purpose: this one writes the
+        # request body to disk before it does anything else.
+        'file_metadata': os.environ.get('FILE_METADATA_RATE', '20/hour'),
+        'sanitize_resume': os.environ.get('SANITIZE_RESUME_RATE', '60/hour'),
     },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }


### PR DESCRIPTION
## 📝 Description

The five features merged in #929–#933 each shipped a view, a serializer, tests and a React component — and none of them were added to `analyzer/urls.py`. Seven view classes exist, no URL reaches any of them, and the frontend was merged calling the exact paths the view docstrings promise. Every one of those features 404s.

`test_every_view_class_in_a_view_module_is_routed` has been saying so; it was masked by #935, which stopped the suite running at all.

## 🔗 Related Issue

Closes #936

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## 🔍 What changed

### The routes

Seven paths, at the URLs the callers already use — same reasoning as the last round of this: moving the frontend instead would break any client already deployed against them.

| Path | View | Called by |
|---|---|---|
| `/api/log-application/` | `LogApplicationView` | `ResumeABTesting.tsx:71` |
| `/api/ab-testing-stats/` | `ABTestingStatsView` | `ResumeABTesting.tsx:47` |
| `/api/check-accessibility/` | `AccessibilityCheckView` | `AccessibilityReport.tsx:30` |
| `/api/detect-cliches/` | `ClicheDetectorView` | `ClicheDetector.tsx:33` |
| `/api/optimize-linkedin/` | `LinkedInOptimizationView` | `LinkedInOptimizer.tsx:43` |
| `/api/file-metadata/` | `FileMetadataView` | `PrivacyScrubber.tsx:32` |
| `/api/sanitize-resume/` | `SanitizeResumeView` | `PrivacyScrubber.tsx:59` |

### Throttles, before routing them

Routing these as they stood would have opened five unauthenticated endpoints with no ceiling — `DEFAULT_PERMISSION_CLASSES` is `AllowAny` and none of the five override it. `settings.py` already states the project's rule for this, so each gets its own scope and an env-overridable rate next to the existing ones:

| Scope | Default | Env var |
|---|---|---|
| `accessibility_check` | 60/hour | `ACCESSIBILITY_CHECK_RATE` |
| `cliche_detection` | 60/hour | `CLICHE_DETECTION_RATE` |
| `linkedin_optimization` | 30/hour | `LINKEDIN_OPTIMIZATION_RATE` |
| `file_metadata` | 20/hour | `FILE_METADATA_RATE` |
| `sanitize_resume` | 60/hour | `SANITIZE_RESUME_RATE` |

`file_metadata` is the tightest deliberately: it is open, accepts an arbitrary upload, and writes every request body to the server's disk before doing any work. The two A/B testing views are already `IsAuthenticated`, so the user id bounds them.

Each throttle sets `scope` explicitly. Every `AnonRateThrottle` subclass inherits the scope `"anon"` otherwise, which would put unrelated endpoints in one shared bucket — the same trap `bullet_views.py` documents.

### Three smaller things in the same views

- **`{"details": str(e)}` no longer goes back to the client** on a 500, in four views. It hands the caller file paths, SQL and library internals on any unexpected failure. `logger.exception` puts it where the operator can read it instead.
- **`FileMetadataView` checked the file type after streaming the upload to disk**, so an unsupported type still cost a full write. Checked first now, and the temp-file suffix comes from that allowlist rather than straight from the client's filename.
- **`temp_path` is bound before the `with`.** If writing the upload raised, the `finally` clause raised `NameError` on an unbound name over the top of the real error.

### `tests_ab_testing.py` never ran an assertion

Its `setUp` builds `ResumeAnalysis(... ats_score=85)`. There is no `ats_score` field — the column is `score` — and `target_role` is non-null with no default, so every test in the class errored before reaching its first assertion.

One assertion was also wrong. The fixture creates two rows for resume 2 (one `applied`, one `offered`) but the comment above it reads "1 applied, 1 offered (100% success)" — two different counts of the same two rows. 1 of 2 is 50%, and the assertion was written against the comment. Corrected, with the sort order for resume 1 pinned alongside it.

### Two new contract tests

Both walk what is actually routed rather than a hand-written list, so a new endpoint is covered the day it is added:

- **`test_every_open_routed_view_declares_a_throttle`** — seeded with a baseline of the seven open views that predate the check (four of them third-party: Spectacular ×2, `TokenRefreshView`, `CustomTokenObtainPairView`). The baseline is not an endorsement; the assertion's job is to stop the *next* unbounded endpoint, and it can only do that if it is green today. Tightening the existing seven changes their own behaviour and belongs with whoever owns them.
- **`test_every_declared_throttle_scope_has_a_rate`** — a scope with no entry in `DEFAULT_THROTTLE_RATES` raises `ImproperlyConfigured`, but only when a request arrives. A typo in either half of that pair is otherwise invisible until someone calls the endpoint.

## 🧪 How Has This Been Tested?

- [x] Backend tests pass (`python manage.py test analyzer`)

Verified on top of #940, which this needs to be able to run at all:

```
Ran 822 tests
```

`test_every_view_class_in_a_view_module_is_routed` and all five `tests_ab_testing` tests are green. The six still-red tests belong to #937, #938 and #939 and are untouched here.

## 📌 Note

Depends on #940. That PR fixes a `NameError` in `models.py` that stops Django loading at all; without it nothing in this PR can be exercised.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
