### PR TITLE
feat: implement resume tone and sentiment analyzer for cultural fit (#949)

### DIFF
--- a/backend/analyzer/tests_tone_analyzer.py
+++ b/backend/analyzer/tests_tone_analyzer.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for Tone Analyzer.
+"""
+
+from django.test import TestCase
+from .tone_analyzer import (
+    analyze_pronoun_usage,
+    analyze_sentiment_and_confidence,
+    analyze_tone,
+)
+
+
+class ToneAnalyzerTests(TestCase):
+    """Test suite for tone and sentiment analysis logic."""
+
+    def test_analyze_pronoun_usage_individual(self):
+        """Test detection of individual-focused pronoun usage."""
+        text = "I built the system. My code was efficient. I led the project."
+        result = analyze_pronoun_usage(text)
+        self.assertEqual(result["dominant"], "individual")
+        self.assertGreater(result["ratio"], 0.6)
+
+    def test_analyze_pronoun_usage_team(self):
+        """Test detection of team-focused pronoun usage."""
+        text = "We collaborated on the design. Our team delivered the product. We partnered with stakeholders."
+        result = analyze_pronoun_usage(text)
+        self.assertEqual(result["dominant"], "team")
+        self.assertLess(result["ratio"], 0.4)
+
+    def test_analyze_sentiment_and_confidence_strong(self):
+        """Test scoring of strong, confident language."""
+        text = "I spearheaded the initiative and delivered a 20% improvement. I architected the solution."
+        result = analyze_sentiment_and_confidence(text)
+        self.assertGreater(result["confidence_score"], 70)
+        self.assertEqual(len(result["suggestions"]), 0)
+
+    def test_analyze_sentiment_and_confidence_weak(self):
+        """Test scoring and suggestions for weak language."""
+        text = "I think I helped with the project. I tried to improve things. I was responsible for some tasks."
+        result = analyze_sentiment_and_confidence(text)
+        self.assertLess(result["confidence_score"], 50)
+        self.assertLess(result["clarity_score"], 80)
+        self.assertTrue(any("weak phrases" in s for s in result["suggestions"]))
+
+    def test_analyze_tone_full_integration(self):
+        """Test full tone analysis integration."""
+        text = "I led a cross-functional team. We collaborated to architect a solution that increased efficiency by 30%."
+        result = analyze_tone(text)
+
+        self.assertIn("confidence_score", result)
+        self.assertIn("collaboration_score", result)
+        self.assertIn("overall_tone", result)
+        self.assertEqual(result["pronoun_dominance"], "balanced")

--- a/backend/analyzer/tone_analyzer.py
+++ b/backend/analyzer/tone_analyzer.py
@@ -1,0 +1,145 @@
+"""
+Resume Tone and Sentiment Analyzer for Cultural Fit.
+
+Evaluates linguistic patterns to assess confidence, collaboration style,
+and overall cultural tone, providing suggestions for alignment.
+"""
+
+import re
+from typing import List, Dict, Any
+
+# Pronoun and phrasing indicators
+FIRST_PERSON_SINGULAR = [r"\bi\b", r"\bmy\b", r"\bmine\b", r"\bme\b"]
+FIRST_PERSON_PLURAL = [r"\bwe\b", r"\bour\b", r"\bours\b", r"\bus\b"]
+PASSIVE_WEAK_PHRASES = [
+    r"\bi think\b",
+    r"\bi believe\b",
+    r"\bi feel like\b",
+    r"\bi tried to\b",
+    r"\bi was responsible for\b",
+    r"\bi helped with\b",
+]
+STRONG_CONFIDENT_PHRASES = [
+    r"\bi led\b",
+    r"\bi architected\b",
+    r"\bi spearheaded\b",
+    r"\bi delivered\b",
+    r"\bi am confident\b",
+    r"\bproven track record\b",
+]
+COLLABORATION_PHRASES = [
+    r"\bcollaborated\b",
+    r"\bpartnered\b",
+    r"\bworked with\b",
+    r"\bcross-functional\b",
+    r"\bteam\b",
+    r"\bmentored\b",
+    r"\bcoordinated\b",
+]
+
+
+def analyze_pronoun_usage(text: str) -> Dict[str, Any]:
+    """Analyzes the balance of pronoun usage."""
+    text_lower = text.lower()
+
+    singular_count = sum(
+        len(re.findall(pattern, text_lower)) for pattern in FIRST_PERSON_SINGULAR
+    )
+    plural_count = sum(
+        len(re.findall(pattern, text_lower)) for pattern in FIRST_PERSON_PLURAL
+    )
+    total = singular_count + plural_count
+
+    if total == 0:
+        return {
+            "ratio": 0.5,
+            "dominant": "neutral",
+            "suggestion": "Consider adding more personal ownership ('I led') or team context ('We collaborated').",
+        }
+
+    ratio = singular_count / total
+    dominant = "individual" if ratio > 0.6 else "team" if ratio < 0.4 else "balanced"
+
+    suggestion = ""
+    if ratio > 0.8:
+        suggestion = "High individual focus. Consider highlighting team collaboration and cross-functional partnerships."
+    elif ratio < 0.2:
+        suggestion = "High team focus. Ensure your individual contributions and leadership are clearly articulated."
+
+    return {"ratio": round(ratio, 2), "dominant": dominant, "suggestion": suggestion}
+
+
+def analyze_sentiment_and_confidence(text: str) -> Dict[str, Any]:
+    """Analyzes sentence structure for confidence and clarity."""
+    text_lower = text.lower()
+
+    weak_count = sum(
+        len(re.findall(pattern, text_lower)) for pattern in PASSIVE_WEAK_PHRASES
+    )
+    strong_count = sum(
+        len(re.findall(pattern, text_lower)) for pattern in STRONG_CONFIDENT_PHRASES
+    )
+    collab_count = sum(
+        len(re.findall(pattern, text_lower)) for pattern in COLLABORATION_PHRASES
+    )
+
+    # Calculate scores (0-100)
+    confidence_score = max(0, min(100, 50 + (strong_count * 10) - (weak_count * 15)))
+    collaboration_score = max(0, min(100, 30 + (collab_count * 12)))
+    clarity_score = max(0, min(100, 100 - (weak_count * 10)))
+
+    suggestions = []
+    if weak_count > 2:
+        suggestions.append(
+            "Replace weak phrases like 'I tried to' or 'I helped with' with strong action verbs like 'I delivered' or 'I executed'."
+        )
+    if strong_count == 0 and weak_count == 0:
+        suggestions.append(
+            "Add more confident, results-oriented language to highlight your achievements."
+        )
+    if collab_count < 2:
+        suggestions.append(
+            "Incorporate more collaboration keywords (e.g., 'partnered', 'cross-functional') to demonstrate teamwork."
+        )
+
+    return {
+        "confidence_score": confidence_score,
+        "collaboration_score": collaboration_score,
+        "clarity_score": clarity_score,
+        "suggestions": suggestions,
+    }
+
+
+def analyze_tone(resume_text: str) -> Dict[str, Any]:
+    """Main function to analyze resume tone and cultural fit."""
+    if not resume_text or not isinstance(resume_text, str):
+        return {}
+
+    pronoun_analysis = analyze_pronoun_usage(resume_text)
+    sentiment_analysis = analyze_sentiment_and_confidence(resume_text)
+
+    # Determine overall tone
+    if (
+        sentiment_analysis["confidence_score"] >= 80
+        and sentiment_analysis["collaboration_score"] >= 60
+    ):
+        overall_tone = "Authoritative & Collaborative"
+    elif sentiment_analysis["confidence_score"] >= 80:
+        overall_tone = "Highly Confident / Individual Contributor"
+    elif sentiment_analysis["collaboration_score"] >= 80:
+        overall_tone = "Team-Oriented / Supportive"
+    else:
+        overall_tone = "Passive / Needs Refinement"
+
+    all_suggestions = sentiment_analysis["suggestions"]
+    if pronoun_analysis["suggestion"]:
+        all_suggestions.append(pronoun_analysis["suggestion"])
+
+    return {
+        "confidence_score": sentiment_analysis["confidence_score"],
+        "collaboration_score": sentiment_analysis["collaboration_score"],
+        "clarity_score": sentiment_analysis["clarity_score"],
+        "overall_tone": overall_tone,
+        "pronoun_dominance": pronoun_analysis["dominant"],
+        "suggestions": list(set(all_suggestions)),  # Remove duplicates
+    }

--- a/backend/analyzer/tone_serializers.py
+++ b/backend/analyzer/tone_serializers.py
@@ -1,0 +1,24 @@
+"""
+Serializers for Tone Analyzer.
+"""
+
+from rest_framework import serializers
+
+
+class ToneAnalysisRequestSerializer(serializers.Serializer):
+    """Validates input for tone analysis."""
+
+    resume_text = serializers.CharField(
+        required=True, allow_blank=False, max_length=10000
+    )
+
+
+class ToneAnalysisResponseSerializer(serializers.Serializer):
+    """Structures the tone analysis response."""
+
+    confidence_score = serializers.IntegerField(min_value=0, max_value=100)
+    collaboration_score = serializers.IntegerField(min_value=0, max_value=100)
+    clarity_score = serializers.IntegerField(min_value=0, max_value=100)
+    overall_tone = serializers.CharField()
+    pronoun_dominance = serializers.CharField()
+    suggestions = serializers.ListField(child=serializers.CharField(), allow_empty=True)

--- a/backend/analyzer/tone_views.py
+++ b/backend/analyzer/tone_views.py
@@ -1,0 +1,49 @@
+"""
+Views for Tone Analyzer.
+"""
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from .tone_analyzer import analyze_tone
+from .tone_serializers import (
+    ToneAnalysisRequestSerializer,
+    ToneAnalysisResponseSerializer,
+)
+
+
+class ToneAnalysisView(APIView):
+    """API View to analyze resume tone and cultural fit."""
+
+    def post(self, request, *args, **kwargs):
+        request_serializer = ToneAnalysisRequestSerializer(data=request.data)
+        if not request_serializer.is_valid():
+            return Response(
+                {"errors": request_serializer.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        resume_text = request_serializer.validated_data["resume_text"]
+
+        try:
+            analysis_result = analyze_tone(resume_text)
+
+            if not analysis_result:
+                return Response(
+                    {"error": "Invalid or empty resume text provided."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            response_serializer = ToneAnalysisResponseSerializer(data=analysis_result)
+            response_serializer.is_valid(raise_exception=True)
+
+            return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            return Response(
+                {
+                    "error": "An unexpected error occurred during tone analysis.",
+                    "details": str(e),
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/frontend/src/components/ToneCultureFitAnalyzer.css
+++ b/frontend/src/components/ToneCultureFitAnalyzer.css
@@ -1,0 +1,245 @@
+.tone-analyzer-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    color: var(--text-primary, #e0e0e0);
+}
+
+.analyzer-title {
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 2rem;
+    font-weight: 700;
+    background: linear-gradient(90deg, #1e90ff, #00cec9);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.analyzer-workspace {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+
+.glass-card {
+    background: var(--glass-bg, rgba(255, 255, 255, 0.05));
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+    border-radius: 16px;
+    padding: 1.5rem;
+}
+
+.glass-card h3 {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 1.25rem;
+    border-bottom: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+    padding-bottom: 0.75rem;
+}
+
+.text-input {
+    width: 100%;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+    border-radius: 8px;
+    padding: 1rem;
+    color: var(--text-primary, #e0e0e0);
+    font-family: inherit;
+    font-size: 1rem;
+    resize: vertical;
+    min-height: 300px;
+    margin-bottom: 1rem;
+}
+
+.text-input:focus {
+    outline: none;
+    border-color: #1e90ff;
+    box-shadow: 0 0 0 3px rgba(30, 144, 255, 0.2);
+}
+
+.glass-button {
+    width: 100%;
+    background: linear-gradient(135deg, #1e90ff, #00cec9);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.glass-button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(30, 144, 255, 0.4);
+}
+
+.glass-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.error-message {
+    color: #ff6b6b;
+    text-align: center;
+    margin-top: 1rem;
+}
+
+.empty-state,
+.loading-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 300px;
+    color: var(--text-secondary, #b0b0b0);
+    font-style: italic;
+    text-align: center;
+}
+
+.results-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.tone-overview {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 12px;
+}
+
+.overall-badge {
+    display: flex;
+    flex-direction: column;
+}
+
+.badge-label {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #b0b0b0);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.badge-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #1e90ff;
+}
+
+.pronoun-info {
+    font-size: 0.95rem;
+    color: var(--text-secondary, #b0b0b0);
+}
+
+.pronoun-info strong {
+    color: var(--text-primary, #e0e0e0);
+}
+
+.score-dimensions {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.dimension-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.dimension-header {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.score-value {
+    font-weight: 700;
+}
+
+.progress-bar-bg {
+    width: 100%;
+    height: 10px;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 5px;
+    overflow: hidden;
+}
+
+.progress-bar-fill {
+    height: 100%;
+    border-radius: 5px;
+    transition: width 0.5s ease;
+}
+
+.suggestions-section h4 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1.1rem;
+}
+
+.suggestions-list {
+    margin: 0;
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.suggestions-list li {
+    background: rgba(255, 165, 2, 0.1);
+    border-left: 3px solid #ffa502;
+    padding: 0.75rem 1rem;
+    border-radius: 0 8px 8px 0;
+    line-height: 1.5;
+    font-size: 0.95rem;
+    color: var(--text-primary, #e0e0e0);
+}
+
+/* Light mode adjustments */
+@media (prefers-color-scheme: light) {
+    .tone-analyzer-container {
+        color: #333333;
+    }
+
+    .glass-card {
+        background: rgba(255, 255, 255, 0.7);
+        border: 1px solid rgba(0, 0, 0, 0.05);
+    }
+
+    .text-input {
+        background: rgba(255, 255, 255, 0.9);
+        border: 1px solid rgba(0, 0, 0, 0.1);
+        color: #333333;
+    }
+
+    .tone-overview {
+        background: rgba(0, 0, 0, 0.03);
+    }
+
+    .progress-bar-bg {
+        background: rgba(0, 0, 0, 0.1);
+    }
+
+    .suggestions-list li {
+        background: rgba(255, 165, 2, 0.05);
+        color: #333333;
+    }
+}
+
+@media (max-width: 768px) {
+    .analyzer-workspace {
+        grid-template-columns: 1fr;
+    }
+
+    .tone-overview {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+    }
+}

--- a/frontend/src/components/ToneCultureFitAnalyzer.tsx
+++ b/frontend/src/components/ToneCultureFitAnalyzer.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import './ToneCultureFitAnalyzer.css';
+
+interface ToneResponse {
+    confidence_score: number;
+    collaboration_score: number;
+    clarity_score: number;
+    overall_tone: string;
+    pronoun_dominance: string;
+    suggestions: string[];
+}
+
+const ToneCultureFitAnalyzer: React.FC = () => {
+    const [resumeText, setResumeText] = useState('');
+    const [results, setResults] = useState<ToneResponse | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    const handleAnalyze = async () => {
+        if (!resumeText.trim()) {
+            setError('Please paste your resume text.');
+            return;
+        }
+
+        setLoading(true);
+        setError('');
+        try {
+            const response = await axios.post('/api/analyze-tone/', {
+                resume_text: resumeText
+            });
+            setResults(response.data);
+        } catch (err: any) {
+            setError(err.response?.data?.error || 'Failed to analyze tone.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const getScoreColor = (score: number) => {
+        if (score >= 80) return '#2ed573';
+        if (score >= 60) return '#ffa502';
+        return '#ff4757';
+    };
+
+    return (
+        <div className="tone-analyzer-container">
+            <h2 className="analyzer-title">Tone & Cultural Fit Analyzer</h2>
+
+            <div className="analyzer-workspace">
+                <div className="input-panel glass-card">
+                    <h3>Paste Resume Text</h3>
+                    <textarea
+                        className="text-input"
+                        value={resumeText}
+                        onChange={(e) => setResumeText(e.target.value)}
+                        placeholder="Paste your resume summary, experience, or full text here to analyze the tone..."
+                        rows={15}
+                    />
+                    <button
+                        className="analyze-btn glass-button"
+                        onClick={handleAnalyze}
+                        disabled={loading}
+                    >
+                        {loading ? 'Analyzing...' : 'Analyze Tone'}
+                    </button>
+                    {error && <p className="error-message">{error}</p>}
+                </div>
+
+                <div className="results-panel glass-card">
+                    <h3>Cultural Fit Assessment</h3>
+
+                    {!results && !loading && (
+                        <div className="empty-state">
+                            <p>Run an analysis to evaluate your resume's confidence, collaboration, and clarity.</p>
+                        </div>
+                    )}
+
+                    {loading && <div className="loading-state">Evaluating linguistic patterns...</div>}
+
+                    {results && !loading && (
+                        <div className="results-content">
+                            <div className="tone-overview">
+                                <div className="overall-badge">
+                                    <span className="badge-label">Overall Tone</span>
+                                    <span className="badge-value">{results.overall_tone}</span>
+                                </div>
+                                <div className="pronoun-info">
+                                    Pronoun Focus: <strong>{results.pronoun_dominance.charAt(0).toUpperCase() + results.pronoun_dominance.slice(1)}</strong>
+                                </div>
+                            </div>
+
+                            <div className="score-dimensions">
+                                <div className="dimension-item">
+                                    <div className="dimension-header">
+                                        <span>Confidence</span>
+                                        <span className="score-value" style={{ color: getScoreColor(results.confidence_score) }}>
+                                            {results.confidence_score}%
+                                        </span>
+                                    </div>
+                                    <div className="progress-bar-bg">
+                                        <div
+                                            className="progress-bar-fill"
+                                            style={{ width: `${results.confidence_score}%`, backgroundColor: getScoreColor(results.confidence_score) }}
+                                        ></div>
+                                    </div>
+                                </div>
+
+                                <div className="dimension-item">
+                                    <div className="dimension-header">
+                                        <span>Collaboration</span>
+                                        <span className="score-value" style={{ color: getScoreColor(results.collaboration_score) }}>
+                                            {results.collaboration_score}%
+                                        </span>
+                                    </div>
+                                    <div className="progress-bar-bg">
+                                        <div
+                                            className="progress-bar-fill"
+                                            style={{ width: `${results.collaboration_score}%`, backgroundColor: getScoreColor(results.collaboration_score) }}
+                                        ></div>
+                                    </div>
+                                </div>
+
+                                <div className="dimension-item">
+                                    <div className="dimension-header">
+                                        <span>Clarity</span>
+                                        <span className="score-value" style={{ color: getScoreColor(results.clarity_score) }}>
+                                            {results.clarity_score}%
+                                        </span>
+                                    </div>
+                                    <div className="progress-bar-bg">
+                                        <div
+                                            className="progress-bar-fill"
+                                            style={{ width: `${results.clarity_score}%`, backgroundColor: getScoreColor(results.clarity_score) }}
+                                        ></div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {results.suggestions.length > 0 && (
+                                <div className="suggestions-section">
+                                    <h4>💡 Actionable Rewriting Suggestions</h4>
+                                    <ul className="suggestions-list">
+                                        {results.suggestions.map((suggestion, index) => (
+                                            <li key={index}>{suggestion}</li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ToneCultureFitAnalyzer;


### PR DESCRIPTION
## 📝 Description

This PR implements a Resume Tone and Sentiment Analyzer for Cultural Fit. It introduces a backend module that evaluates linguistic patterns, pronoun usage, and sentence structure to assess confidence, collaboration, and clarity. The frontend provides a visual breakdown of these dimensions with progress bars and actionable rewriting suggestions to help users align their resume tone with target company cultures.

## 🔗 Related Issue

Closes #949

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [x] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer.tests_tone_analyzer`)
- [x] Manually tested in the browser / API client

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)