### PR TITLE
fix: count resume bullets as confident, and stop lowercasing acronyms (#1009)

### DIFF
--- a/backend/analyzer/market_value_estimator.py
+++ b/backend/analyzer/market_value_estimator.py
@@ -35,12 +35,70 @@ HIGH_VALUE_SKILLS = [
     "management",
 ]
 
+# Display spelling for the skills we recognise. matched_skills used to be
+# rendered with ``", ".join(...).title()``, which rewrites the caller's casing
+# and turns every acronym into sentence case -- AWS became "Aws", SQL "Sql",
+# GCP "Gcp". These are talking points a candidate reads out in a salary
+# conversation, so the spelling is the deliverable.
+CANONICAL_SKILL_NAMES = {
+    "machine learning": "Machine Learning",
+    "artificial intelligence": "Artificial Intelligence",
+    "aws": "AWS",
+    "azure": "Azure",
+    "kubernetes": "Kubernetes",
+    "docker": "Docker",
+    "tensorflow": "TensorFlow",
+    "pytorch": "PyTorch",
+    "blockchain": "Blockchain",
+    "rust": "Rust",
+    "go": "Go",
+    "golang": "Go",
+    "system design": "System Design",
+    "architecture": "Architecture",
+    "leadership": "Leadership",
+    "management": "Management",
+}
+
 NEGOTIATION_TEMPLATES = {
     "high_experience": "Emphasize your {years} years of experience and proven track record of {achievements} to justify the upper end of the range.",
     "high_value_skills": "Highlight your expertise in high-demand areas like {skills}, which command a premium in the current market.",
     "leadership": "Focus on your leadership experience and ability to mentor teams, as these soft skills significantly increase market value.",
     "general": "Research the specific company's compensation bands and be prepared to discuss your total compensation expectations, including equity and benefits.",
 }
+
+
+def display_skill_name(skill: str) -> str:
+    """How a skill should be spelled back to the user.
+
+    Known skills use their canonical spelling. Anything else keeps the casing
+    the caller supplied when they cased it themselves (``PyTorch``, ``CI/CD``),
+    since that is more likely right than anything we would impose, and is only
+    title-cased when it arrives entirely lowercase.
+    """
+    canonical = CANONICAL_SKILL_NAMES.get(skill.strip().lower())
+    if canonical:
+        return canonical
+    if any(character.isupper() for character in skill):
+        return skill
+    return skill.title()
+
+
+def find_high_value_skills(skills: List[str]) -> List[str]:
+    """The caller's skills that HIGH_VALUE_SKILLS recognises, canonically spelled.
+
+    Single source of truth for "which of these skills are worth money".
+    MarketValueView kept its own five-entry copy of the list while
+    calculate_salary_range priced against all sixteen, so a candidate could get
+    an uplift and an empty value_driving_skills in the same response.
+    """
+    seen = set()
+    matched = []
+    for skill in skills:
+        key = skill.strip().lower()
+        if key in HIGH_VALUE_SKILLS and key not in seen:
+            seen.add(key)
+            matched.append(display_skill_name(skill))
+    return matched
 
 
 def normalize_role(role: str) -> str:
@@ -102,11 +160,11 @@ def generate_negotiation_points(level: str, skills: List[str]) -> List[str]:
         )
         points.append(NEGOTIATION_TEMPLATES["leadership"])
 
-    matched_skills = [s for s in skills if s.lower() in HIGH_VALUE_SKILLS][:3]
+    matched_skills = find_high_value_skills(skills)[:3]
     if matched_skills:
         points.append(
             NEGOTIATION_TEMPLATES["high_value_skills"].format(
-                skills=", ".join(matched_skills).title()
+                skills=", ".join(matched_skills)
             )
         )
 

--- a/backend/analyzer/market_views.py
+++ b/backend/analyzer/market_views.py
@@ -5,7 +5,11 @@ Views for Market Value Estimator.
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from .market_value_estimator import calculate_salary_range, generate_negotiation_points
+from .market_value_estimator import (
+    calculate_salary_range,
+    find_high_value_skills,
+    generate_negotiation_points,
+)
 from .market_serializers import (
     MarketValueRequestSerializer,
     MarketValueResponseSerializer,
@@ -31,15 +35,12 @@ class MarketValueView(APIView):
             salary_range = calculate_salary_range(target_role, experience_level, skills)
             negotiation_points = generate_negotiation_points(experience_level, skills)
 
-            # Identify value driving skills
-            high_value = [
-                "machine learning",
-                "aws",
-                "kubernetes",
-                "leadership",
-                "system design",
-            ]
-            value_driving = [s for s in skills if s.lower() in high_value]
+            # Identify value driving skills. This used to be a five-entry copy
+            # of the list, while calculate_salary_range above priced against
+            # all sixteen -- so "Docker, Rust, Azure" earned an uplift and came
+            # back with an empty value_driving_skills, i.e. the response raised
+            # the number and then reported that nothing drove it.
+            value_driving = find_high_value_skills(skills)
 
             response_data = {
                 "salary_range": salary_range,

--- a/backend/analyzer/tests_market_value_estimator.py
+++ b/backend/analyzer/tests_market_value_estimator.py
@@ -4,6 +4,8 @@ Unit tests for Market Value Estimator.
 
 from django.test import TestCase
 from .market_value_estimator import (
+    display_skill_name,
+    find_high_value_skills,
     normalize_role,
     normalize_level,
     calculate_salary_range,
@@ -51,3 +53,66 @@ class MarketValueEstimatorTests(TestCase):
         self.assertGreater(len(points), 0)
         self.assertTrue(any("Leadership" in p for p in points))
         self.assertTrue(any("AWS" in p for p in points))
+
+
+class SkillCasingTests(TestCase):
+    """Casing of skills in generated advice.
+
+    matched_skills was rendered with ``", ".join(...).title()``, which rewrote
+    the caller's casing: AWS -> "Aws", SQL -> "Sql", GCP -> "Gcp". These are
+    talking points a candidate reads out loud in a salary conversation.
+    """
+
+    def test_acronyms_survive_in_negotiation_points(self):
+        points = generate_negotiation_points("Senior", ["Python", "Leadership", "AWS"])
+        self.assertTrue(any("AWS" in p for p in points))
+        self.assertFalse(any("Aws" in p for p in points))
+
+    def test_canonical_spelling_is_used_for_known_skills(self):
+        self.assertEqual(display_skill_name("aws"), "AWS")
+        self.assertEqual(display_skill_name("AWS"), "AWS")
+        self.assertEqual(display_skill_name("  Aws  "), "AWS")
+        self.assertEqual(display_skill_name("tensorflow"), "TensorFlow")
+        self.assertEqual(display_skill_name("machine learning"), "Machine Learning")
+
+    def test_caller_casing_is_preserved_for_unknown_skills(self):
+        self.assertEqual(display_skill_name("CI/CD"), "CI/CD")
+        self.assertEqual(display_skill_name("PostgreSQL"), "PostgreSQL")
+
+    def test_all_lowercase_unknown_skill_is_title_cased(self):
+        self.assertEqual(display_skill_name("project planning"), "Project Planning")
+
+
+class HighValueSkillSourceTests(TestCase):
+    """One list decides both the price and the explanation.
+
+    MarketValueView carried its own five-entry copy while
+    calculate_salary_range priced against all sixteen, so a candidate could be
+    given an uplift and an empty value_driving_skills in the same response.
+    """
+
+    SKILLS = ["Docker", "Rust", "Azure"]
+
+    def test_skills_that_raise_the_salary_are_the_skills_reported(self):
+        base = calculate_salary_range("Software Engineer", "Mid", [])
+        boosted = calculate_salary_range("Software Engineer", "Mid", self.SKILLS)
+
+        self.assertGreater(boosted["median"], base["median"])
+        self.assertEqual(
+            find_high_value_skills(self.SKILLS), ["Docker", "Rust", "Azure"]
+        )
+
+    def test_unrecognised_skills_are_excluded(self):
+        self.assertEqual(find_high_value_skills(["Python", "Excel"]), [])
+
+    def test_matching_is_case_and_whitespace_insensitive(self):
+        self.assertEqual(find_high_value_skills(["  kUbErNeTeS "]), ["Kubernetes"])
+
+    def test_duplicates_are_collapsed(self):
+        self.assertEqual(find_high_value_skills(["AWS", "aws", "Aws"]), ["AWS"])
+
+    def test_golang_and_go_report_the_same_name(self):
+        self.assertEqual(find_high_value_skills(["golang"]), ["Go"])
+
+    def test_empty_input(self):
+        self.assertEqual(find_high_value_skills([]), [])

--- a/backend/analyzer/tests_tone_analyzer.py
+++ b/backend/analyzer/tests_tone_analyzer.py
@@ -51,3 +51,111 @@ class ToneAnalyzerTests(TestCase):
         self.assertIn("collaboration_score", result)
         self.assertIn("overall_tone", result)
         self.assertEqual(result["pronoun_dominance"], "balanced")
+
+
+class BulletStyleVerbTests(TestCase):
+    """Action verbs written the way resume bullets are actually written.
+
+    Every entry in STRONG_CONFIDENT_PHRASES used to be anchored to a literal
+    leading "i", so a resume following the bare-past-tense convention scored a
+    flat 50 and was labelled Passive.
+    """
+
+    BULLET_RESUME = (
+        "Led a cross-functional team of 12 engineers. "
+        "Architected a payments platform handling 2 million transactions. "
+        "Delivered a 30 percent reduction in checkout latency. "
+        "Mentored four junior developers and partnered with product on "
+        "roadmap planning across two quarters."
+    )
+
+    def test_bare_verbs_count_as_confident(self):
+        result = analyze_sentiment_and_confidence(self.BULLET_RESUME)
+        self.assertGreaterEqual(result["confidence_score"], 80)
+
+    def test_bullet_resume_is_not_labelled_passive(self):
+        result = analyze_tone(self.BULLET_RESUME)
+        self.assertNotEqual(result["overall_tone"], "Passive / Needs Refinement")
+
+    def test_bullet_resume_is_not_told_to_add_confident_language(self):
+        result = analyze_sentiment_and_confidence(self.BULLET_RESUME)
+        self.assertFalse(
+            any("results-oriented" in s for s in result["suggestions"]),
+            "a resume full of strong verbs should not be asked for strong verbs",
+        )
+
+    def test_i_prefixed_and_bare_forms_score_the_same(self):
+        """Writing style should not change the score of the same claims."""
+        bare = "Led the migration. Architected the service. Delivered the rewrite."
+        prefixed = "I led the migration. I architected the service. I delivered the rewrite."
+        self.assertEqual(
+            analyze_sentiment_and_confidence(bare)["confidence_score"],
+            analyze_sentiment_and_confidence(prefixed)["confidence_score"],
+        )
+
+    def test_second_verb_of_a_compound_clause_is_counted(self):
+        """"I spearheaded X and delivered Y" reads "and delivered", not "I delivered"."""
+        one = analyze_sentiment_and_confidence("I spearheaded the initiative.")
+        two = analyze_sentiment_and_confidence(
+            "I spearheaded the initiative and delivered a 20% improvement."
+        )
+        self.assertGreater(two["confidence_score"], one["confidence_score"])
+
+    def test_bullet_style_filler_is_still_caught(self):
+        """The weak list had the same "I"-anchoring problem in reverse."""
+        text = (
+            "Responsible for maintaining the build. "
+            "Helped with the release process. "
+            "Worked on various tickets. "
+            "Assisted with documentation. "
+            "Participated in planning meetings and was involved in code review."
+        )
+        result = analyze_sentiment_and_confidence(text)
+        self.assertLess(result["confidence_score"], 50)
+        self.assertTrue(any("weak phrases" in s for s in result["suggestions"]))
+
+
+class CorpusAdviceThresholdTests(TestCase):
+    """Whole-resume judgements should not be made from a fragment."""
+
+    def test_short_strong_snippet_gets_no_collaboration_nag(self):
+        result = analyze_sentiment_and_confidence(
+            "I spearheaded the initiative and delivered a 20% improvement. "
+            "I architected the solution."
+        )
+        self.assertEqual(result["suggestions"], [])
+
+    def test_long_solo_resume_does_get_the_collaboration_nudge(self):
+        text = " ".join(
+            [
+                "Architected the billing service and delivered the migration.",
+                "Owned the deployment pipeline end to end.",
+                "Launched three internal tools over eighteen months.",
+                "Secured budget for the observability rewrite.",
+                "Established the on-call rotation and the incident review process.",
+                "Overhauled the release checklist and shipped it to production.",
+            ]
+        )
+        self.assertGreaterEqual(len(text.split()), 40)
+        result = analyze_sentiment_and_confidence(text)
+        self.assertTrue(any("collaboration" in s for s in result["suggestions"]))
+
+    def test_weak_phrase_advice_is_not_length_gated(self):
+        """Concrete, locatable advice stays regardless of length."""
+        result = analyze_sentiment_and_confidence(
+            "Helped with it. Worked on it. Responsible for it."
+        )
+        self.assertTrue(any("weak phrases" in s for s in result["suggestions"]))
+
+    def test_scores_stay_within_bounds(self):
+        for text in ("", "x", "Led. " * 40, "Helped with it. " * 40):
+            with self.subTest(text=text[:20]):
+                result = analyze_sentiment_and_confidence(text)
+                for key in ("confidence_score", "collaboration_score", "clarity_score"):
+                    self.assertGreaterEqual(result[key], 0)
+                    self.assertLessEqual(result[key], 100)
+
+    def test_analyze_tone_rejects_non_string_input(self):
+        self.assertEqual(analyze_tone(None), {})
+        self.assertEqual(analyze_tone(""), {})
+        self.assertEqual(analyze_tone(123), {})

--- a/backend/analyzer/tone_analyzer.py
+++ b/backend/analyzer/tone_analyzer.py
@@ -11,19 +11,46 @@ from typing import List, Dict, Any
 # Pronoun and phrasing indicators
 FIRST_PERSON_SINGULAR = [r"\bi\b", r"\bmy\b", r"\bmine\b", r"\bme\b"]
 FIRST_PERSON_PLURAL = [r"\bwe\b", r"\bour\b", r"\bours\b", r"\bus\b"]
+# Both lists used to anchor every entry to a literal leading "i" -- r"\bi led\b",
+# r"\bi was responsible for\b". Resume bullets are written as bare past-tense
+# verbs ("Led a team of 12"), which is the accepted convention, so the resumes
+# that followed best practice scored a flat 50 and were told to "add more
+# confident language". The "I" form also loses the second verb of any compound
+# clause: "I spearheaded the initiative and delivered a 20% improvement" reads
+# "and delivered", not "I delivered".
+#
+# Matching the verb itself covers both: "\bled\b" is in "I led" and in "Led".
 PASSIVE_WEAK_PHRASES = [
     r"\bi think\b",
     r"\bi believe\b",
     r"\bi feel like\b",
-    r"\bi tried to\b",
-    r"\bi was responsible for\b",
-    r"\bi helped with\b",
+    r"\btried to\b",
+    r"\bresponsible for\b",
+    r"\bhelped with\b",
+    r"\bassisted with\b",
+    r"\bworked on\b",
+    r"\binvolved in\b",
+    r"\bparticipated in\b",
+    r"\bduties included\b",
+    r"\btasked with\b",
+    r"\bfamiliar with\b",
 ]
 STRONG_CONFIDENT_PHRASES = [
-    r"\bi led\b",
-    r"\bi architected\b",
-    r"\bi spearheaded\b",
-    r"\bi delivered\b",
+    r"\bled\b",
+    r"\barchitected\b",
+    r"\bspearheaded\b",
+    r"\bdelivered\b",
+    r"\blaunched\b",
+    r"\bshipped\b",
+    r"\bdrove\b",
+    r"\bowned\b",
+    r"\bfounded\b",
+    r"\bpioneered\b",
+    r"\bestablished\b",
+    r"\borchestrated\b",
+    r"\boverhauled\b",
+    r"\bnegotiated\b",
+    r"\bsecured\b",
     r"\bi am confident\b",
     r"\bproven track record\b",
 ]
@@ -36,6 +63,13 @@ COLLABORATION_PHRASES = [
     r"\bmentored\b",
     r"\bcoordinated\b",
 ]
+
+# "You do not mention collaboration enough" and "add more confident language"
+# are judgements about a whole resume. Below this many words there is not
+# enough text to support either, and emitting them on a fragment produces
+# advice the input cannot justify. analyze_sentiment_and_confidence is called
+# both on whole resumes and on individual sections, so the guard lives here.
+MIN_WORDS_FOR_CORPUS_ADVICE = 40
 
 
 def analyze_pronoun_usage(text: str) -> Dict[str, Any]:
@@ -89,15 +123,17 @@ def analyze_sentiment_and_confidence(text: str) -> Dict[str, Any]:
     clarity_score = max(0, min(100, 100 - (weak_count * 10)))
 
     suggestions = []
+    long_enough = len(text.split()) >= MIN_WORDS_FOR_CORPUS_ADVICE
+
     if weak_count > 2:
         suggestions.append(
-            "Replace weak phrases like 'I tried to' or 'I helped with' with strong action verbs like 'I delivered' or 'I executed'."
+            "Replace weak phrases like 'tried to' or 'helped with' with strong action verbs like 'delivered' or 'executed'."
         )
-    if strong_count == 0 and weak_count == 0:
+    if long_enough and strong_count == 0 and weak_count == 0:
         suggestions.append(
             "Add more confident, results-oriented language to highlight your achievements."
         )
-    if collab_count < 2:
+    if long_enough and collab_count < 2:
         suggestions.append(
             "Incorporate more collaboration keywords (e.g., 'partnered', 'cross-functional') to demonstrate teamwork."
         )


### PR DESCRIPTION
Closes #1009

## `tone_analyzer` scored best-practice resumes worst

Every entry in `STRONG_CONFIDENT_PHRASES` was anchored to a literal leading `i`:

```python
STRONG_CONFIDENT_PHRASES = [
    r"\bi led\b", r"\bi architected\b", r"\bi spearheaded\b",
    r"\bi delivered\b", r"\bi am confident\b", r"\bproven track record\b",
]
```

Resume bullets are written as bare past-tense verbs — that is the convention every resume guide teaches. So:

> "Led a cross-functional team of 12 engineers. Architected a payments platform. Delivered a 30% reduction in checkout latency."

`strong_count` = **0**. Result:

- `confidence_score` = 50, the untouched base
- because `strong_count == 0 and weak_count == 0`, the user was told *"Add more confident, results-oriented language to highlight your achievements"*
- `analyze_tone` labelled the resume **"Passive / Needs Refinement"**

Three strong verbs, a headcount and a quantified result, and we called it passive for not writing "I" in front of each verb.

The same anchoring lost the second verb of any compound clause — `"I spearheaded the initiative and delivered a 20% improvement"` reads `and delivered`, so only two of three verbs counted (`50 + 2×10 = 70`, the failing assertion).

Matching the verb itself handles both, since `\bled\b` occurs in "I led" and in "Led". After the change the example above scores **80 / "Authoritative & Collaborative"**.

The weak list had the identical problem in reverse: `"Responsible for maintaining the build"` is precisely the filler this checker exists to catch, and `r"\bi was responsible for\b"` missed it. Those are de-anchored too, plus the bullet-form fillers people actually write (`worked on`, `involved in`, `participated in`, `duties included`, `tasked with`).

### Suggestion gating

The collaboration nudge and the "add confident language" nudge fired unconditionally. Both are judgements about a whole resume, and emitting them from a fourteen-word fragment is advice the input cannot support. Both are now gated on `MIN_WORDS_FOR_CORPUS_ADVICE = 40`.

The weak-phrase suggestion is deliberately **not** gated — it points at specific words the caller can locate and fix, so it is useful at any length. There is a test for that distinction.

## `market_value_estimator` lowercased acronyms in its own advice

```python
skills=", ".join(matched_skills).title()
```

`.title()` rewrites the caller's casing: `AWS` → `Aws`, `SQL` → `Sql`, `GCP` → `Gcp`, `CI/CD` → `Ci/Cd`. These are negotiation talking points — text a candidate reads out loud on a call with a recruiter, telling them to emphasise their expertise in "Aws". `matched_skills` already held the caller's original strings; `.title()` only destroyed information.

Skills now render through `display_skill_name`:

- canonical spelling for skills we recognise (`aws` → `AWS`, `tensorflow` → `TensorFlow`, `golang` → `Go`)
- the caller's own casing when they cased it themselves (`PostgreSQL`, `CI/CD` survive)
- title case only for input arriving entirely lowercase

## `MarketValueView` priced with one list and explained with another

```python
high_value = ["machine learning", "aws", "kubernetes", "leadership", "system design"]
value_driving = [s for s in skills if s.lower() in high_value]
```

Five entries, hand-copied. `calculate_salary_range` prices against `HIGH_VALUE_SKILLS`, which has sixteen. A candidate listing `Docker, Rust, Azure` received a 15% uplift and an **empty** `value_driving_skills` — the response raised the number and then reported that nothing drove it, leaving the UI unable to explain its own output.

Both paths now call `find_high_value_skills`, so the list that sets the price is the list that explains it.

## Tests

23 added (10 → 33).

Tone: bare verbs counted; bullet resume not labelled Passive; not told to add verbs it already has; `I`-prefixed and bare forms scoring identically; compound-clause verbs; bullet-style filler still caught; short fragment gets no collaboration nag; long solo resume still does; weak-phrase advice not length-gated; score bounds; non-string input.

Market: acronyms surviving into negotiation points (and `"Aws"` explicitly absent); canonical spelling; caller casing preserved; case/whitespace-insensitive matching; duplicates collapsed; `golang`/`go` reporting one name; the priced list and the reported list agreeing.

```
Ran 33 tests in 0.007s
OK
```

Full backend suite: both target failures gone, no new ones. The rest that remain on this branch belong to #1006, #1007 (PR #1010) and #1008 (PR #1011).

## Not changed here

`analyze_pronoun_usage` still suggests adding "I led" / "We collaborated" when a resume contains no first-person pronouns at all, which reads slightly oddly next to an "Authoritative" verdict on a pronoun-free bullet resume. That is a separate judgement call about house style and did not seem right to fold into a bug fix.
