### PR TITLE
fix: measure employment gaps between roles, not across them (#1007)

### DIFF
--- a/backend/analyzer/gap_narrative.py
+++ b/backend/analyzer/gap_narrative.py
@@ -7,6 +7,7 @@ positive narrative explanations for various gap reasons.
 
 import re
 from datetime import datetime
+from string import Formatter
 from typing import List, Dict, Any, Optional
 
 MONTH_MAP = {
@@ -35,84 +36,152 @@ MONTH_MAP = {
     "december": 12,
 }
 
+# A break shorter than this is ordinary notice-period/handover slack, not
+# something a candidate needs a story for.
+GAP_THRESHOLD_MONTHS = 3
+
+# Every template is rendered with the same key set (see NARRATIVE_FIELDS), so
+# any template may use any placeholder. Previously "job_market" referenced
+# {certifications}, which was never supplied, and str.format raised KeyError on
+# every gap that reached it.
 NARRATIVE_TEMPLATES = {
     "upskilling": [
-        "During this period, I dedicated my time to intensive upskilling, completing certifications in {skills} to stay current with industry advancements.",
-        "I took a strategic career pause to focus on professional development, acquiring new competencies in {skills} that directly enhance my value in {target_role} roles.",
+        "During this period I focused on deliberate upskilling, completing certifications in {skills} and staying hands-on through {activities}, all of which I bring directly to the {role_after} role.",
+        "I took a strategic career pause to concentrate on professional development, acquiring new competencies in {skills} that map onto what a {target_role} is expected to do on day one.",
     ],
     "caregiving": [
-        "I stepped away from the workforce to provide essential caregiving for a family member. This experience honed my crisis management, empathy, and organizational skills, and I am now fully prepared to re-engage in my career.",
-        "This timeframe was dedicated to family caregiving responsibilities. I maintained my industry knowledge through {activities} and am now eager to bring my refined soft skills and renewed focus to a new role.",
+        "I stepped away from full-time work to provide essential caregiving for a family member. It sharpened my crisis management, prioritisation and organisational skills, and I kept current with {skills} so that I could return to a {role_after} role without a ramp-up period.",
+        "This timeframe was dedicated to family caregiving responsibilities. I maintained my industry knowledge through {activities} and am ready to bring that refined judgement to the {role_after} role.",
     ],
     "freelance": [
-        "I operated as an independent consultant during this time, delivering {deliverables} for various clients. This allowed me to broaden my expertise in {skills} and manage end-to-end project lifecycles.",
-        "This period reflects my work as a freelance professional, where I successfully {achievements}, demonstrating adaptability and self-directed project management.",
+        "I operated as an independent consultant through this period, delivering {deliverables} for a range of clients. It broadened my depth in {skills} and put me across the whole project lifecycle rather than one slice of it.",
+        "This period reflects freelance work, during which I {achievements}. It demanded self-directed planning and client communication, both of which carry straight into the {role_after} role.",
     ],
     "health": [
-        "I took a necessary medical leave to address a health matter, which is now fully resolved. I used part of this time to {activities}, and I am excited to return to the workforce with renewed energy.",
-        "This gap was due to a temporary health situation that has been completely resolved. I remained engaged with the industry through {activities} and am ready to contribute immediately.",
+        "I took a necessary medical leave to address a health matter that is now fully resolved. I used part of that time to {activities}, and I am returning with full capacity for a {role_after} role.",
+        "This gap was a temporary health situation, since completely resolved. I stayed engaged with the field through {activities} and with {skills} in particular, and can contribute immediately.",
     ],
     "job_market": [
-        "I have been strategically evaluating opportunities to ensure my next role aligns with my long-term career goals in {target_role}, while actively maintaining my skills through {activities}.",
-        "Due to broader market conditions, I have been selectively pursuing roles that match my expertise in {skills}, using this time to refine my portfolio and complete {certifications}.",
+        "I have been deliberately selective about my next move, holding out for a {role_after} role that fits my longer-term direction in {target_role}, and keeping my skills sharp through {activities}.",
+        "Broader market conditions lengthened my search, so I used the time to deepen my expertise in {skills}, rebuild my portfolio and complete {certifications}.",
     ],
 }
+
+# Defaults for anything the caller does not supply. Keys are the union of every
+# placeholder used across NARRATIVE_TEMPLATES; keeping them in one place is what
+# makes "add a template" a safe change.
+NARRATIVE_FIELDS = {
+    "skills": "new technologies",
+    "target_role": "this field",
+    "activities": "independent study and industry reading",
+    "deliverables": "scalable software solutions",
+    "achievements": "streamlined client workflows",
+    "certifications": "additional professional certifications",
+    "role_after": "next",
+    "role_before": "previous",
+}
+
+
+class _DefaultingFormatter(Formatter):
+    """``str.format`` that substitutes a placeholder name instead of raising.
+
+    A template is content, and content gets edited by people who are not
+    looking at the call site. Losing the whole response to a ``KeyError``
+    because someone added ``{mentors}`` to a sentence is not a reasonable
+    failure mode for a text generator.
+    """
+
+    def get_value(self, key, args, kwargs):
+        if isinstance(key, str):
+            return kwargs.get(key, NARRATIVE_FIELDS.get(key, ""))
+        return super().get_value(key, args, kwargs)
+
+
+_FORMATTER = _DefaultingFormatter()
 
 
 def parse_date(date_str: str) -> Optional[datetime]:
     """Parses various date string formats into a datetime object."""
+    if not date_str:
+        return None
+
     date_str = date_str.strip().lower()
     if date_str in ["present", "now", "current"]:
         return datetime.now()
 
-    parts = date_str.split()
+    parts = re.split(r"[\s\-/]+", date_str)
     if len(parts) >= 2:
         month_str, year_str = parts[0], parts[1]
         month = MONTH_MAP.get(month_str[:3])
         if month and year_str.isdigit():
             return datetime(year=int(year_str), month=month, day=1)
+        # Numeric "2021-03" / "2021/03" order, as well as "03-2021".
+        if month_str.isdigit() and year_str.isdigit():
+            a, b = int(month_str), int(year_str)
+            if 1 <= b <= 12 and a > 12:
+                return datetime(year=a, month=b, day=1)
+            if 1 <= a <= 12 and b > 12:
+                return datetime(year=b, month=a, day=1)
     elif len(parts) == 1 and parts[0].isdigit():
         return datetime(year=int(parts[0]), month=1, day=1)
 
     return None
 
 
+def months_between(earlier: datetime, later: datetime) -> int:
+    """Whole months from ``earlier`` to ``later``. Negative if they overlap."""
+    return (later.year - earlier.year) * 12 + (later.month - earlier.month)
+
+
 def detect_gaps(timeline_data: List[Dict[str, str]]) -> List[Dict[str, Any]]:
-    """Detects employment gaps greater than 3 months between roles."""
-    gaps = []
+    """Detects employment gaps longer than ``GAP_THRESHOLD_MONTHS`` between roles.
+
+    A gap is the stretch between the end of the earlier role and the start of
+    the one that follows it. The previous implementation measured the later
+    role's *end* back to the earlier role's *start*, which is the span covering
+    both jobs rather than the space between them: it reported 79 months for a
+    13-month gap, grew by a month every month whenever the later role was still
+    "Present", and reported a gap for back-to-back roles that had none.
+    """
+    gaps: List[Dict[str, Any]] = []
     if not timeline_data or len(timeline_data) < 2:
         return gaps
 
-    # Sort by start date descending (most recent first)
+    # Most recent first.
     sorted_timeline = sorted(
         timeline_data,
-        key=lambda x: parse_date(x.get("start_date", "2000-01")) or datetime.min,
+        key=lambda x: parse_date(x.get("start_date", "")) or datetime.min,
         reverse=True,
     )
 
     for i in range(len(sorted_timeline) - 1):
-        current_role = sorted_timeline[i]
-        prev_role = sorted_timeline[i + 1]
+        later_role = sorted_timeline[i]
+        earlier_role = sorted_timeline[i + 1]
 
-        current_end = parse_date(current_role.get("end_date", "present"))
-        prev_start = parse_date(prev_role.get("start_date", "2000-01"))
+        # The gap runs from when the earlier role ended to when the later one
+        # began -- not the other two endpoints.
+        gap_start = parse_date(earlier_role.get("end_date", "")) or None
+        gap_end = parse_date(later_role.get("start_date", "")) or None
 
-        if current_end and prev_start:
-            # Calculate difference in months
-            diff_months = (current_end.year - prev_start.year) * 12 + (
-                current_end.month - prev_start.month
-            )
+        if not gap_start or not gap_end:
+            continue
 
-            if diff_months > 3:
-                gaps.append(
-                    {
-                        "role_before": prev_role.get("role", "Previous Role"),
-                        "role_after": current_role.get("role", "Current Role"),
-                        "start_date": current_end.strftime("%b %Y"),
-                        "end_date": prev_start.strftime("%b %Y"),
-                        "duration_months": diff_months,
-                    }
-                )
+        duration = months_between(gap_start, gap_end)
+
+        # <= 0 means the roles overlap (concurrent or contiguous work), which is
+        # not a gap at all.
+        if duration <= GAP_THRESHOLD_MONTHS:
+            continue
+
+        gaps.append(
+            {
+                "role_before": earlier_role.get("role", "Previous Role"),
+                "role_after": later_role.get("role", "Current Role"),
+                "start_date": gap_start.strftime("%b %Y"),
+                "end_date": gap_end.strftime("%b %Y"),
+                "duration_months": duration,
+            }
+        )
 
     return gaps
 
@@ -122,23 +191,27 @@ def generate_narratives(
 ) -> List[Dict[str, Any]]:
     """Generates narrative options for each detected gap."""
     results = []
-    skills = context.get("skills", "new technologies")
-    target_role = context.get("target_role", "this field")
-    activities = context.get("activities", "independent study and industry reading")
+    context = context or {}
 
     for gap in gaps:
+        # Per-gap, so the narrative can name the role the candidate returned to
+        # instead of being generic. Caller-supplied context wins; the gap
+        # supplies role_before/role_after; NARRATIVE_FIELDS backs both.
+        fields = dict(NARRATIVE_FIELDS)
+        fields["role_before"] = gap.get("role_before") or fields["role_before"]
+        fields["role_after"] = gap.get("role_after") or fields["role_after"]
+        for key, value in context.items():
+            if value:
+                fields[key] = value
+
         narratives = []
         for category, templates in NARRATIVE_TEMPLATES.items():
             for template in templates[:2]:  # Take top 2 templates per category
-                narrative = template.format(
-                    skills=skills,
-                    target_role=target_role,
-                    activities=activities,
-                    deliverables="scalable software solutions",
-                    achievements="streamlined client workflows",
-                )
                 narratives.append(
-                    {"category": category.capitalize(), "text": narrative}
+                    {
+                        "category": category.replace("_", " ").title(),
+                        "text": _FORMATTER.vformat(template, (), fields),
+                    }
                 )
 
         results.append({**gap, "narratives": narratives})

--- a/backend/analyzer/tests_gap_narrative.py
+++ b/backend/analyzer/tests_gap_narrative.py
@@ -2,8 +2,18 @@
 Unit tests for Gap Narrative Builder.
 """
 
+from datetime import datetime
+from unittest.mock import patch
+
 from django.test import TestCase
-from .gap_narrative import parse_date, detect_gaps, generate_narratives
+
+from .gap_narrative import (
+    NARRATIVE_TEMPLATES,
+    detect_gaps,
+    generate_narratives,
+    months_between,
+    parse_date,
+)
 
 
 class GapNarrativeTests(TestCase):
@@ -59,3 +69,278 @@ class GapNarrativeTests(TestCase):
         self.assertIn("Python", results[0]["narratives"][0]["text"])
         self.assertIn("Senior Dev", results[0]["narratives"][0]["text"])
         self.assertIn("open source contributions", results[0]["narratives"][0]["text"])
+
+
+class DetectGapsIntervalTests(TestCase):
+    """The interval detect_gaps measures, and the boundaries it reports.
+
+    These cover the arithmetic directly: the old implementation measured the
+    later role's end back to the earlier role's start, so it returned the span
+    covering both jobs instead of the space between them.
+    """
+
+    def test_gap_is_measured_from_previous_end_to_next_start(self):
+        timeline = [
+            {"role": "Senior Dev", "start_date": "Jan 2022", "end_date": "Dec 2023"},
+            {"role": "Dev", "start_date": "Jan 2019", "end_date": "Dec 2020"},
+        ]
+        gaps = detect_gaps(timeline)
+        self.assertEqual(len(gaps), 1)
+        # Dec 2020 -> Jan 2022, not Dec 2023 -> Jan 2019.
+        self.assertEqual(gaps[0]["duration_months"], 13)
+
+    def test_gap_length_is_independent_of_todays_date(self):
+        """A gap between two closed roles must not drift over time.
+
+        The old arithmetic anchored on the later role's end date, so whenever
+        that was "Present" the reported gap grew by a month every month.
+        """
+        closed = [
+            {"role": "B", "start_date": "Jan 2022", "end_date": "Dec 2022"},
+            {"role": "A", "start_date": "Jan 2019", "end_date": "Jan 2021"},
+        ]
+        open_ended = [
+            {"role": "B", "start_date": "Jan 2022", "end_date": "Present"},
+            {"role": "A", "start_date": "Jan 2019", "end_date": "Jan 2021"},
+        ]
+        self.assertEqual(
+            detect_gaps(closed)[0]["duration_months"],
+            detect_gaps(open_ended)[0]["duration_months"],
+        )
+
+    def test_reported_boundaries_bound_the_gap_in_order(self):
+        timeline = [
+            {"role": "B", "start_date": "Jun 2022", "end_date": "Present"},
+            {"role": "A", "start_date": "Jan 2019", "end_date": "Feb 2021"},
+        ]
+        gap = detect_gaps(timeline)[0]
+        self.assertEqual(gap["start_date"], "Feb 2021")
+        self.assertEqual(gap["end_date"], "Jun 2022")
+        self.assertEqual(gap["role_before"], "A")
+        self.assertEqual(gap["role_after"], "B")
+
+    def test_contiguous_roles_produce_no_gap(self):
+        timeline = [
+            {"role": "B", "start_date": "Jan 2022", "end_date": "Present"},
+            {"role": "A", "start_date": "Jan 2020", "end_date": "Dec 2021"},
+        ]
+        self.assertEqual(detect_gaps(timeline), [])
+
+    def test_overlapping_roles_produce_no_gap(self):
+        """Concurrent roles gave a negative interval; it must not be reported."""
+        timeline = [
+            {"role": "Consultant", "start_date": "Jan 2021", "end_date": "Present"},
+            {"role": "Engineer", "start_date": "Jan 2019", "end_date": "Dec 2022"},
+        ]
+        self.assertEqual(detect_gaps(timeline), [])
+
+    def test_gap_exactly_at_threshold_is_not_reported(self):
+        timeline = [
+            {"role": "B", "start_date": "Apr 2022", "end_date": "Present"},
+            {"role": "A", "start_date": "Jan 2020", "end_date": "Jan 2022"},
+        ]
+        self.assertEqual(detect_gaps(timeline), [])
+
+    def test_gap_one_month_past_threshold_is_reported(self):
+        timeline = [
+            {"role": "B", "start_date": "May 2022", "end_date": "Present"},
+            {"role": "A", "start_date": "Jan 2020", "end_date": "Jan 2022"},
+        ]
+        gaps = detect_gaps(timeline)
+        self.assertEqual(len(gaps), 1)
+        self.assertEqual(gaps[0]["duration_months"], 4)
+
+    def test_multiple_gaps_across_three_roles(self):
+        timeline = [
+            {"role": "C", "start_date": "Jan 2023", "end_date": "Present"},
+            {"role": "B", "start_date": "Jan 2021", "end_date": "Jan 2022"},
+            {"role": "A", "start_date": "Jan 2018", "end_date": "Jan 2020"},
+        ]
+        gaps = detect_gaps(timeline)
+        self.assertEqual(len(gaps), 2)
+        self.assertEqual(
+            sorted(g["duration_months"] for g in gaps), [12, 12]
+        )
+
+    def test_unsorted_input_is_ordered_before_comparison(self):
+        """Order of the incoming list must not change the answer."""
+        entries = [
+            {"role": "A", "start_date": "Jan 2019", "end_date": "Jan 2020"},
+            {"role": "C", "start_date": "Jan 2023", "end_date": "Present"},
+            {"role": "B", "start_date": "Jan 2021", "end_date": "Jan 2022"},
+        ]
+        self.assertEqual(len(detect_gaps(entries)), 2)
+
+    def test_unparseable_boundary_is_skipped_not_guessed(self):
+        timeline = [
+            {"role": "B", "start_date": "Jan 2022", "end_date": "Present"},
+            {"role": "A", "start_date": "Jan 2019", "end_date": "sometime in 2020"},
+        ]
+        self.assertEqual(detect_gaps(timeline), [])
+
+    def test_single_role_and_empty_timeline(self):
+        self.assertEqual(detect_gaps([]), [])
+        self.assertEqual(
+            detect_gaps([{"role": "A", "start_date": "Jan 2020", "end_date": "Present"}]),
+            [],
+        )
+
+
+class MonthsBetweenTests(TestCase):
+    """The extracted interval helper."""
+
+    def test_same_month_is_zero(self):
+        self.assertEqual(
+            months_between(datetime(2021, 5, 1), datetime(2021, 5, 1)), 0
+        )
+
+    def test_forward_interval_counts_whole_months(self):
+        self.assertEqual(
+            months_between(datetime(2020, 12, 1), datetime(2022, 1, 1)), 13
+        )
+
+    def test_reversed_interval_is_negative(self):
+        self.assertEqual(
+            months_between(datetime(2022, 1, 1), datetime(2020, 12, 1)), -13
+        )
+
+
+class ParseDateTests(TestCase):
+    """Date formats that turn up in real timeline entries."""
+
+    def test_abbreviated_and_full_month_names(self):
+        self.assertEqual(parse_date("Mar 2021"), datetime(2021, 3, 1))
+        self.assertEqual(parse_date("March 2021"), datetime(2021, 3, 1))
+        self.assertEqual(parse_date("SEPTEMBER 2019"), datetime(2019, 9, 1))
+
+    def test_year_only(self):
+        self.assertEqual(parse_date("2022"), datetime(2022, 1, 1))
+
+    def test_numeric_year_month_either_order(self):
+        self.assertEqual(parse_date("2021-03"), datetime(2021, 3, 1))
+        self.assertEqual(parse_date("03/2021"), datetime(2021, 3, 1))
+
+    def test_present_synonyms_resolve_to_now(self):
+        for token in ("Present", "now", "CURRENT"):
+            self.assertIsNotNone(parse_date(token))
+
+    def test_unparseable_and_empty_return_none(self):
+        self.assertIsNone(parse_date("Invalid Date"))
+        self.assertIsNone(parse_date(""))
+        self.assertIsNone(parse_date("   "))
+
+
+class GenerateNarrativesTests(TestCase):
+    """Rendering, including the placeholder that used to raise."""
+
+    GAP = {
+        "role_before": "Dev",
+        "role_after": "Senior Dev",
+        "start_date": "Jan 2021",
+        "end_date": "Jan 2022",
+        "duration_months": 12,
+    }
+
+    def test_every_template_renders_without_raising(self):
+        """job_market referenced {certifications}, which was never passed.
+
+        NARRATIVE_TEMPLATES iterates in insertion order and job_market is last,
+        so this raised KeyError for every gap that reached it -- not
+        conditionally, always.
+        """
+        results = generate_narratives([self.GAP], {"skills": "Python"})
+        texts = [n["text"] for n in results[0]["narratives"]]
+        self.assertEqual(len(texts), 2 * len(NARRATIVE_TEMPLATES))
+        for text in texts:
+            self.assertNotIn("{", text)
+            self.assertNotIn("}", text)
+
+    def test_certifications_placeholder_is_filled(self):
+        results = generate_narratives(
+            [self.GAP], {"certifications": "the AWS Solutions Architect exam"}
+        )
+        texts = [n["text"] for n in results[0]["narratives"]]
+        self.assertTrue(
+            any("AWS Solutions Architect" in t for t in texts),
+            "caller-supplied certifications should reach the job_market template",
+        )
+
+    def test_unknown_placeholder_in_a_template_does_not_raise(self):
+        """Adding a placeholder to a template must not break the endpoint."""
+        with patch.dict(
+            NARRATIVE_TEMPLATES,
+            {"custom": ["A sentence with an {undeclared_field} in it."]},
+        ):
+            results = generate_narratives([self.GAP], {})
+        self.assertTrue(results)
+
+    def test_narratives_name_the_role_being_returned_to(self):
+        results = generate_narratives([self.GAP], {"skills": "Python"})
+        texts = [n["text"] for n in results[0]["narratives"]]
+        self.assertTrue(any("Senior Dev" in t for t in texts))
+
+    def test_caller_context_overrides_defaults(self):
+        results = generate_narratives(
+            [self.GAP],
+            {
+                "skills": "Rust",
+                "activities": "maintaining an open source crate",
+                "deliverables": "three production data pipelines",
+                "achievements": "shipped a billing rewrite",
+            },
+        )
+        joined = " ".join(n["text"] for n in results[0]["narratives"])
+        self.assertIn("Rust", joined)
+        self.assertIn("maintaining an open source crate", joined)
+        self.assertIn("three production data pipelines", joined)
+        self.assertIn("shipped a billing rewrite", joined)
+
+    def test_blank_context_values_fall_back_to_defaults(self):
+        results = generate_narratives([self.GAP], {"skills": ""})
+        joined = " ".join(n["text"] for n in results[0]["narratives"])
+        self.assertIn("new technologies", joined)
+
+    def test_missing_context_uses_defaults_without_raising(self):
+        results = generate_narratives([self.GAP], {})
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0]["narratives"])
+
+    def test_gap_fields_are_preserved_alongside_narratives(self):
+        results = generate_narratives([self.GAP], {})
+        for key, value in self.GAP.items():
+            self.assertEqual(results[0][key], value)
+
+    def test_no_gaps_yields_no_results(self):
+        self.assertEqual(generate_narratives([], {"skills": "Python"}), [])
+
+    def test_category_labels_are_human_readable(self):
+        results = generate_narratives([self.GAP], {})
+        categories = {n["category"] for n in results[0]["narratives"]}
+        self.assertIn("Job Market", categories)
+        self.assertIn("Upskilling", categories)
+
+
+class GapNarrativeEndToEndTests(TestCase):
+    """detect_gaps feeding generate_narratives, the way the view calls it."""
+
+    def test_clean_history_produces_no_gaps_and_no_narratives(self):
+        timeline = [
+            {"role": "Senior Dev", "start_date": "Jan 2022", "end_date": "Present"},
+            {"role": "Dev", "start_date": "Jan 2020", "end_date": "Dec 2021"},
+        ]
+        gaps = detect_gaps(timeline)
+        self.assertEqual(generate_narratives(gaps, {"skills": "Python"}), [])
+
+    def test_real_gap_produces_narratives_naming_the_next_role(self):
+        timeline = [
+            {"role": "Staff Engineer", "start_date": "Jan 2022", "end_date": "Present"},
+            {"role": "Engineer", "start_date": "Jan 2018", "end_date": "Dec 2020"},
+        ]
+        results = generate_narratives(
+            detect_gaps(timeline), {"skills": "Go", "activities": "conference talks"}
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["duration_months"], 13)
+        joined = " ".join(n["text"] for n in results[0]["narratives"])
+        self.assertIn("Staff Engineer", joined)
+        self.assertIn("Go", joined)


### PR DESCRIPTION
Closes #1007

## The interval was wrong

`detect_gaps` sorts the timeline most-recent-first, so in the loop `sorted_timeline[i]` is the **newer** role and `sorted_timeline[i + 1]` is the **older** one. It then measured:

```python
current_end = parse_date(current_role.get("end_date", "present"))   # newer role's END
prev_start  = parse_date(prev_role.get("start_date", "2000-01"))    # older role's START
diff_months = (current_end.year - prev_start.year) * 12 + (...)
```

That is the span *covering both jobs*, not the space between them. A gap runs from the earlier role's **end** to the later role's **start**.

| | Reported before | Correct |
|---|---|---|
| Jan 2019–Dec 2020, then Jan 2022–Present | 79 months | 13 months |
| Jan 2020–Dec 2021, then Jan 2022–Present (no gap) | 79 months | none |

The second row is the one that mattered most: **a candidate with an unbroken work history was told they had a six-and-a-half-year employment gap** and offered narratives to explain it away.

There was also a time-dependency. Because the newer role's `end_date` is normally `Present`, `parse_date` returned `datetime.now()` and the reported gap length grew by a month every month. Two people running the same resume six months apart got different numbers. There is now a test that pins a gap between two closed roles to the same value as the equivalent open-ended pair.

The reported `start_date` / `end_date` were the same wrong pair and inverted — `start_date` came from the newer boundary, `end_date` from the older — so the range read backwards.

### What changed

- The gap is `earlier_role.end_date → later_role.start_date`.
- Overlapping (concurrent) roles produce a negative interval and are not reported. Previously the covering-span arithmetic made these look like large gaps.
- Interval arithmetic pulled out into `months_between(earlier, later)`, so the direction is stated once and is testable on its own.
- `GAP_THRESHOLD_MONTHS = 3` replaces the bare `3`.

## `generate_narratives` raised on every gap

The `job_market` template references `{certifications}`. `generate_narratives` passed `skills`, `target_role`, `activities`, `deliverables` and `achievements` — not that one. `NARRATIVE_TEMPLATES` iterates in insertion order and `job_market` is last, so `KeyError: 'certifications'` was raised for **every** gap that got that far, not conditionally on input. Combined with the bug above, that included resumes with no real gap.

Rather than just adding the missing key, the placeholders now live in one place:

```python
NARRATIVE_FIELDS = {
    "skills": "new technologies",
    "certifications": "additional professional certifications",
    ...
}
```

and templates render through a `Formatter` subclass that falls back to that table. A template is content; someone editing a sentence to add `{mentors}` should not be able to take the endpoint down from a string literal. There is a test for exactly that.

Two smaller things in the same function:

- `deliverables` and `achievements` were hardcoded, so the freelance narratives claimed the user had delivered "scalable software solutions" regardless of what they did. They now come from `context` like every other field.
- Narratives never mentioned the role the candidate returned to, though `gap["role_after"]` was sitting in the dict. Templates can now use `{role_after}`.

`parse_date` also picked up numeric `2021-03` / `03/2021` forms and returns `None` for blank input instead of raising on `.strip()`.

## Tests

31 added (4 → 35), covering:

- the interval, both boundaries, and that the length does not drift with today's date
- threshold edges: exactly 3 months (no gap) vs 4 (gap)
- contiguous, overlapping, unsorted, single-entry and empty timelines
- unparseable boundaries skipped rather than guessed
- `months_between` in both directions
- every accepted date format
- every template rendering with no leftover braces, the `{certifications}` path, an undeclared placeholder, context overrides and blank-value fallback

```
Ran 35 tests in 0.005s
OK
```

Full backend suite: the three `tests_gap_narrative` failures are gone, no new ones. The six that remain on this branch are the separate problems in #1006, #1008 and #1009.

## One thing this does not fix

`GapNarrativeView` is still unrouted, and `GapNarrativeResponseSerializer` requires a `total_narratives_generated` field that the view never builds — so once routed it would 500 on success regardless of this PR. Both belong to #1006 and are handled there.
