### PR TITLE
fix: stop the LinkedIn optimizer corrupting the profile it generates (#937)

### DIFF
--- a/backend/analyzer/linkedin_optimizer.py
+++ b/backend/analyzer/linkedin_optimizer.py
@@ -49,6 +49,108 @@ WEAK_PHRASES = [
     "handled",
 ]
 
+# Auxiliaries that turn a weak phrase into a passive clause. Swapping
+# "responsible for" for "spearheaded" inside "I was responsible for the
+# rollout" produces "I was spearheaded the rollout" — passive, and not
+# English. When one of these introduces the phrase it is replaced along with
+# it, so the clause comes back active.
+_LEADING_AUXILIARIES = r"(?:was|were|is|are|been|being)\s+"
+
+WEAK_PHRASE_PATTERN = re.compile(
+    r"\b(?:"
+    + _LEADING_AUXILIARIES
+    + r")?(?:"
+    + "|".join(re.escape(phrase) for phrase in WEAK_PHRASES)
+    + r")\b",
+    re.IGNORECASE,
+)
+
+# Whole-word match. `"Led" in description` is a substring test, and "led" is
+# inside "handled", "fulfilled", "called", "scheduled" and "modelled" — so
+# "Handled customer escalations and fulfilled orders" counted as already
+# carrying a strong verb and was left exactly as it was.
+ACTION_VERB_PATTERN = re.compile(
+    r"\b(?:" + "|".join(re.escape(verb) for verb in ACTION_VERBS) + r")\b",
+    re.IGNORECASE,
+)
+
+# `.title()` is wrong for most technical skills: it produced "Javascript",
+# "Ios", "Node.Js", "Postgresql" and "Rest Api". These go straight onto a
+# profile whose skill matching is string-based, so the spelling matters.
+#
+# Keyed on the lowercased skill. Anything not listed falls through to the
+# rules in `_canonical_skill` below.
+SKILL_DISPLAY_CASING = {
+    "javascript": "JavaScript",
+    "typescript": "TypeScript",
+    "nodejs": "Node.js",
+    "node.js": "Node.js",
+    "node js": "Node.js",
+    "react.js": "React.js",
+    "next.js": "Next.js",
+    "vue.js": "Vue.js",
+    "jquery": "jQuery",
+    "html": "HTML",
+    "css": "CSS",
+    "scss": "SCSS",
+    "sass": "Sass",
+    "sql": "SQL",
+    "nosql": "NoSQL",
+    "mysql": "MySQL",
+    "postgresql": "PostgreSQL",
+    "postgres": "PostgreSQL",
+    "sqlite": "SQLite",
+    "mongodb": "MongoDB",
+    "graphql": "GraphQL",
+    "rest api": "REST API",
+    "restful api": "RESTful API",
+    "grpc": "gRPC",
+    "api": "API",
+    "ios": "iOS",
+    "macos": "macOS",
+    "android": "Android",
+    "aws": "AWS",
+    "gcp": "GCP",
+    "ci/cd": "CI/CD",
+    "cicd": "CI/CD",
+    "devops": "DevOps",
+    "mlops": "MLOps",
+    "github": "GitHub",
+    "gitlab": "GitLab",
+    "php": "PHP",
+    "asp.net": "ASP.NET",
+    ".net": ".NET",
+    "dotnet": ".NET",
+    "c#": "C#",
+    "c++": "C++",
+    "objective-c": "Objective-C",
+    "pytorch": "PyTorch",
+    "tensorflow": "TensorFlow",
+    "numpy": "NumPy",
+    "scipy": "SciPy",
+    "pandas": "pandas",
+    "scikit-learn": "scikit-learn",
+    "matlab": "MATLAB",
+    "json": "JSON",
+    "xml": "XML",
+    "yaml": "YAML",
+    "saas": "SaaS",
+    "ux": "UX",
+    "ui": "UI",
+    "ui/ux": "UI/UX",
+    "seo": "SEO",
+    "etl": "ETL",
+    "jwt": "JWT",
+    "oauth": "OAuth",
+    "openai": "OpenAI",
+    "nlp": "NLP",
+    "llm": "LLM",
+}
+
+# The closing clause of a generated headline, kept as a name so the pieces of
+# `optimize_headline` read as a list of segments.
+HEADLINE_TAGLINE = "Driving Innovation and Measurable Results"
+
 
 def clean_and_format_text(text: str) -> str:
     """
@@ -63,11 +165,73 @@ def clean_and_format_text(text: str) -> str:
     if not text or not isinstance(text, str):
         return ""
 
-    # Replace multiple spaces with a single space
-    text = re.sub(r"\s+", " ", text)
-    # Replace multiple newlines with a double newline for paragraph breaks
-    text = re.sub(r"\n\s*\n", "\n\n", text)
+    # Order matters, and used to be the wrong way round. `\s` includes
+    # newlines, so collapsing on `\s+` first flattened every paragraph break
+    # into a space and left the second substitution with nothing to match —
+    # it could never fire. The About section came back as one wall of text,
+    # and the "\n\nCore Competencies:" block appended below was glued onto
+    # the end of the preceding sentence.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+
+    # Horizontal whitespace only: `[^\S\n]` is "whitespace that is not a
+    # newline", which is the set `\s+` was too broad for.
+    text = re.sub(r"[^\S\n]+", " ", text)
+
+    # Trim the spaces that sat either side of a line break.
+    text = re.sub(r" *\n *", "\n", text)
+
+    # Any run of blank lines becomes exactly one paragraph break.
+    text = re.sub(r"\n{2,}", "\n\n", text)
+
     return text.strip()
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Cut `text` to `limit` characters, ending on a word where possible.
+
+    LinkedIn rejects anything over the limit outright, so the cut has to
+    happen — but slicing blind left profiles ending mid-word ("...Kubernet...").
+    Backs off to the last space when one is reasonably close to the end;
+    falls back to the blind cut when there is no space to back off to, which
+    keeps the result exactly `limit` characters for unbroken input.
+    """
+    if len(text) <= limit:
+        return text
+
+    cut = text[: limit - 3]
+    boundary = cut.rfind(" ")
+    # Only worth backing off if it does not throw away most of the text.
+    if boundary > limit * 0.6:
+        cut = cut[:boundary]
+
+    return cut.rstrip(" |,;:-") + "..."
+
+
+def _canonical_skill(skill: str) -> str:
+    """Return `skill` spelled the way the thing is actually spelled.
+
+    Three rules, in order:
+
+    1. A known technical skill takes its canonical casing from
+       ``SKILL_DISPLAY_CASING``.
+    2. A skill that already carries a capital past its first character is
+       left alone — "iOS", "PostgreSQL" and "GraphQL" are deliberate, and
+       ``.title()`` destroys all three.
+    3. Everything else is title-cased, which is what plain lowercase input
+       ("django", "project management") wants.
+    """
+    cleaned = clean_and_format_text(skill).replace("\n", " ").strip()
+    if not cleaned:
+        return ""
+
+    canonical = SKILL_DISPLAY_CASING.get(cleaned.lower())
+    if canonical:
+        return canonical
+
+    if any(char.isupper() for char in cleaned[1:]):
+        return cleaned
+
+    return cleaned.title()
 
 
 def optimize_headline(
@@ -75,6 +239,11 @@ def optimize_headline(
 ) -> str:
     """
     Optimizes the LinkedIn headline to be impactful and within character limits.
+
+    `current_headline` was declared, documented and never read: whatever the
+    user had written was discarded and everyone got the same template. It
+    leads the result now, because it is the only part of a headline that says
+    something specific about this person.
 
     Args:
         current_headline (str): The existing or extracted headline.
@@ -84,21 +253,36 @@ def optimize_headline(
     Returns:
         str: The optimized headline.
     """
-    if not target_role:
-        target_role = "Professional"
+    target_role = (target_role or "").strip() or "Professional"
 
-    skills_str = " | ".join(top_skills[:3]) if top_skills else ""
+    current = clean_and_format_text(current_headline).replace("\n", " ").strip()
 
-    # Construct a strong, keyword-rich headline
-    optimized = (
-        f"{target_role} | {skills_str} | Driving Innovation and Measurable Results"
-    )
+    segments = []
+    if current:
+        segments.append(current)
+    # The role is only worth its own segment if the headline does not already
+    # say it — otherwise "Software Engineer | Software Engineer | ...".
+    if target_role.lower() not in " | ".join(segments).lower():
+        segments.append(target_role)
 
-    # Enforce character limit strictly
-    if len(optimized) > LINKEDIN_LIMITS["headline"]:
-        optimized = optimized[: LINKEDIN_LIMITS["headline"] - 3] + "..."
+    skills = [_canonical_skill(skill) for skill in (top_skills or [])[:3]]
+    skills_str = " | ".join(skill for skill in skills if skill)
+    if skills_str:
+        segments.append(skills_str)
 
-    return optimized
+    segments.append(HEADLINE_TAGLINE)
+
+    return _truncate(" | ".join(segments), LINKEDIN_LIMITS["headline"])
+
+
+def _replace_weak_phrase(match: "re.Match") -> str:
+    """Swap a weak phrase for "spearheaded", keeping the sentence's casing.
+
+    The replacement was always lowercase, so a sentence opening on "Responsible
+    for ..." came back opening on "spearheaded ...".
+    """
+    replacement = "spearheaded"
+    return replacement.capitalize() if match.group(0)[0].isupper() else replacement
 
 
 def optimize_about_section(
@@ -118,26 +302,24 @@ def optimize_about_section(
     if not about_text:
         about_text = f"Results-driven {target_role} with a proven track record of delivering high-impact solutions."
 
-    optimized_text = about_text
+    optimized_text = WEAK_PHRASE_PATTERN.sub(_replace_weak_phrase, about_text)
 
-    # Replace weak phrases with strong action verbs
-    for phrase in WEAK_PHRASES:
-        optimized_text = re.sub(
-            rf"\b{phrase}\b", "spearheaded", optimized_text, flags=re.IGNORECASE
-        )
-
-    # Ensure top skills are mentioned naturally at the end if not already present
-    skills_str = ", ".join(top_skills[:5])
-    if skills_str and skills_str.lower() not in optimized_text.lower():
-        optimized_text += f"\n\nCore Competencies: {skills_str}."
+    # Mention any of the top skills the text does not already name. The old
+    # check tested for the whole comma-joined string in one go, which is
+    # essentially never present, so the block was appended unconditionally —
+    # including skills the sentence above had just listed.
+    lowered = optimized_text.lower()
+    unmentioned = [
+        canonical
+        for canonical in (_canonical_skill(skill) for skill in (top_skills or [])[:5])
+        if canonical and canonical.lower() not in lowered
+    ]
+    if unmentioned:
+        optimized_text += f"\n\nCore Competencies: {', '.join(unmentioned)}."
 
     optimized_text = clean_and_format_text(optimized_text)
 
-    # Enforce character limit
-    if len(optimized_text) > LINKEDIN_LIMITS["about"]:
-        optimized_text = optimized_text[: LINKEDIN_LIMITS["about"] - 3] + "..."
-
-    return optimized_text
+    return _truncate(optimized_text, LINKEDIN_LIMITS["about"])
 
 
 def optimize_experience(experiences: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -152,33 +334,33 @@ def optimize_experience(experiences: List[Dict[str, Any]]) -> List[Dict[str, Any
     """
     optimized_experiences = []
 
-    for exp in experiences:
-        title = exp.get("title", "Professional")
-        company = exp.get("company", "Company")
-        description = exp.get("description", "")
+    for exp in experiences or []:
+        title = exp.get("title") or "Professional"
+        company = exp.get("company") or "Company"
 
-        # Enhance description with action verbs if it's too passive
-        if description and not any(
-            verb.lower() in description.lower() for verb in ACTION_VERBS
-        ):
+        # Held separately. `description` used to be reassigned by the
+        # enhancement below and then handed back as "original_description",
+        # so the field whose whole purpose is a before/after comparison
+        # returned the "after".
+        original_description = exp.get("description") or ""
+
+        description = original_description
+        if description and not ACTION_VERB_PATTERN.search(description):
             description = (
                 f"Spearheaded key initiatives as {title} at {company}. {description}"
             )
 
-        optimized_desc = clean_and_format_text(description)
-
-        # Enforce character limit for experience description
-        if len(optimized_desc) > LINKEDIN_LIMITS["experience_description"]:
-            optimized_desc = (
-                optimized_desc[: LINKEDIN_LIMITS["experience_description"] - 3] + "..."
-            )
+        optimized_desc = _truncate(
+            clean_and_format_text(description),
+            LINKEDIN_LIMITS["experience_description"],
+        )
 
         optimized_experiences.append(
             {
                 "title": title,
                 "company": company,
                 "description": optimized_desc,
-                "original_description": description,
+                "original_description": original_description,
             }
         )
 
@@ -195,16 +377,25 @@ def optimize_skills(skills: List[str]) -> List[str]:
     Returns:
         List[str]: A deduplicated and formatted list of skills, max 50.
     """
-    # Deduplicate and clean
-    cleaned_skills = list(
-        set([clean_and_format_text(skill).title() for skill in skills if skill])
-    )
+    # `dict` rather than `set`: insertion order is the caller's relevance
+    # order, and the cut below depends on it. Keyed on the lowercased form so
+    # "python" and "Python" collapse to one entry.
+    seen: Dict[str, str] = {}
+    for skill in skills or []:
+        if not skill or not isinstance(skill, str):
+            continue
+        canonical = _canonical_skill(skill)
+        if canonical:
+            seen.setdefault(canonical.lower(), canonical)
 
-    # Sort alphabetically for consistency
-    cleaned_skills.sort()
+    # Cut *before* sorting. Sorting first and truncating after threw away the
+    # caller's ordering, so a profile with more than 50 skills kept the
+    # alphabetically first 50 rather than the 50 most relevant — everything
+    # from roughly "R" onward was dropped regardless of how central it was.
+    kept = list(seen.values())[: LINKEDIN_LIMITS["skills"]]
 
-    # Enforce limit
-    return cleaned_skills[: LINKEDIN_LIMITS["skills"]]
+    # Alphabetical for display, once the selection is settled.
+    return sorted(kept)
 
 
 def generate_linkedin_profile(resume_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/analyzer/tests_linkedin_optimizer.py
+++ b/backend/analyzer/tests_linkedin_optimizer.py
@@ -129,3 +129,209 @@ class LinkedInOptimizerTests(TestCase):
         self.assertIn("Data Scientist", result["headline"])
         self.assertIn("spearheaded", result["about"].lower())
         self.assertEqual(len(result["skills"]), 3)  # Deduplicated
+
+
+class CleanAndFormatTextTests(TestCase):
+    """`\s` includes newlines, and the two substitutions ran in the wrong order.
+
+    Collapsing on `\s+` first flattened every paragraph break into a space,
+    which left the paragraph-normalising rule underneath it with nothing to
+    match — it could never fire, for any input.
+    """
+
+    def test_paragraph_breaks_survive(self):
+        self.assertEqual(
+            clean_and_format_text("Para one.\n\n\nPara two.\n   \n\nPara three."),
+            "Para one.\n\nPara two.\n\nPara three.",
+        )
+
+    def test_a_single_newline_is_not_promoted_to_a_paragraph_break(self):
+        self.assertEqual(
+            clean_and_format_text("Line one.\nLine two."), "Line one.\nLine two."
+        )
+
+    def test_horizontal_whitespace_still_collapses(self):
+        self.assertEqual(clean_and_format_text("a \t  b"), "a b")
+
+    def test_carriage_returns_are_normalised(self):
+        self.assertEqual(
+            clean_and_format_text("Para one.\r\n\r\nPara two."),
+            "Para one.\n\nPara two.",
+        )
+
+    def test_spaces_around_a_break_are_trimmed(self):
+        self.assertEqual(
+            clean_and_format_text("Para one.   \n\n   Para two."),
+            "Para one.\n\nPara two.",
+        )
+
+    def test_the_core_competencies_block_keeps_its_own_paragraph(self):
+        """The end-to-end version of the bug.
+
+        `optimize_about_section` appends "\n\nCore Competencies: ..." and then
+        calls `clean_and_format_text`, so the flattening landed on the block
+        it had just added.
+        """
+        about = optimize_about_section("A summary sentence.", "Engineer", ["Python"])
+        self.assertIn("\n\nCore Competencies: Python.", about)
+
+
+class SkillCasingTests(TestCase):
+    """`.title()` produced "Javascript", "Ios", "Node.Js" and "Postgresql".
+
+    These are copied onto a profile whose skill matching is string-based, so
+    a mis-spelled skill is a skill that does not match.
+    """
+
+    def test_known_technical_skills_keep_their_real_spelling(self):
+        optimized = optimize_skills(
+            ["javascript", "ios", "node.js", "rest api", "postgresql", "graphql"]
+        )
+        self.assertEqual(
+            optimized,
+            ["GraphQL", "JavaScript", "Node.js", "PostgreSQL", "REST API", "iOS"],
+        )
+
+    def test_deliberate_internal_capitals_are_left_alone(self):
+        """A skill that already carries a capital past its first character
+        is spelled that way on purpose."""
+        self.assertEqual(optimize_skills(["SQL", "PyTorch", "iOS"]), ["PyTorch", "SQL", "iOS"])
+
+    def test_plain_lowercase_input_is_still_title_cased(self):
+        self.assertEqual(
+            optimize_skills(["project management", "django"]),
+            ["Django", "Project Management"],
+        )
+
+    def test_symbols_survive(self):
+        self.assertEqual(optimize_skills(["c++", "c#", ".net"]), [".NET", "C#", "C++"])
+
+    def test_deduplication_is_case_insensitive(self):
+        self.assertEqual(optimize_skills(["python", "PYTHON", "Python"]), ["Python"])
+
+    def test_blank_and_non_string_entries_are_dropped(self):
+        self.assertEqual(optimize_skills(["python", "", "   ", None, 7]), ["Python"])
+
+
+class SkillTruncationTests(TestCase):
+    """Sorting ran before the 50-skill cut, so the cut fell alphabetically."""
+
+    def test_the_cut_falls_on_relevance_not_the_alphabet(self):
+        # 51 skills, the most relevant one last in the alphabet.
+        skills = ["Zebra Handling"] + [f"Skill{i:02d}" for i in range(50)]
+        optimized = optimize_skills(skills)
+
+        self.assertEqual(len(optimized), LINKEDIN_LIMITS["skills"])
+        self.assertIn(
+            "Zebra Handling",
+            optimized,
+            "The caller's first skill was dropped because it sorts last.",
+        )
+        self.assertNotIn("Skill49", optimized)
+
+    def test_the_result_is_still_sorted_for_display(self):
+        optimized = optimize_skills([f"Skill{i:02d}" for i in range(60)])
+        self.assertEqual(optimized, sorted(optimized))
+
+
+class HeadlineTests(TestCase):
+    """`current_headline` was declared, documented, and never read."""
+
+    def test_the_users_own_headline_leads_the_result(self):
+        headline = optimize_headline(
+            "Backend Engineer @ Acme | Payments infrastructure",
+            "Software Engineer",
+            ["python"],
+        )
+        self.assertTrue(
+            headline.startswith("Backend Engineer @ Acme | Payments infrastructure"),
+            headline,
+        )
+
+    def test_the_role_is_not_repeated_when_the_headline_already_says_it(self):
+        headline = optimize_headline("Software Engineer", "Software Engineer", [])
+        self.assertEqual(headline.lower().count("software engineer"), 1)
+
+    def test_an_empty_headline_falls_back_to_the_role(self):
+        self.assertTrue(optimize_headline("", "Data Scientist", []).startswith("Data Scientist"))
+
+    def test_a_missing_role_falls_back_to_professional(self):
+        self.assertIn("Professional", optimize_headline("", "", []))
+
+    def test_headline_skills_are_canonically_cased(self):
+        self.assertIn("iOS", optimize_headline("", "Engineer", ["ios"]))
+
+    def test_truncation_does_not_cut_mid_word(self):
+        headline = optimize_headline(
+            "", "Senior Distributed Systems Reliability Engineer " * 8, []
+        )
+        self.assertLessEqual(len(headline), LINKEDIN_LIMITS["headline"])
+        self.assertTrue(headline.endswith("..."))
+        self.assertFalse(headline[:-3].endswith(" "))
+
+
+class WeakPhraseReplacementTests(TestCase):
+    """Replacing a weak phrase must not leave the sentence passive."""
+
+    def test_a_leading_auxiliary_goes_with_the_phrase(self):
+        optimized = optimize_about_section(
+            "I was responsible for the rollout.", "Manager", []
+        )
+        self.assertIn("I spearheaded the rollout.", optimized)
+        self.assertNotIn("was spearheaded", optimized)
+
+    def test_sentence_case_is_preserved(self):
+        optimized = optimize_about_section("Responsible for hiring.", "Manager", [])
+        self.assertTrue(optimized.startswith("Spearheaded hiring."), optimized)
+
+    def test_skills_already_named_are_not_appended_again(self):
+        optimized = optimize_about_section(
+            "Ten years of Python and SQL work.", "Engineer", ["python", "sql", "aws"]
+        )
+        self.assertIn("Core Competencies: AWS.", optimized)
+        self.assertEqual(optimized.lower().count("python"), 1)
+
+
+class ActionVerbDetectionTests(TestCase):
+    """`"Led" in description` is a substring test, and "led" is inside
+    "handled", "fulfilled", "called", "scheduled" and "modelled"."""
+
+    def test_a_weak_description_is_not_mistaken_for_a_strong_one(self):
+        optimized = optimize_experience(
+            [
+                {
+                    "title": "Support Lead",
+                    "company": "Acme",
+                    "description": "Handled customer escalations and fulfilled orders.",
+                }
+            ]
+        )
+        self.assertTrue(optimized[0]["description"].startswith("Spearheaded"))
+
+    def test_a_genuinely_strong_description_is_left_alone(self):
+        description = "Led the migration to Kubernetes."
+        optimized = optimize_experience(
+            [{"title": "SRE", "company": "Acme", "description": description}]
+        )
+        self.assertEqual(optimized[0]["description"], description)
+
+    def test_original_description_is_the_original(self):
+        """The field exists for a before/after comparison and returned the
+        "after", because `description` was reassigned before it was read."""
+        original = "worked on the backend api."
+        optimized = optimize_experience(
+            [{"title": "Dev", "company": "Acme", "description": original}]
+        )
+        self.assertEqual(optimized[0]["original_description"], original)
+        self.assertNotEqual(
+            optimized[0]["original_description"], optimized[0]["description"]
+        )
+
+    def test_missing_keys_do_not_raise(self):
+        optimized = optimize_experience([{}])
+        self.assertEqual(optimized[0]["title"], "Professional")
+        self.assertEqual(optimized[0]["company"], "Company")
+        self.assertEqual(optimized[0]["original_description"], "")
+
+    def test_none_experiences_is_treated_as_empty(self):
+        self.assertEqual(optimize_experience(None), [])


### PR DESCRIPTION
## 📝 Description

`analyzer/linkedin_optimizer.py` had five separate defects. Two of them are caught by the module's own test file — `test_clean_and_format_text_normalization` and `test_optimize_experience_enhancement` have been red since the feature merged, behind #935.

## 🔗 Related Issue

Closes #937

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## 🔍 What changed

### 1. Every paragraph break was destroyed

```python
text = re.sub(r"\s+", " ", text)        # \s includes \n
text = re.sub(r"\n\s*\n", "\n\n", text) # nothing left to match — dead line
```

`\s` covers newlines, so the first rule flattened them and the second could never fire, for any input. Now: normalise line endings, collapse **horizontal** whitespace only (`[^\S\n]+`), trim around breaks, fold blank runs into one break.

```python
>>> clean_and_format_text("This   is  a   test.\n\n\nWith   multiple  spaces.")
'This is a test.\n\nWith multiple spaces.'     # was 'This is a test. With multiple spaces.'
```

This also fixes the `\n\nCore Competencies: …` block, which `optimize_about_section` appends and then immediately flattens by calling `clean_and_format_text`.

### 2. `original_description` returned the "after"

`description` was reassigned by the enhancement above it, then handed back under the name whose entire purpose is a before/after comparison. Held in its own variable now.

### 3. `.title()` mis-spelled technical skills

```python
>>> optimize_skills(["javascript","ios","node.js","rest api","postgresql","graphql"])
['GraphQL','JavaScript','Node.js','PostgreSQL','REST API','iOS']
#  was:  ['Graphql','Ios','Node.Js','Postgresql','Rest Api','Javascript']
```

Three rules, in order:
1. A known technical skill takes its canonical casing from a table.
2. A skill already carrying a capital past its first character is left alone — `iOS`, `PostgreSQL`, `SQL`, `PyTorch` are deliberate and `.title()` destroys all four.
3. Everything else is title-cased, which is what plain lowercase input (`django`, `project management`) wants.

### 4. The cut fell alphabetically, not on relevance

```python
cleaned_skills.sort()
return cleaned_skills[:50]      # keeps A–R, drops the rest
```

The argument is `top_skills` — an ordered list. Sorting first threw that ordering away, so a profile with more than 50 skills kept the alphabetically first 50. Cut first on the caller's order, sort after for display, so `optimize_skills(...) == sorted(...)` still holds.

### 5. `current_headline` was never read

Declared, documented as "the existing or extracted headline", and ignored — everyone got the same template ending in "Driving Innovation and Measurable Results". It leads the result now, and the target role is only added as its own segment when the headline does not already say it (no more "Software Engineer | Software Engineer | …").

### Four smaller ones in the same pass

- **The action-verb check was a substring test.** `"led"` is inside *handled*, *fulfilled*, *called*, *scheduled*, *modelled* — so `"Handled customer escalations and fulfilled orders"` counted as already strong and was left exactly as it was. Whole-word regex now.
- **Weak-phrase replacement produced passive voice.** *"I was responsible for the rollout"* → *"I was spearheaded the rollout"*. A leading auxiliary is now replaced along with the phrase: *"I spearheaded the rollout"*. The replacement also keeps the sentence's capitalisation instead of always being lowercase.
- **The "Core Competencies" guard never fired.** It tested for the whole comma-joined skills string in one go, which is essentially never present, so the block was appended unconditionally — including skills the summary had just named. Filtered per skill.
- **Truncation cut mid-word.** Backs off to a word boundary when one is close enough, falling back to the blind cut when there is no space to back off to (which keeps the exact-length behaviour the existing truncation tests pin).

## 🧪 How Has This Been Tested?

- [x] Backend tests pass (`python manage.py test analyzer`)

```
Ran 848 tests   (was 820)
```

All 10 pre-existing `tests_linkedin_optimizer` tests pass unchanged — no assertion in that file was edited. 28 new tests added, grouped one class per defect: `CleanAndFormatTextTests`, `SkillCasingTests`, `SkillTruncationTests`, `HeadlineTests`, `WeakPhraseReplacementTests`, `ActionVerbDetectionTests`.

## 📌 Note

Verified on top of #940, which this needs in order to run at all.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
