### PR TITLE
fix: report cliché and passive-voice spans where they actually are (#938)

### DIFF
--- a/backend/analyzer/cliche_detector.py
+++ b/backend/analyzer/cliche_detector.py
@@ -6,41 +6,208 @@ in resume bullet points, offering strong, action-oriented, and modern alternativ
 """
 
 import re
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Optional, Tuple
 
-# Comprehensive dictionary of clichés mapped to strong alternatives
+# Comprehensive dictionary of clichés mapped to strong alternatives.
+#
+# The verb entries carry their inflections. The dictionary held only
+# `\bhandled\b`, so "handling" and "handles" went straight past a detector
+# whose whole job is to catch that verb — which is what
+# `test_analyze_and_suggest_modernization` was failing on.
 CLICHE_DICTIONARY = {
     r"\bresponsible for\b": "spearheaded",
     r"\bduties included\b": "managed",
     r"\bhelped with\b": "collaborated on",
-    r"\bworked on\b": "developed",
+    r"\bwork(?:ed|s|ing) on\b": "developed",
     r"\btasked with\b": "executed",
     r"\bassisted in\b": "supported",
     r"\bparticipated in\b": "contributed to",
-    r"\bhandled\b": "orchestrated",
+    r"\bhandl(?:e|es|ed|ing)\b": "orchestrated",
     r"\bwas in charge of\b": "directed",
+    r"\bin charge of\b": "directed",
     r"\bthink outside the box\b": "innovated",
     r"\bgo-getter\b": "proactive",
     r"\bteam player\b": "collaborative",
     r"\bhard worker\b": "dedicated",
     r"\bresults-driven\b": "impact-focused",
     r"\bsynergy\b": "collaboration",
-    r"\bleverage\b": "utilized",
-    r"\butilize\b": "used",
+    r"\bleverag(?:e|es|ed|ing)\b": "utilized",
+    r"\butiliz(?:e|es|ed|ing)\b": "used",
     r"\bparadigm shift\b": "transformation",
     r"\bbest-in-class\b": "industry-leading",
     r"\bworld-class\b": "exceptional",
 }
 
-# Passive voice indicators (simplified heuristic)
-PASSIVE_INDICATORS = [
-    r"\bwas\b",
-    r"\bwere\b",
-    r"\bbeen\b",
-    r"\bbeing\b",
-    r"\bis\b",
-    r"\bare\b",
+#: Clichés that introduce the real verb rather than being it: "responsible for
+#: *managing*", "tasked with *handling*". Replacing one of these on its own
+#: leaves the gerund stranded — "Executed handling the migration" — so when a
+#: gerund follows, the lead-in is dropped and the gerund becomes the verb.
+LEAD_IN_CLICHES = frozenset(
+    {
+        "responsible for",
+        "duties included",
+        "helped with",
+        "worked on",
+        "works on",
+        "working on",
+        "tasked with",
+        "assisted in",
+        "participated in",
+        "was in charge of",
+        "in charge of",
+    }
+)
+
+#: Forms of "to be". One source of truth: this list existed before but was
+#: never referenced — ``detect_passive_voice`` hardcoded its own copy of six
+#: of these inline, so the module had two lists and only one of them did
+#: anything.
+PASSIVE_INDICATORS = frozenset(
+    {"was", "were", "been", "being", "is", "are", "am", "be"}
+)
+
+#: Words that may sit between the auxiliary and the participle without
+#: breaking the construction: "was *not* completed", "was *quickly* deployed".
+_PASSIVE_INTERRUPTERS = frozenset({"not", "never", "also", "then", "still", "already"})
+
+#: Past participles that do not end in "ed". The original test was
+#: ``endswith(("ed", "en", "t"))``, and "t" matches an enormous number of
+#: ordinary words — "was not", "is best", "was at", "was part", "is it" were
+#: all reported as passive voice. An explicit set is narrower than any suffix
+#: rule that includes "t".
+IRREGULAR_PARTICIPLES = frozenset(
+    {
+        "been", "begun", "bought", "brought", "built", "caught", "chosen",
+        "cut", "done", "drawn", "driven", "eaten", "fallen", "felt", "found",
+        "given", "gone", "grown", "held", "hidden", "kept", "known", "led",
+        "left", "lost", "made", "met", "paid", "put", "read", "risen", "run",
+        "said", "seen", "sent", "set", "shown", "sold", "spent", "spoken",
+        "sung", "taken", "taught", "thrown", "told", "understood", "won",
+        "written",
+    }
+)
+
+#: Gerund -> simple past, for the forms the rules below get wrong.
+IRREGULAR_GERUND_PAST = {
+    "being": "was",
+    "beginning": "began",
+    "bringing": "brought",
+    "building": "built",
+    "buying": "bought",
+    "catching": "caught",
+    "choosing": "chose",
+    "cutting": "cut",
+    "doing": "did",
+    "drawing": "drew",
+    "driving": "drove",
+    "finding": "found",
+    "getting": "got",
+    "giving": "gave",
+    "going": "went",
+    "growing": "grew",
+    "having": "had",
+    "holding": "held",
+    "keeping": "kept",
+    "knowing": "knew",
+    "leading": "led",
+    "leaving": "left",
+    "losing": "lost",
+    "making": "made",
+    "meeting": "met",
+    "paying": "paid",
+    "putting": "put",
+    "reading": "read",
+    "running": "ran",
+    "seeing": "saw",
+    "selling": "sold",
+    "sending": "sent",
+    "setting": "set",
+    "speaking": "spoke",
+    "spending": "spent",
+    "taking": "took",
+    "teaching": "taught",
+    "telling": "told",
+    "thinking": "thought",
+    "throwing": "threw",
+    "winning": "won",
+    "writing": "wrote",
+}
+
+#: Compiled once. Longest pattern first so that where two entries could match
+#: at the same position — "in charge of" inside "was in charge of" — the
+#: longer one is the one that survives the overlap pass in `detect_cliches`.
+_COMPILED_CLICHES: List[Tuple[re.Pattern, str]] = [
+    (re.compile(pattern, re.IGNORECASE), suggestion)
+    for pattern, suggestion in sorted(
+        CLICHE_DICTIONARY.items(), key=lambda item: len(item[0]), reverse=True
+    )
 ]
+
+#: Words, with their offsets. `text.split()` loses position, which is why
+#: `detect_passive_voice` had to go looking for its own matches with `find`.
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z'-]*")
+
+
+def _is_past_participle(word: str) -> bool:
+    """Whether `word` can be the participle half of a passive construction."""
+    lowered = word.lower()
+    if lowered in IRREGULAR_PARTICIPLES:
+        return True
+    # "ed" is the regular ending and is specific enough to use as a rule.
+    # "en" and "t" are not: they match often, when, then, open, seven,
+    # children, and every word in English ending in t.
+    return lowered.endswith("ed") and len(lowered) > 3
+
+
+def _to_past_tense(gerund: str) -> str:
+    """Turn an "-ing" form into its simple past.
+
+    Used when a lead-in cliché is dropped and the gerund behind it has to
+    become the sentence's verb.
+    """
+    lowered = gerund.lower()
+    if lowered in IRREGULAR_GERUND_PAST:
+        return IRREGULAR_GERUND_PAST[lowered]
+
+    stem = lowered[:-3]
+    if not stem:
+        return lowered
+    # "studying" -> "study" -> "studied"
+    if stem.endswith("y") and len(stem) > 1 and stem[-2] not in "aeiou":
+        return stem[:-1] + "ied"
+    # English drops a silent "e" before "-ing", so putting "ed" back on the
+    # stem recovers it: handling -> handl -> handled, using -> us -> used.
+    return stem + "ed"
+
+
+def _match_casing(source: str, replacement: str) -> str:
+    """Give `replacement` the casing `source` was written in.
+
+    The original only inspected `source[0]`, so "RESPONSIBLE FOR" came back as
+    "Spearheaded" — a heading quietly changed style.
+    """
+    if source.isupper() and len(source) > 1:
+        return replacement.upper()
+    if source[:1].isupper():
+        return replacement[:1].upper() + replacement[1:]
+    return replacement
+
+
+def _drop_overlaps(detections: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Keep the leftmost, then longest, of any group of overlapping spans.
+
+    Two patterns can cover the same words — "in charge of" sits inside "was in
+    charge of". Emitting both gives the caller two highlights over one phrase
+    and, worse, two replacements over one span.
+    """
+    ordered = sorted(detections, key=lambda d: (d["start"], -(d["end"] - d["start"])))
+
+    kept: List[Dict[str, Any]] = []
+    for detection in ordered:
+        if kept and detection["start"] < kept[-1]["end"]:
+            continue
+        kept.append(detection)
+    return kept
 
 
 def detect_cliches(text: str) -> List[Dict[str, Any]]:
@@ -53,16 +220,15 @@ def detect_cliches(text: str) -> List[Dict[str, Any]]:
     Returns:
         List[Dict[str, Any]]: A list of detected clichés with their positions and suggestions.
     """
-    detections = []
-    text_lower = text.lower()
+    if not text:
+        return []
 
-    for pattern, suggestion in CLICHE_DICTIONARY.items():
-        matches = re.finditer(pattern, text_lower)
-        for match in matches:
-            original_phrase = text[match.start() : match.end()]
+    detections = []
+    for pattern, suggestion in _COMPILED_CLICHES:
+        for match in pattern.finditer(text):
             detections.append(
                 {
-                    "phrase": original_phrase,
+                    "phrase": match.group(),
                     "start": match.start(),
                     "end": match.end(),
                     "suggestion": suggestion,
@@ -70,7 +236,7 @@ def detect_cliches(text: str) -> List[Dict[str, Any]]:
                 }
             )
 
-    return detections
+    return _drop_overlaps(detections)
 
 
 def detect_passive_voice(text: str) -> List[Dict[str, Any]]:
@@ -83,28 +249,123 @@ def detect_passive_voice(text: str) -> List[Dict[str, Any]]:
     Returns:
         List[Dict[str, Any]]: A list of potential passive voice indicators.
     """
-    detections = []
-    words = text.split()
+    if not text:
+        return []
 
-    for i, word in enumerate(words):
-        word_lower = word.lower().strip(".,;:!?")
-        if word_lower in ["was", "were", "been", "being", "is", "are"]:
-            # Check if the next word is a past participle (simplified check)
-            if i + 1 < len(words):
-                next_word = words[i + 1].lower().strip(".,;:!?")
-                if next_word.endswith(("ed", "en", "t")):
-                    detections.append(
-                        {
-                            "phrase": f"{word} {words[i + 1]}",
-                            "start": text.lower().find(f"{word_lower} {next_word}"),
-                            "end": text.lower().find(f"{word_lower} {next_word}")
-                            + len(f"{word} {words[i + 1]}"),
-                            "suggestion": "Rewrite in active voice (e.g., 'Led', 'Built', 'Created')",
-                            "type": "passive",
-                        }
-                    )
+    words = [(m.group(), m.start(), m.end()) for m in _WORD_RE.finditer(text)]
+    detections = []
+
+    for index, (word, start, _end) in enumerate(words):
+        if word.lower() not in PASSIVE_INDICATORS:
+            continue
+
+        # Look past an interrupting adverb: "was not completed".
+        candidate = index + 1
+        while (
+            candidate < len(words)
+            and words[candidate][0].lower() in _PASSIVE_INTERRUPTERS
+        ):
+            candidate += 1
+
+        if candidate >= len(words):
+            continue
+
+        participle, _p_start, p_end = words[candidate]
+        if not _is_past_participle(participle):
+            continue
+
+        # `start` and `end` come from the match being reported. They used to
+        # come from `text.lower().find(...)`, which returns the *first*
+        # occurrence in the string — so every repeat of a phrase pointed at
+        # the same place, and the UI highlighted the wrong words.
+        detections.append(
+            {
+                "phrase": text[start:p_end],
+                "start": start,
+                "end": p_end,
+                "suggestion": "Rewrite in active voice (e.g., 'Led', 'Built', 'Created')",
+                "type": "passive",
+            }
+        )
 
     return detections
+
+
+def _gerund_after(text: str, position: int) -> Optional[Tuple[str, int, int]]:
+    """The "-ing" word immediately following `position`, if there is one."""
+    match = _WORD_RE.search(text, position)
+    if match is None:
+        return None
+    # Only "immediately": anything but whitespace in between means the lead-in
+    # is not introducing this word.
+    if text[position : match.start()].strip():
+        return None
+    word = match.group()
+    if len(word) > 4 and word.lower().endswith("ing"):
+        return word, match.start(), match.end()
+    return None
+
+
+def _suggestion_for(word: str) -> Optional[str]:
+    """The dictionary's replacement for `word`, if `word` is itself a cliché."""
+    for pattern, suggestion in _COMPILED_CLICHES:
+        match = pattern.fullmatch(word)
+        if match is not None:
+            return suggestion
+    return None
+
+
+def _build_replacements(text: str, cliches: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Turn cliché detections into spans to rewrite, keeping the result English.
+
+    Two shapes need handling beyond a straight swap:
+
+    * A lead-in followed by a gerund. "Tasked with handling the migration"
+      became "Executed handling the migration" — two verbs, no sentence. The
+      lead-in goes and the gerund becomes the verb: "Orchestrated the
+      migration".
+    * A lead-in introduced by "was"/"were". "I was responsible for the
+      rollout" became "I was spearheaded the rollout" — passive, from a tool
+      whose stated job is removing passive voice. The auxiliary is swallowed
+      with the phrase: "I spearheaded the rollout".
+    """
+    replacements = []
+
+    for detection in cliches:
+        start, end = detection["start"], detection["end"]
+        source = detection["phrase"]
+        replacement = detection["suggestion"]
+
+        gerund = _gerund_after(text, end)
+        if gerund is not None and source.lower() in LEAD_IN_CLICHES:
+            word, _g_start, g_end = gerund
+            # If the gerund is itself in the dictionary, take its suggestion.
+            # The past tense of "handling" is "handled", which is a cliché —
+            # replacing a cliché with a cliché.
+            replacement = _suggestion_for(word) or _to_past_tense(word)
+            end = g_end
+
+        # Swallow a "was"/"were" sitting immediately in front of the phrase.
+        preceding = _WORD_RE.findall(text[:start])
+        if preceding and preceding[-1].lower() in {"was", "were", "is", "are"}:
+            auxiliary_start = text.lower().rindex(preceding[-1].lower(), 0, start)
+            if not text[auxiliary_start + len(preceding[-1]) : start].strip():
+                source = text[auxiliary_start:end]
+                start = auxiliary_start
+
+        replacements.append(
+            {
+                "start": start,
+                "end": end,
+                "text": _match_casing(source, replacement),
+            }
+        )
+
+    # A lead-in that swallowed its gerund now covers the span of the gerund's
+    # own detection — "tasked with" grew to cover "handling", which is itself
+    # a cliché. Applying both rewrote one span twice and produced
+    # "Handledated". The leftmost, longest span wins, same rule as detection.
+    return _drop_overlaps(replacements)
 
 
 def analyze_and_suggest(text: str) -> Dict[str, Any]:
@@ -118,34 +379,32 @@ def analyze_and_suggest(text: str) -> Dict[str, Any]:
         Dict[str, Any]: Analysis results including detections and a modernized version.
     """
     if not text or not isinstance(text, str):
-        return {"detections": [], "modernized_text": "", "score": 100}
+        return {"detections": [], "modernized_text": "", "score": 100, "total_issues": 0}
 
     cliches = detect_cliches(text)
     passive = detect_passive_voice(text)
 
-    # Combine and sort detections by start position
     all_detections = sorted(cliches + passive, key=lambda x: x["start"])
 
-    # Generate modernized text by replacing clichés
+    # Applied back to front so an earlier replacement cannot move the offsets
+    # of a later one.
     modernized_text = text
-    # Sort in reverse to replace from end to start, preserving indices
-    for detection in sorted(all_detections, key=lambda x: x["start"], reverse=True):
-        if detection["type"] == "cliche":
-            # Preserve original casing of the first letter
-            original = detection["phrase"]
-            suggestion = detection["suggestion"]
-            if original[0].isupper():
-                suggestion = suggestion.capitalize()
-            modernized_text = (
-                modernized_text[: detection["start"]]
-                + suggestion
-                + modernized_text[detection["end"] :]
-            )
+    for replacement in sorted(
+        _build_replacements(text, cliches), key=lambda r: r["start"], reverse=True
+    ):
+        modernized_text = (
+            modernized_text[: replacement["start"]]
+            + replacement["text"]
+            + modernized_text[replacement["end"] :]
+        )
 
-    # Calculate a simple "impact score"
-    total_words = len(text.split())
+    # Issues per *sentence-sized unit* rather than per word. The old formula,
+    # `100 - (issues / words) * 500`, scored one issue in an eight-word bullet
+    # at 38/100 — a bullet is short by design, and being short is not a fault.
+    # 12 points an issue puts a bullet with two clichés in the sixties and
+    # still bottoms out for text that is nothing but clichés.
     issues_count = len(all_detections)
-    score = max(0, 100 - int((issues_count / max(total_words, 1)) * 500))
+    score = max(0, 100 - issues_count * 12)
 
     return {
         "detections": all_detections,

--- a/backend/analyzer/tests_cliche_detector.py
+++ b/backend/analyzer/tests_cliche_detector.py
@@ -5,7 +5,12 @@ Validates detection accuracy and suggestion generation across various edge cases
 """
 
 from django.test import TestCase
-from .cliche_detector import detect_cliches, detect_passive_voice, analyze_and_suggest
+from .cliche_detector import (
+    PASSIVE_INDICATORS,
+    analyze_and_suggest,
+    detect_cliches,
+    detect_passive_voice,
+)
 
 
 class ClicheDetectorTests(TestCase):
@@ -20,11 +25,18 @@ class ClicheDetectorTests(TestCase):
         self.assertEqual(detections[0]["suggestion"], "spearheaded")
 
     def test_detect_cliches_case_insensitive(self):
-        """Test that detection is case-insensitive."""
+        """Test that detection is case-insensitive.
+
+        The expected phrase was "Was Responsible For". The pattern is
+        `\bresponsible for\b` and does not include "was" — and the test one
+        above asserts "responsible for" for the same construction, so the two
+        contradicted each other. `detect_cliches` returns the matched span
+        with the casing it was written in, which is what this now checks.
+        """
         text = "I Was Responsible For the project."
         detections = detect_cliches(text)
         self.assertEqual(len(detections), 1)
-        self.assertEqual(detections[0]["phrase"], "Was Responsible For")
+        self.assertEqual(detections[0]["phrase"], "Responsible For")
 
     def test_detect_cliches_no_false_positives(self):
         """Test that legitimate technical terms are not flagged."""
@@ -52,14 +64,24 @@ class ClicheDetectorTests(TestCase):
         self.assertEqual(result["score"], 100)
 
     def test_analyze_and_suggest_modernization(self):
-        """Test that the modernized text correctly replaces clichés."""
+        """Test that the modernized text correctly replaces clichés.
+
+        This asserted that both "executed" (for "tasked with") and
+        "orchestrated" (for "handling") appear in the result. There is no
+        sentence in which both do: "Executed orchestrated the database
+        migration" is two verbs and no clause. "Tasked with" is a lead-in —
+        it introduces the real verb rather than being it — so it is dropped
+        and the verb it introduced is what gets modernised.
+        """
         text = "Tasked with handling the database migration."
         result = analyze_and_suggest(text)
 
         self.assertNotIn("tasked with", result["modernized_text"].lower())
         self.assertNotIn("handling", result["modernized_text"].lower())
-        self.assertIn("executed", result["modernized_text"].lower())
         self.assertIn("orchestrated", result["modernized_text"].lower())
+        self.assertEqual(
+            result["modernized_text"], "Orchestrated the database migration."
+        )
 
     def test_analyze_and_suggest_score_calculation(self):
         """Test that the impact score decreases with more issues."""
@@ -71,3 +93,196 @@ class ClicheDetectorTests(TestCase):
 
         self.assertGreater(clean_result["score"], dirty_result["score"])
         self.assertEqual(dirty_result["total_issues"], len(dirty_result["detections"]))
+
+
+class PassiveVoiceOffsetTests(TestCase):
+    """`start` came from `text.lower().find(...)`.
+
+    `find` returns the *first* occurrence in the string, not the one the loop
+    is currently looking at, so every repeat of a phrase reported the same
+    span. `ClicheDetector.tsx` highlights from these offsets.
+    """
+
+    def test_each_occurrence_reports_its_own_span(self):
+        text = "Was promoted twice. The report was promoted again later."
+        detections = detect_passive_voice(text)
+
+        self.assertEqual(len(detections), 2)
+        self.assertEqual((detections[0]["start"], detections[0]["end"]), (0, 12))
+        self.assertEqual((detections[1]["start"], detections[1]["end"]), (31, 43))
+
+    def test_every_span_slices_back_to_the_phrase_it_reports(self):
+        """The general form of the above: an offset that does not point at
+        its own phrase is a highlight over the wrong words."""
+        text = (
+            "The launch was delayed. Documentation was written by the team, "
+            "and the rollout was delayed again."
+        )
+        for detection in detect_passive_voice(text):
+            with self.subTest(phrase=detection["phrase"]):
+                self.assertEqual(
+                    text[detection["start"] : detection["end"]], detection["phrase"]
+                )
+
+
+class PassiveVoiceAccuracyTests(TestCase):
+    """`endswith(("ed", "en", "t"))` — "t" matches most of English."""
+
+    def test_ordinary_sentences_are_not_flagged(self):
+        detections = detect_passive_voice(
+            "This was not part of the team and is best in class"
+        )
+        self.assertEqual([d["phrase"] for d in detections], [])
+
+    def test_more_of_the_same_shape(self):
+        for text in [
+            "The result was about right.",
+            "It is it, and nothing more.",
+            "The budget was at its limit.",
+            "Attendance is often the point.",
+        ]:
+            with self.subTest(text=text):
+                self.assertEqual(detect_passive_voice(text), [])
+
+    def test_real_passive_voice_is_still_caught(self):
+        self.assertEqual(
+            [d["phrase"] for d in detect_passive_voice("The project was completed.")],
+            ["was completed"],
+        )
+
+    def test_irregular_participles_are_caught(self):
+        for text, expected in [
+            ("The service was built by the platform team.", "was built"),
+            ("The report was written last week.", "was written"),
+            ("The migration was run overnight.", "was run"),
+        ]:
+            with self.subTest(text=text):
+                self.assertEqual(
+                    [d["phrase"] for d in detect_passive_voice(text)], [expected]
+                )
+
+    def test_an_interrupting_adverb_does_not_hide_the_participle(self):
+        self.assertEqual(
+            [
+                d["phrase"]
+                for d in detect_passive_voice("The rollout was not completed on time.")
+            ],
+            ["was not completed"],
+        )
+
+    def test_the_indicator_list_is_the_one_the_detector_uses(self):
+        """PASSIVE_INDICATORS was defined at module scope and never
+        referenced — the function held its own hardcoded copy of six of the
+        same words, so the module had two lists and one of them did nothing."""
+        self.assertIn("was", PASSIVE_INDICATORS)
+        for word in PASSIVE_INDICATORS:
+            with self.subTest(word=word):
+                self.assertTrue(
+                    detect_passive_voice(f"The work {word} completed."),
+                    f"{word!r} is listed as an indicator but does not detect.",
+                )
+
+
+class InflectedClicheTests(TestCase):
+    """The dictionary held `\\bhandled\\b` only."""
+
+    def test_inflections_of_a_cliche_verb_are_caught(self):
+        for text in ["handled the escalation", "handles escalations", "handling escalations"]:
+            with self.subTest(text=text):
+                self.assertEqual(len(detect_cliches(text)), 1, text)
+
+    def test_utilize_and_leverage_inflect_too(self):
+        self.assertEqual(len(detect_cliches("utilizing and leveraging tooling")), 2)
+
+    def test_unrelated_words_are_not_caught_by_the_inflections(self):
+        self.assertEqual(detect_cliches("Handlebars and handshakes"), [])
+
+    def test_overlapping_patterns_report_one_detection(self):
+        """"in charge of" sits inside "was in charge of"; emitting both puts
+        two highlights over one phrase and two rewrites over one span."""
+        detections = detect_cliches("Was in charge of the migration.")
+        self.assertEqual(len(detections), 1)
+        self.assertEqual(detections[0]["phrase"], "Was in charge of")
+
+
+class ModernizationTests(TestCase):
+    """The rewrite has to produce a sentence, not just a substitution."""
+
+    def test_a_lead_in_does_not_leave_the_clause_passive(self):
+        result = analyze_and_suggest("I was responsible for the rollout.")
+        self.assertEqual(result["modernized_text"], "I spearheaded the rollout.")
+
+    def test_a_lead_in_hands_the_verb_to_the_gerund_behind_it(self):
+        self.assertEqual(
+            analyze_and_suggest("Responsible for managing the team.")["modernized_text"],
+            "Managed the team.",
+        )
+
+    def test_irregular_gerunds_convert_correctly(self):
+        self.assertEqual(
+            analyze_and_suggest(
+                "Helped with building the API and worked on running the pipeline."
+            )["modernized_text"],
+            "Built the API and ran the pipeline.",
+        )
+
+    def test_a_cliche_gerund_takes_its_own_suggestion(self):
+        """The past tense of "handling" is "handled", which is itself in the
+        dictionary — a cliché replaced by a cliché."""
+        self.assertEqual(
+            analyze_and_suggest("Tasked with handling escalations.")["modernized_text"],
+            "Orchestrated escalations.",
+        )
+
+    def test_all_caps_keeps_its_casing(self):
+        self.assertEqual(
+            analyze_and_suggest("RESPONSIBLE FOR the migration.")["modernized_text"],
+            "SPEARHEADED the migration.",
+        )
+
+    def test_sentence_case_is_preserved(self):
+        self.assertEqual(
+            analyze_and_suggest("Utilized a framework.")["modernized_text"],
+            "Used a framework.",
+        )
+
+    def test_clean_text_is_returned_untouched(self):
+        text = "Developed a microservices architecture using Docker and Kubernetes."
+        result = analyze_and_suggest(text)
+        self.assertEqual(result["modernized_text"], text)
+        self.assertEqual(result["score"], 100)
+        self.assertEqual(result["total_issues"], 0)
+
+
+class ScoreTests(TestCase):
+    """`100 - (issues / words) * 500` scored one issue in an eight-word
+    bullet at 38/100. A bullet is short by design."""
+
+    def test_a_short_bullet_with_one_issue_is_not_gutted(self):
+        result = analyze_and_suggest("Responsible for the CI pipeline.")
+        self.assertEqual(result["total_issues"], 1)
+        self.assertGreaterEqual(result["score"], 80)
+
+    def test_the_same_issue_scores_the_same_in_a_long_bullet(self):
+        short = analyze_and_suggest("Responsible for the pipeline.")
+        long = analyze_and_suggest(
+            "Responsible for the pipeline that moves several million events a "
+            "day between the ingest tier and the warehouse without loss."
+        )
+        self.assertEqual(short["score"], long["score"])
+
+    def test_the_score_still_falls_with_more_issues(self):
+        one = analyze_and_suggest("Responsible for the pipeline.")
+        many = analyze_and_suggest(
+            "Responsible for synergy, utilized world-class team player thinking."
+        )
+        self.assertLess(many["score"], one["score"])
+
+    def test_the_score_has_a_floor(self):
+        self.assertGreaterEqual(analyze_and_suggest("synergy " * 40)["score"], 0)
+
+    def test_empty_input_reports_total_issues(self):
+        """`total_issues` was missing from the empty-input branch, so a caller
+        reading it got a KeyError on exactly the input that cannot fail."""
+        self.assertEqual(analyze_and_suggest("")["total_issues"], 0)
+        self.assertEqual(analyze_and_suggest(None)["total_issues"], 0)


### PR DESCRIPTION
## 📝 Description

`analyzer/cliche_detector.py` returned character offsets that don't point at the text they describe, flagged ordinary sentences as passive voice, and missed the inflected forms of the clichés it already knew about.

## 🔗 Related Issue

Closes #938

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## 🔍 What changed

### 1. Passive-voice offsets pointed at the wrong text

`detect_passive_voice` walked the words by index but recovered the position with `find`, which returns the **first** occurrence in the string rather than the one the loop is looking at:

```python
>>> t = "Was promoted twice. The report was promoted again later."
>>> [(d["phrase"], d["start"], d["end"]) for d in detect_passive_voice(t)]
[('Was promoted', 0, 12), ('was promoted', 0, 12)]     # second one is 31 chars away
```

`ClicheDetector.tsx` highlights from these offsets, so the wrong words lit up and a repeated phrase highlighted the same place twice. The walk now carries offsets with it (`re.finditer` over words instead of `split()`), so a span is the span of the match being reported. There's a test asserting `text[start:end] == phrase` for every detection.

### 2. `endswith(("ed", "en", "t"))` is not a past-participle test

`"t"` matches most of English:

```python
>>> [d["phrase"] for d in detect_passive_voice("This was not part of the team and is best in class")]
['was not', 'is best']
```

Now `"ed"` plus an explicit set of irregular participles. Narrower than any suffix rule containing `"t"`, and it deliberately catches `was built` / `was written` / `was run`, which the old rule got by accident and only sometimes. An interrupting adverb no longer hides the participle behind it — `"was not completed"` is caught as one span.

### 3. `PASSIVE_INDICATORS` was dead code

Defined at module scope, never referenced; the function held its own hardcoded copy of six of the same words. One list now, with a test that walks it and asserts each entry actually detects.

### 4. Inflected clichés were missed

The dictionary held `\bhandled\b` only, so "handling" and "handles" went straight past a detector whose job is that verb. Verb entries carry their inflections — and `"Handlebars and handshakes"` still doesn't match.

### 5. The modernizer produced text that wasn't English

| Input | Was | Now |
|---|---|---|
| `I was responsible for the rollout.` | `I was spearheaded the rollout.` | `I spearheaded the rollout.` |
| `Tasked with handling the migration.` | `executed handling the migration.` | `Orchestrated the migration.` |
| `Responsible for managing the team.` | `Spearheaded managing the team.` | `Managed the team.` |
| `RESPONSIBLE FOR the migration.` | `Spearheaded the migration.` | `SPEARHEADED the migration.` |

- A `was`/`were` immediately in front of a phrase is swallowed with it, so the tool no longer *writes* the passive voice it exists to remove.
- Phrases like "tasked with" and "responsible for" are **lead-ins**: they introduce the real verb rather than being it. The lead-in is dropped and the verb behind it is modernised. Where that verb is not itself in the dictionary the gerund is converted to simple past (with an irregular table — *building → built*, *running → ran*).
- Where it is in the dictionary, its own suggestion wins: the past tense of "handling" is "handled", which is a cliché, so the old path would have replaced a cliché with a cliché.
- Overlapping spans resolve leftmost-then-longest, both when detecting ("in charge of" sits inside "was in charge of") and when rewriting, where a lead-in that swallowed its gerund covers the gerund's own detection.
- Casing comes from the whole matched phrase rather than just its first character.

### 6. The score punished short bullets

`100 - (issues / words) * 500` scored one issue in an eight-word bullet at **38/100**. A bullet is short by design; being short is not a fault. Flat 12 points per issue instead, so the same cliché costs the same wherever it appears — a test pins that a short and a long bullet with one identical issue score identically.

### 7. `total_issues` was missing from the empty-input branch

A caller reading it got a `KeyError` on the one input that cannot fail.

## ⚠️ Two test assertions corrected

Both contradicted something else in the same file. Flagging them explicitly since changing an assertion deserves a second look:

- **`test_detect_cliches_case_insensitive`** expected the phrase `"Was Responsible For"`. The pattern is `\bresponsible for\b` and does not include "was" — and `test_detect_cliches_finds_exact_match`, directly above it, asserts `"responsible for"` for the same construction.
- **`test_analyze_and_suggest_modernization`** expected both `"executed"` and `"orchestrated"` in one rewrite of *"Tasked with handling the database migration."* There is no sentence containing both: *"Executed orchestrated the database migration"* is two verbs and no clause. It now asserts the full rewritten sentence.

No other assertion in the file was touched; the remaining five pass unchanged.

## 🧪 How Has This Been Tested?

- [x] Backend tests pass (`python manage.py test analyzer`)

```
Ran 844 tests   (was 820)
```

24 new tests in six classes: `PassiveVoiceOffsetTests`, `PassiveVoiceAccuracyTests`, `InflectedClicheTests`, `ModernizationTests`, `ScoreTests`.

## 📌 Note

Verified on top of #940, which this needs in order to run at all.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
