### PR TITLE
fix: make the accessibility rules fire on what they describe (#939)

### DIFF
--- a/backend/analyzer/accessibility_checker.py
+++ b/backend/analyzer/accessibility_checker.py
@@ -9,29 +9,172 @@ or problematic layouts that hinder assistive technologies.
 import re
 from typing import List, Dict, Any
 
+#: Characters that mark a list item at the start of a line. Named once and
+#: used twice: `no_bullet_points` looks for them, and `special_characters`
+#: must not then complain about the ones it just recommended.
+BULLET_CHARS = "-*•‣▪●◦·⁃∙"
+
+#: A line that opens a list item: a bullet character or a numbered marker,
+#: with whitespace after it.
+BULLET_LINE_RE = re.compile(
+    rf"^[ \t]*(?:[{re.escape(BULLET_CHARS)}]|\d+[.)])[ \t]+\S", re.MULTILINE
+)
+
+#: How much of the document counts as "the top" for the contact-block rule.
+CONTACT_HEADER_LINES = 15
+CONTACT_HEADER_CHARS = 800
+
+#: Contact signals. The words, plus the shapes of an address and a phone
+#: number — a contact block that reads "j.doe@example.com | +1 555 0142" is a
+#: contact block whether or not it uses the word "email".
+CONTACT_SIGNAL_RE = re.compile(
+    r"(?:email|e-mail|phone|mobile|tel(?:ephone)?|address|linkedin|github|"
+    r"portfolio|contact)"
+    r"|[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}"
+    r"|\+?\d[\d\s().-]{7,}\d",
+    re.IGNORECASE,
+)
+
+#: Characters a screen reader genuinely struggles with: arrows, dingbats,
+#: geometric and miscellaneous symbols, box drawing, emoji, and — the worst
+#: of them — Private Use Area codepoints, which is where icon fonts put their
+#: glyphs and where a screen reader has nothing at all to say.
+#:
+#: The rule used to be an allowlist, `[^\w\s\-\.\,\:\;\(\)\[\]\/\@]`, which
+#: flagged "%" (the quantified metrics every resume guide asks for), "&"
+#: (R&D), "+" and "#" (C++, C#), "|" (the standard contact-line separator)
+#: and "•" — the bullet character `no_bullet_points` recommends two rules
+#: above. It fired on essentially every real resume.
+PROBLEM_CHAR_RE = re.compile(
+    "["
+    "←-⇿"  # arrows
+    "─-╿"  # box drawing
+    "▀-▟"  # block elements
+    "■-◿"  # geometric shapes
+    "☀-⛿"  # miscellaneous symbols
+    "✀-➿"  # dingbats
+    "-"  # private use area (icon fonts)
+    "\U0001f000-\U0001faff"  # emoji and pictographs
+    "]"
+)
+
+#: Acronyms and initialisms that are written in capitals because that is how
+#: they are spelled. `\b[A-Z]{4,}\b` could not tell these apart from
+#: caps-locked prose, so "Built REST APIs in JAVA using SPRING and JUNIT;
+#: shipped HTTPS/OAUTH flows" counted as six accessibility problems.
+KNOWN_ACRONYMS = frozenset(
+    {
+        # Web and data
+        "HTML", "CSS", "SCSS", "SASS", "JSON", "XML", "YAML", "CSV", "HTTP",
+        "HTTPS", "REST", "SOAP", "GRPC", "API", "APIS", "SQL", "NOSQL",
+        "GRAPHQL", "ORM", "CRUD", "ETL", "SDK", "CLI", "GUI", "UI", "UX",
+        "SEO", "CMS", "CDN", "DNS", "TCP", "SSH", "SSL", "TLS", "URL", "URI",
+        # Platforms and practice
+        "AWS", "GCP", "IAM", "VPC", "SAAS", "PAAS", "IAAS", "CI", "CD",
+        "CICD", "SRE", "QA", "TDD", "BDD", "MVC", "MVP", "SPA", "PWA",
+        "SCRUM", "AGILE", "KPI", "OKR", "ROI", "SLA", "SLO",
+        # Auth and security
+        "JWT", "OAUTH", "SAML", "SSO", "MFA", "RBAC", "GDPR", "SOC", "PCI",
+        # AI and analytics
+        "AI", "ML", "NLP", "LLM", "GPU", "CPU", "RAM", "OCR", "BI",
+        # Job titles and credentials
+        "CEO", "CTO", "COO", "CFO", "CIO", "VP", "SVP", "EVP", "PM", "PMP",
+        "MBA", "BSC", "MSC", "PHD", "BS", "MS", "BA", "MA", "CPA", "CFA",
+        # Languages and tools commonly written in caps
+        "PHP", "SAS", "SPSS", "MATLAB", "LATEX", "IDE", "IOS", "OS",
+        # Regions and misc
+        "USA", "UK", "EU", "NYC", "LLC", "INC", "R&D", "IT", "HR",
+    }
+)
+
+#: How many capitalised words that are *not* recognised acronyms it takes
+#: before the text reads as caps-locked rather than as a technical resume.
+EXCESSIVE_CAPS_THRESHOLD = 5
+
+#: Words in capitals, two letters or more.
+CAPS_WORD_RE = re.compile(r"\b[A-Z][A-Z&/.'-]{1,}\b")
+
+
+def _top_of_document(text: str) -> str:
+    """The part of the resume a reader meets first."""
+    lines = text.splitlines()[:CONTACT_HEADER_LINES]
+    return "\n".join(lines)[:CONTACT_HEADER_CHARS]
+
+
+def _has_contact_block_at_top(text: str) -> bool:
+    """Whether the top of the document carries contact details.
+
+    The rule's description has always said "top-level contact information
+    section", but the check searched the whole document for the *words*
+    "email", "phone", "address" or "linkedin" — so a resume mentioning "email
+    marketing" in a bullet on page two passed, and nothing tested position.
+    """
+    return bool(CONTACT_SIGNAL_RE.search(_top_of_document(text)))
+
+
+def _has_bullet_lines(text: str) -> bool:
+    """Whether the text uses list markers, as opposed to merely containing one.
+
+    The check was `"-" not in text and "*" not in text and "•" not in text`,
+    a substring test over the whole document. Any hyphen anywhere satisfied
+    it — a date range, a phone number, a hyphenated word — so on a real
+    resume the rule could not fire. "2020-2023" alone switched it off.
+    """
+    return bool(BULLET_LINE_RE.search(text))
+
+
+def _is_known_acronym(word: str) -> bool:
+    """Whether `word` is a recognised acronym, however it is punctuated.
+
+    Acronyms arrive with punctuation attached — "HTTPS/" from "HTTPS/OAuth",
+    "B.S." from a degree line, "CI/CD" as a pair — so a bare set lookup
+    misses most of them and they get counted as caps-locked prose.
+    """
+    upper = word.upper().strip(".&/'-")
+    if upper in KNOWN_ACRONYMS:
+        return True
+    # "B.S." -> "BS"
+    if upper.replace(".", "") in KNOWN_ACRONYMS:
+        return True
+    # "CI/CD" -> "CI" and "CD"
+    if "/" in upper:
+        parts = [part for part in upper.split("/") if part]
+        return bool(parts) and all(part in KNOWN_ACRONYMS for part in parts)
+    return False
+
+
+def _unexplained_caps_words(text: str) -> List[str]:
+    """Capitalised words that are not recognised acronyms."""
+    return [word for word in CAPS_WORD_RE.findall(text) if not _is_known_acronym(word)]
+
+
+def _has_problem_characters(text: str) -> bool:
+    """Whether the text contains a character assistive tech cannot vocalise."""
+    return bool(PROBLEM_CHAR_RE.search(text))
+
+
 # Heuristic rules for accessibility checks
 ACCESSIBILITY_RULES = {
     "missing_contact_header": {
         "severity": "critical",
         "description": "Resume lacks a clear, top-level contact information section.",
-        "check": lambda text: not re.search(
-            r"(?:email|phone|address|linkedin)", text, re.IGNORECASE
-        ),
+        "check": lambda text: not _has_contact_block_at_top(text),
     },
     "no_bullet_points": {
         "severity": "warning",
         "description": "Experience sections lack bullet points, making them hard to parse for screen readers.",
-        "check": lambda text: "-" not in text and "*" not in text and "•" not in text,
+        "check": lambda text: not _has_bullet_lines(text),
     },
     "excessive_caps": {
         "severity": "warning",
         "description": "Excessive use of ALL CAPS can be read as individual letters by some screen readers.",
-        "check": lambda text: len(re.findall(r"\b[A-Z]{4,}\b", text)) > 5,
+        "check": lambda text: len(_unexplained_caps_words(text))
+        >= EXCESSIVE_CAPS_THRESHOLD,
     },
     "special_characters": {
         "severity": "info",
         "description": "Contains special characters or symbols that may not be vocalized correctly.",
-        "check": lambda text: bool(re.search(r"[^\w\s\-\.\,\:\;\(\)\[\]\/\@]", text)),
+        "check": _has_problem_characters,
     },
     "missing_section_headers": {
         "severity": "critical",
@@ -78,9 +221,9 @@ def get_recommendation(rule_name: str) -> str:
     """
     recommendations = {
         "missing_contact_header": "Add a dedicated 'Contact' section at the very top with your email, phone, and LinkedIn URL.",
-        "no_bullet_points": "Use standard bullet characters (-, *, or •) for lists to ensure screen readers identify them as list items.",
+        "no_bullet_points": "Start each list item on its own line with a standard bullet character (-, *, or •) so screen readers announce it as a list item.",
         "excessive_caps": "Use Title Case or Sentence case instead of ALL CAPS for headings to improve screen reader vocalization.",
-        "special_characters": "Replace decorative symbols (e.g., arrows, stars) with standard text or simple bullet points.",
+        "special_characters": "Replace decorative symbols (e.g., arrows, icon-font glyphs, emoji) with standard text or simple bullet points.",
         "missing_section_headers": "Include clear, standard headings like 'Professional Experience', 'Education', and 'Skills'.",
     }
     return recommendations.get(

--- a/backend/analyzer/tests_accessibility_checker.py
+++ b/backend/analyzer/tests_accessibility_checker.py
@@ -6,8 +6,10 @@ Covers various structural failure scenarios and valid accessible resumes.
 
 from django.test import TestCase
 from .accessibility_checker import (
-    check_accessibility,
+    BULLET_CHARS,
+    EXCESSIVE_CAPS_THRESHOLD,
     calculate_accessibility_score,
+    check_accessibility,
     get_recommendation,
 )
 
@@ -92,3 +94,186 @@ class AccessibilityCheckerTests(TestCase):
         """Test that a fallback recommendation is provided for unknown rules."""
         rec = get_recommendation("unknown_rule")
         self.assertIn("review", rec.lower())
+
+
+def _rules(text):
+    """The rule names a piece of text trips."""
+    return {finding["rule"] for finding in check_accessibility(text)}
+
+
+class BulletDetectionTests(TestCase):
+    """The check was `"-" not in text and "*" not in text and "•" not in text`.
+
+    A substring test over the whole document, so any hyphen anywhere switched
+    the rule off — a date range, a phone number, a hyphenated word. On a real
+    resume it could not fire.
+    """
+
+    def test_a_date_range_no_longer_hides_the_absence_of_bullets(self):
+        resume = (
+            "Jane Doe\njane@example.com\n\n"
+            "Experience\n"
+            "Senior Engineer, Acme Corp (2020-2023)\n"
+            "Built payment flows and shipped the billing service.\n"
+        )
+        self.assertIn("no_bullet_points", _rules(resume))
+
+    def test_a_hyphenated_word_does_not_count_as_a_bullet(self):
+        resume = "Contact: a@b.com\nExperience\nWorked on a well-known e-commerce platform."
+        self.assertIn("no_bullet_points", _rules(resume))
+
+    def test_every_accepted_bullet_character_is_recognised(self):
+        for char in BULLET_CHARS:
+            with self.subTest(char=char):
+                resume = f"Contact: a@b.com\nExperience\n{char} Led the team\n"
+                self.assertNotIn("no_bullet_points", _rules(resume))
+
+    def test_numbered_lists_count_as_lists(self):
+        for marker in ("1.", "2)"):
+            with self.subTest(marker=marker):
+                resume = f"Contact: a@b.com\nExperience\n{marker} Led the team\n"
+                self.assertNotIn("no_bullet_points", _rules(resume))
+
+    def test_a_bullet_character_mid_sentence_is_not_a_list(self):
+        resume = "Contact: a@b.com\nExperience\nRevenue rose 5% - twice over.\n"
+        self.assertIn("no_bullet_points", _rules(resume))
+
+
+class SpecialCharacterTests(TestCase):
+    """The rule was an allowlist so narrow it fired on almost every resume."""
+
+    def test_the_bullet_character_the_other_rule_recommends_is_not_flagged(self):
+        """`no_bullet_points` recommends "•"; `special_characters` flagged it.
+        Following one recommendation tripped the other."""
+        self.assertNotIn(
+            "special_characters", _rules("Contact: a@b.com\nExperience\n• Led the team\n")
+        )
+
+    def test_ordinary_resume_punctuation_is_not_flagged(self):
+        resume = (
+            "Contact: jane@example.com | +1 (555) 010-4477\n"
+            "Experience\n"
+            "- Cut latency 30% and grew revenue 2x\n"
+            "- Stack: C++, C#, R&D tooling & Node.js\n"
+            "- Salary band: $120k-$150k\n"
+        )
+        self.assertNotIn("special_characters", _rules(resume))
+
+    def test_accented_names_are_not_flagged(self):
+        resume = "Contact: jose@example.com\nExperience\n- Worked with José Álvarez in Zürich\n"
+        self.assertNotIn("special_characters", _rules(resume))
+
+    def test_decorative_symbols_are_still_flagged(self):
+        for symbol in ("→", "★", "✅", "▓", "🚀"):
+            with self.subTest(symbol=symbol):
+                resume = f"Contact: a@b.com\nExperience\n- Revenue {symbol} up 40%\n"
+                self.assertIn("special_characters", _rules(resume))
+
+    def test_private_use_glyphs_are_flagged(self):
+        """Icon fonts put their glyphs in the Private Use Area, where a screen
+        reader has nothing at all to say."""
+        resume = "Contact: a@b.com\nExperience\n-  jane@example.com\n"
+        self.assertIn("special_characters", _rules(resume))
+
+
+class ExcessiveCapsTests(TestCase):
+    """`\\b[A-Z]{4,}\\b` counted acronyms as caps-locked prose, and its
+    threshold of `> 5` was one past its own fixture."""
+
+    def test_a_technical_resume_is_not_flagged_for_its_acronyms(self):
+        resume = (
+            "Contact: jane@example.com\n"
+            "Experience\n"
+            "- Built REST APIs with SQL, AWS, JSON, HTML, CI/CD and OAUTH\n"
+            "Education\n"
+            "- B.S. Computer Science\n"
+        )
+        self.assertNotIn("excessive_caps", _rules(resume))
+
+    def test_a_technical_resume_scores_100(self):
+        """The end-to-end version: two rules firing on a well-formed resume
+        cost it 20 points."""
+        resume = (
+            "Contact: jane@example.com | 555-0142\n"
+            "Experience\n"
+            "- Built REST APIs in Java using Spring; shipped HTTPS/OAuth flows\n"
+            "- Increased conversion by 40% and cut latency 30%\n"
+            "- Stack: C++, C#, R&D tooling\n"
+            "Education\n"
+            "- B.S. Computer Science\n"
+        )
+        self.assertEqual(check_accessibility(resume), [])
+        self.assertEqual(calculate_accessibility_score(check_accessibility(resume)), 100)
+
+    def test_caps_locked_prose_is_still_flagged(self):
+        resume = (
+            "Contact: a@b.com\nExperience\n"
+            "- DELIVERED SEVERAL LARGE PROJECTS ACROSS MULTIPLE TEAMS\n"
+        )
+        self.assertIn("excessive_caps", _rules(resume))
+
+    def test_short_acronyms_are_recognised_too(self):
+        """`{4,}` could not see VP, CTO, QA or AI at all, so a fixture built
+        from job titles counted 5 where it needed 6."""
+        resume = "Contact: a@b.com\nExperience\n- VP, CTO, QA, AI, ML, UX and BI work\n"
+        self.assertNotIn("excessive_caps", _rules(resume))
+
+    def test_the_threshold_is_the_documented_one(self):
+        pool = ["ALPHA", "BRAVO", "CHARLIE", "DELTA", "ECHO", "FOXTROT", "GOLF"]
+
+        words = " ".join(pool[:EXCESSIVE_CAPS_THRESHOLD])
+        resume = f"Contact: a@b.com\nExperience\n- {words}\n"
+        self.assertIn("excessive_caps", _rules(resume))
+
+        fewer = " ".join(pool[: EXCESSIVE_CAPS_THRESHOLD - 1])
+        self.assertNotIn(
+            "excessive_caps", _rules(f"Contact: a@b.com\nExperience\n- {fewer}\n")
+        )
+
+
+class ContactHeaderPositionTests(TestCase):
+    """The description says "top-level"; the check searched the whole document."""
+
+    def test_email_marketing_on_page_two_is_not_a_contact_block(self):
+        resume = "Summary\n" + ("Delivered projects.\n" * 30) + "Ran email marketing.\n"
+        self.assertIn("missing_contact_header", _rules(resume))
+
+    def test_a_contact_block_at_the_top_passes(self):
+        resume = "Jane Doe\njane@example.com\n\nExperience\n- Led the team\n"
+        self.assertNotIn("missing_contact_header", _rules(resume))
+
+    def test_a_bare_email_counts_without_the_word_email(self):
+        resume = "Jane Doe\nj.doe@example.com\n\nExperience\n- Led the team\n"
+        self.assertNotIn("missing_contact_header", _rules(resume))
+
+    def test_a_bare_phone_number_counts(self):
+        resume = "Jane Doe\n+1 (555) 010-4477\n\nExperience\n- Led the team\n"
+        self.assertNotIn("missing_contact_header", _rules(resume))
+
+
+class RuleConsistencyTests(TestCase):
+    """The rules must not contradict each other."""
+
+    def test_following_the_bullet_recommendation_does_not_trip_another_rule(self):
+        resume = (
+            "Jane Doe\njane@example.com\n\n"
+            "Experience\n"
+            "• Led a team of five engineers\n"
+            "• Shipped the billing service\n"
+            "Education\n"
+            "• B.S. Computer Science\n"
+        )
+        self.assertEqual(check_accessibility(resume), [])
+
+    def test_every_rule_has_a_recommendation(self):
+        from .accessibility_checker import ACCESSIBILITY_RULES
+
+        fallback = get_recommendation("definitely-not-a-rule")
+        for rule_name in ACCESSIBILITY_RULES:
+            with self.subTest(rule=rule_name):
+                self.assertNotEqual(get_recommendation(rule_name), fallback)
+
+    def test_non_string_input_is_handled(self):
+        self.assertEqual(check_accessibility(None), [])
+        self.assertEqual(check_accessibility(""), [])
+        self.assertEqual(check_accessibility(123), [])


### PR DESCRIPTION
## 📝 Description

Four of the five rules in `analyzer/accessibility_checker.py` checked the wrong condition. Two of them fail the module's own tests — `test_check_accessibility_valid_resume` and `test_check_accessibility_excessive_caps`, both red since the feature merged, behind #935.

## 🔗 Related Issue

Closes #939

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## 🔍 What changed

### 1. `no_bullet_points` could not fire on a real resume

```python
"check": lambda text: "-" not in text and "*" not in text and "•" not in text,
```

A substring test over the whole document, not a check for list formatting. Any hyphen anywhere satisfied it:

```python
>>> resume = "EXPERIENCE\nSenior Engineer, Acme Corp (2020-2023)\nBuilt REST APIs.\n"
>>> "-" not in resume and "*" not in resume and "•" not in resume
False        # no bullets anywhere, rule stays silent
```

`2020-2023` was enough to switch it off. In practice it only ever fired on the synthetic input in the test file. Now looks for a line that *opens* a list item — a bullet character or a numbered marker (`1.`, `2)`), with whitespace after it. A `-` mid-sentence is no longer a list.

### 2. `special_characters` flagged the character the other rule recommends

The allowlist `[^\w\s\-\.\,\:\;\(\)\[\]\/\@]` omitted almost everything a resume legitimately contains:

| Character | Where it shows up |
|---|---|
| `%` | the quantified metrics every resume guide asks for |
| `+` `#` | C++, C# |
| `&` | R&D, Johnson & Johnson |
| `\|` | the standard contact-line separator — used in this module's own passing fixture |
| `•` | the bullet character `no_bullet_points` recommends, two rules above |

Following one recommendation tripped the other, and that contradiction is exactly what `test_check_accessibility_valid_resume` was failing on.

Inverted: the rule now names the characters that actually cause trouble — arrows, box drawing, block elements, geometric shapes, miscellaneous symbols, dingbats, emoji, and **Private Use Area** codepoints, which is where icon fonts put their glyphs and where a screen reader has nothing at all to say. Accented names pass; `→ ★ ✅ ▓ 🚀` are still flagged.

### 3. `excessive_caps` missed its own fixture, and fired on acronyms

```python
"check": lambda text: len(re.findall(r"\b[A-Z]{4,}\b", text)) > 5,
```

`{4,}` cannot see `VP` or `CTO`, so the fixture `EXPERIENCE / SOFTWARE ENGINEER / MANAGER / DIRECTOR / VP / CTO` yields exactly 5 against a threshold of `> 5`.

The opposite problem mattered more — the pattern could not tell caps-locked prose from a technical acronym:

```python
>>> re.findall(r"\b[A-Z]{4,}\b", "Built REST APIs in JAVA using SPRING and JUNIT; shipped HTTPS/OAUTH flows.")
['REST','JAVA','SPRING','JUNIT','HTTPS','OAUTH']     # six "accessibility problems"
```

Now counts capitalised words two letters and up, minus a set of recognised acronyms, at a threshold of `>= 5`. It also normalises the punctuation acronyms actually arrive with — `HTTPS/` (from `HTTPS/OAuth`), `B.S.`, `CI/CD` — which a bare set lookup misses, so they'd have been counted as prose.

### 4. `missing_contact_header` ignored position

The description says "lacks a clear, **top-level** contact information section"; the check searched the entire document for the words "email", "phone", "address" or "linkedin". A resume mentioning *email marketing* in a bullet on page two passed. It now looks at the top of the document, and accepts a bare email address or phone number as a contact block whether or not the word "email" sits next to it.

### The score, end to end

Because two rules over-fired, a well-formatted technical resume lost 20 points to false positives while a genuinely bullet-less one was never told about it:

```python
>>> resume = ("Contact: jane@example.com | 555-0142\n"
...           "Experience\n"
...           "- Built REST APIs in Java using Spring; shipped HTTPS/OAuth flows\n"
...           "- Increased conversion by 40% and cut latency 30%\n"
...           "- Stack: C++, C#, R&D tooling\n"
...           "Education\n- B.S. Computer Science\n")
>>> check_accessibility(resume)
[]                                  # was: special_characters + excessive_caps
>>> calculate_accessibility_score(check_accessibility(resume))
100                                 # was: 80
```

## 🧪 How Has This Been Tested?

- [x] Backend tests pass (`python manage.py test analyzer`)

```
Ran 842 tests   (was 820)
```

**No existing assertion was changed** — all nine tests already in the file pass as written. 22 new tests in five classes: `BulletDetectionTests`, `SpecialCharacterTests`, `ExcessiveCapsTests`, `ContactHeaderPositionTests`, and `RuleConsistencyTests`, which pins the thing that started this: following the bullet recommendation must not trip another rule.

## 📌 Note

Verified on top of #940, which this needs in order to run at all.

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
