### PR TITLE
feat: show QR codes for shared analyses

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "jspdf": "^4.2.1",
         "jszip": "^3.10.1",
         "lucide-react": "^1.33.0",
+        "qrcode.react": "^3.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-icons": "^5.7.0",
@@ -6782,6 +6783,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/querystringify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-icons": "^5.7.0",
+    "qrcode.react": "^3.1.0",
     "react-router-dom": "^7.18.2",
     "recharts": "^3.10.1",
     "swagger-ui-react": "^5.32.13"

--- a/frontend/src/components/ShareResult.css
+++ b/frontend/src/components/ShareResult.css
@@ -32,6 +32,19 @@
   outline: none;
 }
 
+.share-qr-code {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin: 4px 0 12px;
+  padding: 8px;
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--text-tertiary, #6b7280);
+  font-size: 0.75rem;
+}
+
 .share-copy-btn {
   display: flex;
   align-items: center;

--- a/frontend/src/components/ShareResult.test.tsx
+++ b/frontend/src/components/ShareResult.test.tsx
@@ -112,6 +112,14 @@ describe('ShareResult (#705)', () => {
     expect(screen.getByText(/4 views/)).toBeInTheDocument()
   })
 
+  it('renders a QR code for the live share URL', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: LIVE })
+    render(<ShareResult analysisId={12} />)
+
+    expect(await screen.findByRole('img', { name: /qr code for this analysis/i })).toBeInTheDocument()
+    expect(screen.getByText(/scan to open this shared analysis/i)).toBeInTheDocument()
+  })
+
   it('revokes through the API and drops back to the private state', async () => {
     const user = userEvent.setup()
     vi.mocked(api.get).mockResolvedValue({ data: LIVE })

--- a/frontend/src/components/ShareResult.tsx
+++ b/frontend/src/components/ShareResult.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Share2, Check, Copy, Link2Off, RefreshCw, ShieldCheck, Eye, EyeOff } from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
 import { api } from '../api/client'
 import {
   DEFAULT_LIFETIME_DAYS,
@@ -182,6 +183,11 @@ export const ShareResult: React.FC<ShareResultProps> = ({ analysisId }) => {
               {copied ? <Check size={14} /> : <Copy size={14} />}
               {copied ? 'Copied' : 'Copy Link'}
             </button>
+          </div>
+
+          <div className="share-qr-code" role="img" aria-label="QR code for this analysis">
+            <QRCodeSVG value={state.share_url} size={144} includeMargin />
+            <span>Scan to open this shared analysis</span>
           </div>
 
           <div className="share-meta">


### PR DESCRIPTION
## Issue

Closes #950.

## Summary

Add a QR code next to every live share link so a result can be opened from a phone or another nearby device.

## Implementation

- Render a `qrcode.react` SVG from the server-issued share URL.
- Add an accessible label and scan hint.
- Keep the QR presentation readable in light and dark themes with a white quiet zone.
- Add the dependency to the frontend lockfile and a component regression test.

The QR encodes only the existing public share URL; no resume content or new backend data is introduced.

## Tests

- `git diff --check` — passed.
- `npm test -- --run src/components/ShareResult.test.tsx` — not run: the checkout's `node_modules` lacks the `vitest` executable.
- `npm run build` — not run: the checkout's `node_modules` lacks `tsc`.
- `npm run lint` — not run: the checkout's `node_modules` lacks `eslint`.

The initial dependency install exposed an existing peer conflict between `@vitest/coverage-v8@3.2.7` and `vitest@4.1.11`; `--legacy-peer-deps` was used only to resolve the new QR dependency. No external service is required.