### PR TITLE
fix: score the evidence the resume actually contains (#1008)

### DIFF
--- a/backend/analyzer/proficiency_estimator.py
+++ b/backend/analyzer/proficiency_estimator.py
@@ -47,6 +47,62 @@ QUANTIFIABLE_METRICS = [
     r"\b\d+\s+team members?\b",
 ]
 
+# How many sentences either side of a skill mention count as context for it.
+#
+# Resumes name a skill in one sentence and say what was built with it in the
+# next -- "8+ years of experience in Python. I architected a system serving 10
+# million users." Reading only the sentence containing the token throws away
+# the half that carries the evidence.
+SKILL_CONTEXT_WINDOW = 1
+
+# Mentions to consider, and the ceiling on snippets handed back in the
+# response so a skill named throughout a resume does not return the resume.
+MAX_SKILL_MENTIONS = 3
+MAX_CONTEXT_SNIPPETS = 6
+
+
+def build_skill_context(
+    sentences: List[str], skill_lower: str
+) -> Tuple[List[str], List[str]]:
+    """Split the evidence for ``skill_lower`` into primary and supporting.
+
+    Primary: the sentences that name the skill. These decide the proficiency
+    *level*, because the verb attached to a skill is the claim being made about
+    it -- "basic knowledge of Java" is a beginner claim no matter what the next
+    sentence says.
+
+    Supporting: those sentences plus their immediate neighbours. Used only to
+    corroborate a claim with numbers. This is what lets
+
+        "8+ years of experience in Python. I architected a system serving
+         10 million users, optimizing performance by 40%."
+
+    count the metrics in the second sentence, which the previous
+    sentence-must-contain-the-token rule discarded.
+
+    Keeping the two apart matters: a single window would let a neighbouring
+    sentence about a *different* skill donate its level indicators, so
+    "Basic knowledge of Java. 10+ years of Python, architected systems."
+    would promote Java to Expert.
+
+    Both lists come back in document order with duplicates removed.
+    """
+    mention_indices = [i for i, s in enumerate(sentences) if skill_lower in s]
+    if not mention_indices:
+        return [], []
+
+    considered = mention_indices[:MAX_SKILL_MENTIONS]
+    primary = [sentences[i] for i in considered]
+
+    selected = set()
+    for index in considered:
+        low = max(0, index - SKILL_CONTEXT_WINDOW)
+        high = min(len(sentences), index + SKILL_CONTEXT_WINDOW + 1)
+        selected.update(range(low, high))
+
+    supporting = [sentences[i] for i in sorted(selected)][:MAX_CONTEXT_SNIPPETS]
+    return primary, supporting
+
 
 def analyze_skill_context(resume_text: str, skill: str) -> Dict[str, Any]:
     """
@@ -55,11 +111,12 @@ def analyze_skill_context(resume_text: str, skill: str) -> Dict[str, Any]:
     text_lower = resume_text.lower()
     skill_lower = skill.lower()
 
-    # Find sentences containing the skill
     sentences = re.split(r"(?<=[.!?])\s+", text_lower)
-    relevant_sentences = [s for s in sentences if skill_lower in s]
+    primary_snippets, context_snippets = build_skill_context(sentences, skill_lower)
 
-    context_snippets = relevant_sentences[:3]  # Keep up to 3 snippets
+    # Level comes from the sentences that name the skill; metrics may come from
+    # the sentence next door. See build_skill_context.
+    claim_text = " ".join(primary_snippets)
     context_text = " ".join(context_snippets)
 
     score = 50  # Base score
@@ -67,21 +124,23 @@ def analyze_skill_context(resume_text: str, skill: str) -> Dict[str, Any]:
     level = "Intermediate"  # Default
 
     # Check for beginner indicators
-    if any(re.search(indicator, context_text) for indicator in BEGINNER_INDICATORS):
+    if any(re.search(indicator, claim_text) for indicator in BEGINNER_INDICATORS):
         score -= 30
         level = "Beginner"
 
     # Check for advanced indicators
-    if any(re.search(indicator, context_text) for indicator in ADVANCED_INDICATORS):
+    if any(re.search(indicator, claim_text) for indicator in ADVANCED_INDICATORS):
         score += 20
         level = "Advanced"
 
     # Check for expert indicators
-    if any(re.search(indicator, context_text) for indicator in EXPERT_INDICATORS):
+    if any(re.search(indicator, claim_text) for indicator in EXPERT_INDICATORS):
         score += 30
         level = "Expert"
 
-    # Check for quantifiable metrics (boosts confidence)
+    # Quantifiable metrics corroborate the claim, and are read from the wider
+    # window: people put the number in the sentence after the one naming the
+    # skill at least as often as in it.
     metrics_found = [m for m in QUANTIFIABLE_METRICS if re.search(m, context_text)]
     if metrics_found:
         score += 15

--- a/backend/analyzer/project_extractor.py
+++ b/backend/analyzer/project_extractor.py
@@ -17,16 +17,39 @@ PROJECT_HEADERS = [
     r"side projects",
 ]
 
+# (label, pattern). The label is what goes back in ``metrics_found``, which is
+# part of the API response -- deriving it from the regex source, as this used
+# to, produced strings like "X%" and "X users" and could not survive a pattern
+# gaining a group.
 METRIC_PATTERNS = [
-    r"\d+%",
-    r"\d+\s+users?",
-    r"\d+\s+million",
-    r"\d+x",
-    r"\$\d+",
-    r"\d+\s+team members?",
-    r"reduced by \d+",
-    r"increased by \d+",
+    ("percentage", r"\d+(?:\.\d+)?\s*%"),
+    # "10k users", "2.5M requests", "1B rows". The old r"\d+\s+users?" required
+    # whitespace between the number and the noun, so "10k users" never matched:
+    # \d+ consumed "10" and \s+ then hit "k". Abbreviated magnitudes are the
+    # common way to write these on a resume.
+    ("scale", r"\d+(?:\.\d+)?\s*[kKmMbB]\b"),
+    ("scale", r"\d+\s+(?:users?|customers?|requests?|records?|rows?|downloads?)"),
+    ("scale", r"\d+\s+(?:million|billion|thousand)"),
+    ("multiplier", r"\d+(?:\.\d+)?x\b"),
+    ("monetary", r"\$\s?\d+(?:[.,]\d+)?\s*[kKmMbB]?"),
+    ("team size", r"\d+\s+(?:team members?|engineers?|developers?|people)"),
+    # Any tense, and allowing an object between the verb and "by":
+    # "increasing sales by 20%", "reduced latency by 40ms", "cut build times by
+    # half". The old patterns were the two literals "reduced by" and
+    # "increased by", so the participle forms people actually write were missed.
+    (
+        "improvement",
+        r"\b(?:increas|reduc|decreas|improv|boost|rais|lower|cut|grew|grow|"
+        r"accelerat|boost|boosted|shrank|shrink|optimi[sz])\w*\s+"
+        r"(?:\w+\s+){0,3}by\s+\d+",
+    ),
+    ("duration", r"\d+\s*(?:ms|seconds?|minutes?|hours?)\b"),
 ]
+
+# Ceiling on the metric contribution. Each distinct kind of metric is worth 15,
+# but one bullet quoting a percentage, a scale and a dollar figure describes one
+# achievement, not three, and should not be able to carry the whole score.
+MAX_METRIC_SCORE = 45
 
 ACTION_VERBS = [
     r"\barchitected\b",
@@ -116,12 +139,11 @@ def score_project_impact(project: Dict[str, Any]) -> Dict[str, Any]:
     tech_found = []
 
     # Check for metrics
-    for pattern in METRIC_PATTERNS:
-        if re.search(pattern, desc, re.IGNORECASE):
-            score += 15
-            metrics_found.append(
-                pattern.replace("\\", "").replace("d+", "X").replace("s+", " ")
-            )
+    for label, pattern in METRIC_PATTERNS:
+        if re.search(pattern, desc, re.IGNORECASE) and label not in metrics_found:
+            metrics_found.append(label)
+
+    score += min(len(metrics_found) * 15, MAX_METRIC_SCORE)
 
     if not metrics_found:
         suggestions.append(
@@ -152,7 +174,7 @@ def score_project_impact(project: Dict[str, Any]) -> Dict[str, Any]:
         "name": project["name"],
         "description": desc,
         "impact_score": min(100, score),
-        "metrics_found": list(set(metrics_found)),
+        "metrics_found": metrics_found,
         "technologies": list(set(tech_found)),
         "suggestions": suggestions,
     }

--- a/backend/analyzer/tests_proficiency_estimator.py
+++ b/backend/analyzer/tests_proficiency_estimator.py
@@ -3,7 +3,11 @@ Unit tests for Skill Proficiency Estimator.
 """
 
 from django.test import TestCase
-from .proficiency_estimator import analyze_skill_context, estimate_all_proficiencies
+from .proficiency_estimator import (
+    analyze_skill_context,
+    build_skill_context,
+    estimate_all_proficiencies,
+)
 
 
 class ProficiencyEstimatorTests(TestCase):
@@ -47,3 +51,95 @@ class ProficiencyEstimatorTests(TestCase):
         self.assertGreater(
             results[0]["confidence_score"], results[1]["confidence_score"]
         )
+
+
+class SkillContextWindowTests(TestCase):
+    """What counts as evidence for a skill.
+
+    Previously only sentences literally containing the skill token were read,
+    so the sentence next door -- which is where people put the impact and the
+    numbers -- was discarded.
+    """
+
+    EXPERT_RESUME = (
+        "I have 8+ years of experience in Python. "
+        "I architected a system serving 10 million users, "
+        "optimizing performance by 40%."
+    )
+
+    def test_metrics_in_the_adjacent_sentence_are_counted(self):
+        result = analyze_skill_context(self.EXPERT_RESUME, "Python")
+        self.assertEqual(result["estimated_level"], "Expert")
+        self.assertGreater(result["confidence_score"], 80)
+
+    def test_quantified_expertise_is_not_flagged_unsupported(self):
+        """The evidence is one sentence away; we should not accuse the user."""
+        result = analyze_skill_context(self.EXPERT_RESUME, "Python")
+        self.assertEqual(result["warnings"], [])
+
+    def test_context_snippets_include_the_neighbour(self):
+        result = analyze_skill_context(self.EXPERT_RESUME, "Python")
+        joined = " ".join(result["context_snippets"])
+        self.assertIn("architected", joined)
+        self.assertIn("10 million", joined)
+
+    def test_neighbour_cannot_donate_a_proficiency_level(self):
+        """A window must not let one skill inherit another's level.
+
+        "Basic knowledge of Java" is a beginner claim regardless of the Python
+        sentence beside it. Level comes from the sentence naming the skill;
+        only metrics are read from the wider window.
+        """
+        resume = (
+            "Basic knowledge of Java. "
+            "10+ years of experience in Python, architected systems."
+        )
+        java = analyze_skill_context(resume, "Java")
+        python = analyze_skill_context(resume, "Python")
+
+        self.assertEqual(java["estimated_level"], "Beginner")
+        self.assertEqual(python["estimated_level"], "Expert")
+        self.assertGreater(python["confidence_score"], java["confidence_score"])
+
+    def test_unsupported_claim_still_flagged_when_nothing_corroborates_it(self):
+        result = analyze_skill_context("I am a subject matter expert in Go.", "Go")
+        self.assertEqual(result["estimated_level"], "Expert")
+        self.assertIn("lacks quantifiable metrics", result["warnings"][0])
+
+    def test_skill_never_mentioned_yields_no_context(self):
+        result = analyze_skill_context("I write a lot of Python.", "Haskell")
+        self.assertEqual(result["context_snippets"], [])
+        self.assertEqual(result["estimated_level"], "Intermediate")
+
+
+class BuildSkillContextTests(TestCase):
+    """The primary/supporting split, tested directly."""
+
+    SENTENCES = ["alpha one.", "beta two.", "gamma three.", "delta four."]
+
+    def test_primary_is_only_the_mentioning_sentence(self):
+        primary, _ = build_skill_context(self.SENTENCES, "gamma")
+        self.assertEqual(primary, ["gamma three."])
+
+    def test_supporting_adds_one_sentence_either_side(self):
+        _, supporting = build_skill_context(self.SENTENCES, "gamma")
+        self.assertEqual(supporting, ["beta two.", "gamma three.", "delta four."])
+
+    def test_window_clamps_at_document_start_and_end(self):
+        _, first = build_skill_context(self.SENTENCES, "alpha")
+        _, last = build_skill_context(self.SENTENCES, "delta")
+        self.assertEqual(first, ["alpha one.", "beta two."])
+        self.assertEqual(last, ["gamma three.", "delta four."])
+
+    def test_overlapping_windows_do_not_repeat_a_sentence(self):
+        _, supporting = build_skill_context(
+            ["x one.", "x two.", "x three."], "x"
+        )
+        self.assertEqual(len(supporting), len(set(supporting)))
+
+    def test_document_order_is_preserved(self):
+        _, supporting = build_skill_context(self.SENTENCES, "beta")
+        self.assertEqual(supporting, ["alpha one.", "beta two.", "gamma three."])
+
+    def test_absent_skill_returns_two_empty_lists(self):
+        self.assertEqual(build_skill_context(self.SENTENCES, "omega"), ([], []))

--- a/backend/analyzer/tests_project_extractor.py
+++ b/backend/analyzer/tests_project_extractor.py
@@ -57,3 +57,82 @@ class ProjectExtractorTests(TestCase):
         """Test analyze_portfolio with no projects."""
         results = analyze_portfolio("No projects here.")
         self.assertEqual(results, [])
+
+
+class MetricRecognitionTests(TestCase):
+    """Number formats that appear on real resumes.
+
+    The old METRIC_PATTERNS required whitespace between a figure and its noun
+    ("10 users") and matched improvement verbs only in simple past ("increased
+    by"), so genuinely quantified bullets scored as unquantified and were told
+    to add metrics.
+    """
+
+    def score(self, description):
+        return score_project_impact({"name": "P", "description": description})
+
+    def test_abbreviated_scale_counts_as_a_metric(self):
+        """10k / 2.5M / 1B are how people write these."""
+        for text in ("serving 10k users", "handling 2.5M requests", "1B rows indexed"):
+            with self.subTest(text=text):
+                self.assertIn("scale", self.score(text)["metrics_found"])
+
+    def test_spelled_out_scale_still_counts(self):
+        self.assertIn("scale", self.score("serving 10 million users")["metrics_found"])
+
+    def test_improvement_verbs_count_in_any_tense(self):
+        for text in (
+            "increasing sales by 20%",
+            "increased revenue by 30",
+            "reducing latency by 40",
+            "improving throughput by 15",
+            "cut build times by 50",
+            "grew signups by 12",
+        ):
+            with self.subTest(text=text):
+                self.assertIn("improvement", self.score(text)["metrics_found"])
+
+    def test_monetary_and_percentage_and_multiplier(self):
+        self.assertIn("monetary", self.score("saved $40k annually")["metrics_found"])
+        self.assertIn("percentage", self.score("up 12.5%")["metrics_found"])
+        self.assertIn("multiplier", self.score("a 3x speedup")["metrics_found"])
+
+    def test_prose_with_no_numbers_finds_nothing(self):
+        result = self.score("I worked on a thing and it was good.")
+        self.assertEqual(result["metrics_found"], [])
+        self.assertTrue(
+            any("quantifiable metrics" in s for s in result["suggestions"])
+        )
+
+    def test_quantified_bullet_is_not_told_to_add_metrics(self):
+        result = self.score(
+            "Architected and developed a React web app serving 10k users, "
+            "increasing sales by 20%."
+        )
+        self.assertGreater(result["impact_score"], 80)
+        self.assertEqual(result["suggestions"], [])
+
+    def test_metric_labels_are_readable_and_deduplicated(self):
+        """metrics_found goes back in the API response.
+
+        It used to be built by string-mangling the regex source, producing
+        entries like "X%" and "X users".
+        """
+        result = self.score("Grew to 10k users and 20k downloads, up 30%.")
+        self.assertEqual(len(result["metrics_found"]), len(set(result["metrics_found"])))
+        for label in result["metrics_found"]:
+            self.assertNotIn("\\", label)
+            self.assertNotIn("+", label)
+
+    def test_metric_contribution_is_capped(self):
+        """One achievement quoted several ways is still one achievement."""
+        many = self.score("Grew to 10k users, 3x throughput, $40k saved, up 30%.")
+        self.assertLessEqual(many["impact_score"], 100)
+        self.assertGreaterEqual(len(many["metrics_found"]), 3)
+
+    def test_score_stays_within_bounds(self):
+        for text in ("", "x", "Architected 10k users 3x $40k 30% by 20 in 5 ms"):
+            with self.subTest(text=text):
+                score = self.score(text)["impact_score"]
+                self.assertGreaterEqual(score, 0)
+                self.assertLessEqual(score, 100)


### PR DESCRIPTION
Closes #1008

Two scorers dropped evidence the resume did contain, and then told the user to supply it.

## `proficiency_estimator`: only the sentence with the token was read

```python
relevant_sentences = [s for s in sentences if skill_lower in s]
```

Resumes name a skill in one sentence and describe what was built with it in the next. Given:

> "8+ years of experience in Python. I architected a system serving 10 million users, optimizing performance by 40%."

the second sentence contains no "Python", so it was thrown away:

| Signal | In the resume | Counted |
|---|---|---|
| `EXPERT_INDICATORS` — "8+ years of experience" | yes | yes (+30) |
| `ADVANCED_INDICATORS` — "architected" | yes | **no** |
| `QUANTIFIABLE_METRICS` — "10 million", "40%" | yes | **no** |

Score stalled at `50 + 30 = 80`. Worse, `metrics_found` was empty and the truncated context was under 100 characters, so this branch fired:

```python
if level == "Expert" and not metrics_found and len(context_text) < 100:
    warnings.append("Claimed expertise lacks quantifiable metrics or detailed context.")
```

A resume that quantified its impact twice in the very next sentence was reported as an **unsupported expertise claim** — and `ProficiencyEstimationView` surfaces that count as `high_risk_claims_count`, so we accuse the user of padding based on evidence we chose not to read.

### The fix, and why it is a split rather than a bigger window

Evidence is now two things:

- **Primary** — the sentences naming the skill. These decide the *level*. The verb attached to a skill is the claim being made about it.
- **Supporting** — those sentences plus their immediate neighbours. Read only for corroborating metrics.

I tried the obvious one-window version first and it broke `test_estimate_all_proficiencies_sorting`, which turned out to be the test doing its job. With a single window:

```python
"Basic knowledge of Java. 10+ years of experience in Python, architected systems."
```

Java's window pulls in the Python sentence and Java is promoted from Beginner to **Expert**. "Basic knowledge of Java" is a beginner claim no matter what sits next to it. Letting only metrics cross the sentence boundary keeps the neighbour useful without letting it rewrite the claim. There is now a test named for this.

## `project_extractor`: the metric patterns did not match how people write numbers

**Whitespace.** `r"\d+\s+users?"` requires a space between figure and noun, so `"10k users"` never matched — `\d+` consumed `10` and `\s+` then hit `k`. `10k`, `2.5M`, `1B`, `$40k` are the standard forms and were all invisible.

**Tense.** `r"increased by \d+"` and `r"reduced by \d+"` are two literals. `"increasing sales by 20%"`, `"reducing latency by 40ms"`, `"cut build times by half"` — participle forms, and an object between the verb and "by" — were all missed.

On the test bullet, two hard numbers and only one counted:

```
"Architected and developed a React web app serving 10k users, increasing sales by 20%."
40 base + 15 (only "20%") + 20 (verbs) + 5 (React) = 80
```

`METRIC_PATTERNS` is now `(label, pattern)` pairs. The label is what goes into `metrics_found`, which is **part of the API response** — it used to be produced by string-mangling the regex source:

```python
pattern.replace("\\", "").replace("d+", "X").replace("s+", " ")
```

which yielded entries like `"X%"` and `"X users"`, and would have broken outright the first time a pattern gained a group. Metric contribution is capped at 45, because one bullet quoting a percentage, a scale and a dollar figure is describing one achievement, not three.

## Tests

27 added (10 → 37).

Proficiency: metrics from the adjacent sentence counted; quantified expertise no longer flagged; a neighbour cannot donate a level; genuinely bare claims still flagged; window clamping at document start/end; overlapping windows not repeating a sentence; document order preserved.

Project: `10k` / `2.5M` / `1B` / `$40k`; improvement verbs across six tenses; monetary, percentage, multiplier; prose with no numbers still correctly told to add metrics; the quantified bullet no longer told to add metrics; labels readable and deduplicated; the metric cap; score bounds on empty and saturated input.

```
Ran 37 tests in 0.007s
OK
```

Full backend suite: both target failures gone, no new ones. The rest that remain on this branch belong to #1006, #1007 (PR #1010) and #1009.
