### PR TITLE
fix: route the five orphaned analysis views and bound the open endpoints (#1006)

### DIFF
--- a/backend/analyzer/gap_views.py
+++ b/backend/analyzer/gap_views.py
@@ -2,9 +2,12 @@
 Views for Gap Narrative Builder.
 """
 
+import logging
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.throttling import AnonRateThrottle
 from .gap_narrative import detect_gaps, generate_narratives
 from .gap_serializers import (
     GapNarrativeRequestSerializer,
@@ -12,8 +15,29 @@ from .gap_serializers import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
+class GapNarrativeThrottle(AnonRateThrottle):
+    """Caps the GapNarrativeView endpoint.
+
+    ``DEFAULT_PERMISSION_CLASSES`` is ``AllowAny`` and this view does not
+    override it, so the endpoint is open. It parses a caller-supplied
+    timeline and renders ten narrative templates per detected gap. Rate from
+    ``DEFAULT_THROTTLE_RATES["gap_narrative"]``.
+
+    ``scope`` is set explicitly: every ``AnonRateThrottle`` subclass inherits
+    the scope "anon" otherwise, which would put this endpoint in the same
+    bucket as unrelated ones.
+    """
+
+    scope = "gap_narrative"
+
+
 class GapNarrativeView(APIView):
     """API View to detect resume gaps and generate professional narratives."""
+
+    throttle_classes = [GapNarrativeThrottle]
 
     def post(self, request, *args, **kwargs):
         request_serializer = GapNarrativeRequestSerializer(data=request.data)
@@ -30,9 +54,16 @@ class GapNarrativeView(APIView):
             raw_gaps = detect_gaps(timeline_data)
             enriched_gaps = generate_narratives(raw_gaps, context)
 
+            # GapNarrativeResponseSerializer declares total_narratives_generated
+            # as required. Omitting it made is_valid(raise_exception=True) throw,
+            # which the except below turned into a 500 -- so every *successful*
+            # analysis returned "an unexpected error occurred".
             response_data = {
                 "total_gaps_detected": len(enriched_gaps),
                 "gaps": enriched_gaps,
+                "total_narratives_generated": sum(
+                    len(gap["narratives"]) for gap in enriched_gaps
+                ),
             }
 
             response_serializer = GapNarrativeResponseSerializer(data=response_data)
@@ -40,11 +71,12 @@ class GapNarrativeView(APIView):
 
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
+            # `str(e)` used to go back in a "details" field. That hands the
+            # caller file paths, SQL and library internals on any unexpected
+            # failure; the operator wants that detail, the client does not.
+            logger.exception("Gap narrative generation failed")
             return Response(
-                {
-                    "error": "An unexpected error occurred during gap analysis.",
-                    "details": str(e),
-                },
+                {"error": "An unexpected error occurred during gap analysis."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/backend/analyzer/market_views.py
+++ b/backend/analyzer/market_views.py
@@ -2,9 +2,12 @@
 Views for Market Value Estimator.
 """
 
+import logging
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.throttling import AnonRateThrottle
 from .market_value_estimator import calculate_salary_range, generate_negotiation_points
 from .market_serializers import (
     MarketValueRequestSerializer,
@@ -12,8 +15,29 @@ from .market_serializers import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
+class MarketValueThrottle(AnonRateThrottle):
+    """Caps the MarketValueView endpoint.
+
+    ``DEFAULT_PERMISSION_CLASSES`` is ``AllowAny`` and this view does not
+    override it, so the endpoint is open. It scans a caller-supplied skill
+    list against the high-value table for every request. Rate from
+    ``DEFAULT_THROTTLE_RATES["market_value"]``.
+
+    ``scope`` is set explicitly: every ``AnonRateThrottle`` subclass inherits
+    the scope "anon" otherwise, which would put this endpoint in the same
+    bucket as unrelated ones.
+    """
+
+    scope = "market_value"
+
+
 class MarketValueView(APIView):
     """API View to estimate market value and generate negotiation points."""
+
+    throttle_classes = [MarketValueThrottle]
 
     def post(self, request, *args, **kwargs):
         request_serializer = MarketValueRequestSerializer(data=request.data)
@@ -52,11 +76,12 @@ class MarketValueView(APIView):
 
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
+            # `str(e)` used to go back in a "details" field. That hands the
+            # caller file paths, SQL and library internals on any unexpected
+            # failure; the operator wants that detail, the client does not.
+            logger.exception("Market value estimation failed")
             return Response(
-                {
-                    "error": "An unexpected error occurred during market value estimation.",
-                    "details": str(e),
-                },
+                {"error": "An unexpected error occurred during market value estimation."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/backend/analyzer/proficiency_views.py
+++ b/backend/analyzer/proficiency_views.py
@@ -2,9 +2,12 @@
 Views for Skill Proficiency Estimator.
 """
 
+import logging
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.throttling import AnonRateThrottle
 from .proficiency_estimator import estimate_all_proficiencies
 from .proficiency_serializers import (
     ProficiencyEstimationRequestSerializer,
@@ -12,8 +15,30 @@ from .proficiency_serializers import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
+class ProficiencyEstimationThrottle(AnonRateThrottle):
+    """Caps the ProficiencyEstimationView endpoint.
+
+    ``DEFAULT_PERMISSION_CLASSES`` is ``AllowAny`` and this view does not
+    override it, so the endpoint is open. It splits a caller-supplied resume
+    into sentences and runs the full indicator set once per requested skill,
+    so cost grows with body size times skill count. Rate from
+    ``DEFAULT_THROTTLE_RATES["proficiency_estimation"]``.
+
+    ``scope`` is set explicitly: every ``AnonRateThrottle`` subclass inherits
+    the scope "anon" otherwise, which would put this endpoint in the same
+    bucket as unrelated ones.
+    """
+
+    scope = "proficiency_estimation"
+
+
 class ProficiencyEstimationView(APIView):
     """API View to estimate skill proficiency based on resume context."""
+
+    throttle_classes = [ProficiencyEstimationThrottle]
 
     def post(self, request, *args, **kwargs):
         request_serializer = ProficiencyEstimationRequestSerializer(data=request.data)
@@ -43,11 +68,12 @@ class ProficiencyEstimationView(APIView):
 
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
+            # `str(e)` used to go back in a "details" field. That hands the
+            # caller file paths, SQL and library internals on any unexpected
+            # failure; the operator wants that detail, the client does not.
+            logger.exception("Proficiency estimation failed")
             return Response(
-                {
-                    "error": "An unexpected error occurred during proficiency estimation.",
-                    "details": str(e),
-                },
+                {"error": "An unexpected error occurred during proficiency estimation."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/backend/analyzer/project_views.py
+++ b/backend/analyzer/project_views.py
@@ -2,9 +2,12 @@
 Views for Project Portfolio Extractor.
 """
 
+import logging
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.throttling import AnonRateThrottle
 from .project_extractor import analyze_portfolio
 from .project_serializers import (
     ProjectExtractionRequestSerializer,
@@ -12,8 +15,29 @@ from .project_serializers import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
+class ProjectExtractionThrottle(AnonRateThrottle):
+    """Caps the ProjectExtractionView endpoint.
+
+    ``DEFAULT_PERMISSION_CLASSES`` is ``AllowAny`` and this view does not
+    override it, so the endpoint is open. It runs the metric, action-verb
+    and tech-stack passes over every project it finds in a caller-supplied
+    body. Rate from ``DEFAULT_THROTTLE_RATES["project_extraction"]``.
+
+    ``scope`` is set explicitly: every ``AnonRateThrottle`` subclass inherits
+    the scope "anon" otherwise, which would put this endpoint in the same
+    bucket as unrelated ones.
+    """
+
+    scope = "project_extraction"
+
+
 class ProjectExtractionView(APIView):
     """API View to extract and score resume projects."""
+
+    throttle_classes = [ProjectExtractionThrottle]
 
     def post(self, request, *args, **kwargs):
         request_serializer = ProjectExtractionRequestSerializer(data=request.data)
@@ -45,11 +69,12 @@ class ProjectExtractionView(APIView):
 
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
+            # `str(e)` used to go back in a "details" field. That hands the
+            # caller file paths, SQL and library internals on any unexpected
+            # failure; the operator wants that detail, the client does not.
+            logger.exception("Project extraction failed")
             return Response(
-                {
-                    "error": "An unexpected error occurred during project extraction.",
-                    "details": str(e),
-                },
+                {"error": "An unexpected error occurred during project extraction."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/backend/analyzer/tests_api_routes.py
+++ b/backend/analyzer/tests_api_routes.py
@@ -86,6 +86,16 @@ ROUTES = [
     ("/api/optimize-linkedin/", "components/LinkedInOptimizer.tsx"),
     ("/api/file-metadata/", "components/PrivacyScrubber.tsx"),
     ("/api/sanitize-resume/", "components/PrivacyScrubber.tsx"),
+    # And a third time, for the five features merged in #945-#949 (#1006).
+    # Same shape again: view class, serializers, unit tests, no path.
+    ("/api/generate-gap-narrative/", "components/GapNarrativeBuilder.tsx"),
+    ("/api/estimate-market-value/", "components/SalaryMarketEstimator.tsx"),
+    ("/api/estimate-proficiency/", "components/SkillProficiencyEstimator.tsx"),
+    ("/api/analyze-projects/", "components/ProjectPortfolioScorer.tsx"),
+    ("/api/analyze-tone/", "components/ToneCultureFitAnalyzer.tsx"),
+    # Routed in ded2a8a (#777), then dropped by a later merge that kept the
+    # view function. Same conflict-residue shape as #872.
+    ("/api/import-jd-url/", "components/JdVisualizerPanel.tsx"),
 ]
 
 #: Endpoints that are open by default and therefore must declare a throttle.

--- a/backend/analyzer/tests_orphaned_endpoints.py
+++ b/backend/analyzer/tests_orphaned_endpoints.py
@@ -1,0 +1,340 @@
+"""Behaviour of the five endpoints routed in #1006.
+
+``tests_api_routes`` asserts that a path resolves. That is deliberately all it
+asserts, so it cannot tell the difference between a route that works and a route
+that resolves to a view which 500s on every call. These five had never been
+reached by a request at all -- the view classes shipped with unit tests for the
+engine behind them and no test that went through the URL -- so this file drives
+each one end to end.
+
+What it checks, per endpoint:
+
+  - a valid body returns 200 and the shape the response serializer declares
+  - an invalid body returns 400 rather than a traceback
+  - failures do not put the exception string in the response
+  - the throttle is declared and its scope resolves to a real rate
+"""
+
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+from rest_framework.throttling import SimpleRateThrottle
+
+
+def throttled_at(scope, rate):
+    """Temporarily set the rate for one throttle scope.
+
+    Same reasoning as ``tests_public_endpoint_limits.throttled_at``:
+    ``SimpleRateThrottle.THROTTLE_RATES`` is a class attribute bound at import
+    time, so ``override_settings`` does not reach it.
+    """
+    return patch.dict(SimpleRateThrottle.THROTTLE_RATES, {scope: rate})
+
+
+RESUME = (
+    "Senior Engineer with 8+ years of experience in Python. "
+    "Architected a payments platform serving 10k users, "
+    "reducing checkout latency by 30%. "
+    "Projects\n"
+    "Billing Rewrite: Built a React dashboard adopted by 40 teams."
+)
+
+
+class EndpointContractTests(TestCase):
+    """Each newly routed endpoint answers a well-formed request."""
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_tone_analysis_returns_the_declared_shape(self):
+        resp = self.client.post(
+            "/api/analyze-tone/", {"resume_text": RESUME}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        for field in (
+            "confidence_score",
+            "collaboration_score",
+            "clarity_score",
+            "overall_tone",
+            "pronoun_dominance",
+            "suggestions",
+        ):
+            self.assertIn(field, resp.data)
+
+    def test_project_extraction_returns_the_declared_shape(self):
+        resp = self.client.post(
+            "/api/analyze-projects/", {"resume_text": RESUME}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("total_projects_found", resp.data)
+        self.assertIn("average_impact_score", resp.data)
+        self.assertIn("projects", resp.data)
+
+    def test_proficiency_estimation_returns_the_declared_shape(self):
+        resp = self.client.post(
+            "/api/estimate-proficiency/",
+            {"resume_text": RESUME, "skills": ["Python", "React"]},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["total_skills_analyzed"], 2)
+        self.assertIn("high_risk_claims_count", resp.data)
+
+    def test_market_value_returns_the_declared_shape(self):
+        resp = self.client.post(
+            "/api/estimate-market-value/",
+            {
+                "target_role": "Software Engineer",
+                "experience_level": "Senior",
+                "skills": ["AWS", "Kubernetes"],
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("salary_range", resp.data)
+        self.assertIn("negotiation_talking_points", resp.data)
+        self.assertLess(
+            resp.data["salary_range"]["min"], resp.data["salary_range"]["max"]
+        )
+
+    def test_gap_narrative_returns_the_declared_shape(self):
+        """Includes total_narratives_generated.
+
+        ``GapNarrativeResponseSerializer`` declares that field as required and
+        the view never built it, so ``is_valid(raise_exception=True)`` threw and
+        the except block below it turned every *successful* analysis into a 500.
+        """
+        resp = self.client.post(
+            "/api/generate-gap-narrative/",
+            {
+                "timeline_data": [
+                    {
+                        "role": "Engineer",
+                        "start_date": "Jan 2020",
+                        "end_date": "Present",
+                    }
+                ],
+                "context": {"skills": "Python"},
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("total_gaps_detected", resp.data)
+        self.assertIn("total_narratives_generated", resp.data)
+        self.assertIn("gaps", resp.data)
+
+
+class EndpointValidationTests(TestCase):
+    """A malformed body is a 400, not a traceback."""
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_missing_required_fields_are_rejected(self):
+        for path, body in (
+            ("/api/analyze-tone/", {}),
+            ("/api/analyze-projects/", {}),
+            ("/api/estimate-proficiency/", {"resume_text": RESUME}),
+            ("/api/estimate-market-value/", {"target_role": "Engineer"}),
+            ("/api/generate-gap-narrative/", {}),
+        ):
+            with self.subTest(path=path):
+                resp = self.client.post(path, body, format="json")
+                self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn("errors", resp.data)
+
+    def test_blank_resume_text_is_rejected(self):
+        for path in ("/api/analyze-tone/", "/api/analyze-projects/"):
+            with self.subTest(path=path):
+                resp = self.client.post(
+                    path, {"resume_text": ""}, format="json"
+                )
+                self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_is_not_allowed(self):
+        for path in (
+            "/api/analyze-tone/",
+            "/api/analyze-projects/",
+            "/api/estimate-proficiency/",
+            "/api/estimate-market-value/",
+            "/api/generate-gap-narrative/",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(
+                    self.client.get(path).status_code,
+                    status.HTTP_405_METHOD_NOT_ALLOWED,
+                )
+
+
+class ErrorDetailLeakTests(TestCase):
+    """An unexpected failure must not return the exception string.
+
+    All five views returned ``{"error": ..., "details": str(e)}``, which hands
+    the caller file paths, SQL and library internals. ``accessibility_views``
+    had already removed this pattern with a comment explaining why; these five
+    still carried it, and routing them is what made it reachable.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def assert_no_leak(self, path, body, target):
+        secret = "/srv/secret/path/credentials.db"
+        with patch(target, side_effect=RuntimeError(secret)):
+            resp = self.client.post(path, body, format="json")
+
+        self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertNotIn("details", resp.data)
+        self.assertNotIn(secret, str(resp.data))
+        self.assertIn("error", resp.data)
+
+    def test_tone_analysis_does_not_leak(self):
+        self.assert_no_leak(
+            "/api/analyze-tone/",
+            {"resume_text": RESUME},
+            "analyzer.tone_views.analyze_tone",
+        )
+
+    def test_project_extraction_does_not_leak(self):
+        self.assert_no_leak(
+            "/api/analyze-projects/",
+            {"resume_text": RESUME},
+            "analyzer.project_views.analyze_portfolio",
+        )
+
+    def test_proficiency_estimation_does_not_leak(self):
+        self.assert_no_leak(
+            "/api/estimate-proficiency/",
+            {"resume_text": RESUME, "skills": ["Python"]},
+            "analyzer.proficiency_views.estimate_all_proficiencies",
+        )
+
+    def test_market_value_does_not_leak(self):
+        self.assert_no_leak(
+            "/api/estimate-market-value/",
+            {"target_role": "Engineer", "experience_level": "Senior"},
+            "analyzer.market_views.calculate_salary_range",
+        )
+
+    def test_gap_narrative_does_not_leak(self):
+        self.assert_no_leak(
+            "/api/generate-gap-narrative/",
+            {
+                "timeline_data": [
+                    {"role": "A", "start_date": "Jan 2020", "end_date": "Present"}
+                ]
+            },
+            "analyzer.gap_views.detect_gaps",
+        )
+
+
+class EndpointThrottleTests(TestCase):
+    """The ceilings actually engage.
+
+    ``OpenEndpointThrottleTests`` asserts a throttle is *declared*. This asserts
+    one of them is enforced, so a scope name that never resolves to a rate does
+    not pass as protection.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_tone_analysis_is_capped(self):
+        def call():
+            return self.client.post(
+                "/api/analyze-tone/", {"resume_text": RESUME}, format="json"
+            )
+
+        with throttled_at("tone_analysis", "2/hour"):
+            self.assertEqual(call().status_code, status.HTTP_200_OK)
+            self.assertEqual(call().status_code, status.HTTP_200_OK)
+            self.assertEqual(
+                call().status_code, status.HTTP_429_TOO_MANY_REQUESTS
+            )
+
+    def test_availability_check_is_capped(self):
+        """The enumeration oracle. Open by design, unbounded by accident."""
+
+        def call(name):
+            return self.client.get(
+                "/api/auth/check-availability/",
+                {"field": "username", "value": name},
+            )
+
+        with throttled_at("availability_check", "2/hour"):
+            self.assertEqual(call("alice").status_code, status.HTTP_200_OK)
+            self.assertEqual(call("bob").status_code, status.HTTP_200_OK)
+            self.assertEqual(
+                call("carol").status_code, status.HTTP_429_TOO_MANY_REQUESTS
+            )
+
+    def test_each_new_scope_is_distinct(self):
+        """One endpoint's traffic must not consume another's budget.
+
+        Every AnonRateThrottle subclass inherits scope "anon" unless it sets
+        one, which would have shared a single bucket across all five.
+        """
+        from .gap_views import GapNarrativeThrottle
+        from .market_views import MarketValueThrottle
+        from .proficiency_views import ProficiencyEstimationThrottle
+        from .project_views import ProjectExtractionThrottle
+        from .tone_views import ToneAnalysisThrottle
+
+        scopes = [
+            GapNarrativeThrottle.scope,
+            MarketValueThrottle.scope,
+            ProficiencyEstimationThrottle.scope,
+            ProjectExtractionThrottle.scope,
+            ToneAnalysisThrottle.scope,
+        ]
+        self.assertEqual(len(scopes), len(set(scopes)))
+        self.assertNotIn("anon", scopes)
+
+
+class ImportJdUrlRouteTests(TestCase):
+    """The route dropped by a merge that kept the view.
+
+    Added in ded2a8a (#777), absent from urls.py on main, with
+    ``import_jd_url_view`` still defined in views.py -- the same
+    conflict-residue shape as #872.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_route_reaches_the_view(self):
+        resp = self.client.post("/api/import-jd-url/", {"url": ""}, format="json")
+        # 400 from the view's own validation, not 404 from the resolver.
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", resp.data)
+
+    def test_non_http_scheme_is_rejected_before_any_fetch(self):
+        with patch("requests.get") as fetch:
+            resp = self.client.post(
+                "/api/import-jd-url/", {"url": "file:///etc/passwd"}, format="json"
+            )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        fetch.assert_not_called()
+
+    def test_outbound_fetching_is_capped(self):
+        """Unthrottled this is a request forwarder pointed at any URL."""
+
+        def call():
+            return self.client.post(
+                "/api/import-jd-url/", {"url": ""}, format="json"
+            )
+
+        with throttled_at("import_jd_url", "2/hour"):
+            self.assertEqual(call().status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(call().status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                call().status_code, status.HTTP_429_TOO_MANY_REQUESTS
+            )

--- a/backend/analyzer/tone_views.py
+++ b/backend/analyzer/tone_views.py
@@ -2,9 +2,12 @@
 Views for Tone Analyzer.
 """
 
+import logging
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.throttling import AnonRateThrottle
 from .tone_analyzer import analyze_tone
 from .tone_serializers import (
     ToneAnalysisRequestSerializer,
@@ -12,8 +15,29 @@ from .tone_serializers import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
+class ToneAnalysisThrottle(AnonRateThrottle):
+    """Caps the ToneAnalysisView endpoint.
+
+    ``DEFAULT_PERMISSION_CLASSES`` is ``AllowAny`` and this view does not
+    override it, so the endpoint is open. It runs four regex families over a
+    caller-supplied body. Rate from
+    ``DEFAULT_THROTTLE_RATES["tone_analysis"]``.
+
+    ``scope`` is set explicitly: every ``AnonRateThrottle`` subclass inherits
+    the scope "anon" otherwise, which would put this endpoint in the same
+    bucket as unrelated ones.
+    """
+
+    scope = "tone_analysis"
+
+
 class ToneAnalysisView(APIView):
     """API View to analyze resume tone and cultural fit."""
+
+    throttle_classes = [ToneAnalysisThrottle]
 
     def post(self, request, *args, **kwargs):
         request_serializer = ToneAnalysisRequestSerializer(data=request.data)
@@ -39,11 +63,12 @@ class ToneAnalysisView(APIView):
 
             return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
+            # `str(e)` used to go back in a "details" field. That hands the
+            # caller file paths, SQL and library internals on any unexpected
+            # failure; the operator wants that detail, the client does not.
+            logger.exception("Tone analysis failed")
             return Response(
-                {
-                    "error": "An unexpected error occurred during tone analysis.",
-                    "details": str(e),
-                },
+                {"error": "An unexpected error occurred during tone analysis."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -35,6 +35,7 @@ from .views import (
     webhook_detail,
     test_webhook,
     preview_experience_level_view,
+    import_jd_url_view,
 )
 from .badge_views import manage_resume_badge, resume_score_badge
 
@@ -57,6 +58,15 @@ from .cliche_views import ClicheDetectorView
 from .linkedin_views import LinkedInOptimizationView
 from .sanitizer_views import FileMetadataView, SanitizeResumeView
 
+# And again, for the five features merged in #945-#949 (#1006). Same shape as
+# the two batches above: view class, serializers, unit tests, no path. The
+# frontend components for all five already POST to the URLs below.
+from .gap_views import GapNarrativeView
+from .market_views import MarketValueView
+from .proficiency_views import ProficiencyEstimationView
+from .project_views import ProjectExtractionView
+from .tone_views import ToneAnalysisView
+
 urlpatterns = [
     path("upload/", upload_resume),
     path("preview-level/", preview_experience_level_view),
@@ -64,6 +74,8 @@ urlpatterns = [
     path("mock-interview/", mock_interview_view),
     path("compare-uploads/", compare_uploads),
     path("analyze-jd/", analyze_jd_view),
+    # Routed in ded2a8a (#777) and dropped by a later merge that kept the view.
+    path("import-jd-url/", import_jd_url_view, name="import_jd_url"),
     path("compare-bulk-jds/", compare_bulk_jds_view),
     path("compare-bulk-resumes/", compare_bulk_resumes_view),
     path("profile/", user_profile_view),
@@ -184,5 +196,45 @@ urlpatterns = [
         "sanitize-resume/",
         SanitizeResumeView.as_view(),
         name="sanitize_resume",
+    ),
+
+    # Gap explanation and narrative builder (#946).
+    # frontend/src/components/GapNarrativeBuilder.tsx
+    path(
+        "generate-gap-narrative/",
+        GapNarrativeView.as_view(),
+        name="generate_gap_narrative",
+    ),
+
+    # Market value and salary estimator (#947).
+    # frontend/src/components/SalaryMarketEstimator.tsx
+    path(
+        "estimate-market-value/",
+        MarketValueView.as_view(),
+        name="estimate_market_value",
+    ),
+
+    # Skill proficiency estimator (#945).
+    # frontend/src/components/SkillProficiencyEstimator.tsx
+    path(
+        "estimate-proficiency/",
+        ProficiencyEstimationView.as_view(),
+        name="estimate_proficiency",
+    ),
+
+    # Project portfolio extractor and impact scorer (#948).
+    # frontend/src/components/ProjectPortfolioScorer.tsx
+    path(
+        "analyze-projects/",
+        ProjectExtractionView.as_view(),
+        name="analyze_projects",
+    ),
+
+    # Tone and sentiment analyzer (#949).
+    # frontend/src/components/ToneCultureFitAnalyzer.tsx
+    path(
+        "analyze-tone/",
+        ToneAnalysisView.as_view(),
+        name="analyze_tone",
     ),
 ]

--- a/backend/analyzer/views.py
+++ b/backend/analyzer/views.py
@@ -132,6 +132,38 @@ class SignupThrottle(AnonRateThrottle):
     scope = "signup"
 
 
+class AvailabilityCheckThrottle(AnonRateThrottle):
+    """Caps /api/auth/check-availability/.
+
+    The endpoint is ``AllowAny`` and answers "does an account with this
+    username/email exist?" for anyone who asks. With no ceiling that is an
+    enumeration oracle: walk a wordlist, or a breach dump of email addresses,
+    at whatever rate the network allows and learn which ones have accounts
+    here.
+
+    A throttle does not make the oracle go away -- the signup form needs the
+    answer, so the endpoint has to exist -- but it puts a cost on walking it in
+    bulk. Set higher than the analysis endpoints because a legitimate caller
+    hits this once per field as the user types.
+    """
+
+    scope = "availability_check"
+
+
+class ImportJdUrlThrottle(AnonRateThrottle):
+    """Caps /api/import-jd-url/.
+
+    This is the only open endpoint that makes an outbound request to a
+    caller-supplied URL. Unthrottled it is a request forwarder: anyone can have
+    the server issue GETs, at whatever rate they like, from the server's own
+    address and with an 8 second timeout each. Kept deliberately low -- one
+    call is a whole page fetch and parse, and a legitimate user imports a job
+    description a handful of times.
+    """
+
+    scope = "import_jd_url"
+
+
 class SkillsLeaderboardThrottle(AnonRateThrottle):
     """Rate limit for the leaderboard.
 
@@ -228,6 +260,7 @@ def signup(request):
 )
 @api_view(["GET"])
 @permission_classes([AllowAny])
+@throttle_classes([AvailabilityCheckThrottle])
 def check_availability(request):
     field = request.GET.get("field", "").strip().lower()
     value = request.GET.get("value", "").strip()
@@ -1478,6 +1511,7 @@ def analyze_jd_view(request):
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([ImportJdUrlThrottle])
 def import_jd_url_view(request):
     url = request.data.get("url", "").strip()
     if not url:

--- a/backend/resume_analyzer/settings.py
+++ b/backend/resume_analyzer/settings.py
@@ -242,6 +242,29 @@ REST_FRAMEWORK = {
         # request body to disk before it does anything else.
         'file_metadata': os.environ.get('FILE_METADATA_RATE', '20/hour'),
         'sanitize_resume': os.environ.get('SANITIZE_RESUME_RATE', '60/hour'),
+        # The five features merged in #945-#949 repeated the pattern: view
+        # classes with no permission_classes and no throttle_classes, and this
+        # time no routes either, so nothing surfaced it. Routing them (#1006)
+        # opens five more unauthenticated endpoints, so each gets its own
+        # ceiling and its own scope.
+        'gap_narrative': os.environ.get('GAP_NARRATIVE_RATE', '60/hour'),
+        'market_value': os.environ.get('MARKET_VALUE_RATE', '60/hour'),
+        # Lower than its neighbours: cost here is body size times the number of
+        # skills asked for, not body size alone.
+        'proficiency_estimation': os.environ.get(
+            'PROFICIENCY_ESTIMATION_RATE', '30/hour'
+        ),
+        'project_extraction': os.environ.get('PROJECT_EXTRACTION_RATE', '60/hour'),
+        'tone_analysis': os.environ.get('TONE_ANALYSIS_RATE', '60/hour'),
+        # /api/auth/check-availability/ answers "does this account exist?" to
+        # anyone, and had no ceiling at all -- an enumeration oracle walkable
+        # at whatever rate the network allows. Higher than the analysis
+        # endpoints because the signup form calls it as the user types.
+        'availability_check': os.environ.get('AVAILABILITY_CHECK_RATE', '120/hour'),
+        # /api/import-jd-url/ is the only open endpoint that makes an outbound
+        # request to a caller-supplied URL. Low on purpose: one call is a full
+        # page fetch and parse issued from the server's own address.
+        'import_jd_url': os.environ.get('IMPORT_JD_URL_RATE', '20/hour'),
     },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }


### PR DESCRIPTION
Closes #1006

## Five features were 404ing

Five `APIView` subclasses shipped with serializers, unit tests, and React components calling them — and no `path()`:

| View | Route added | Frontend caller |
|---|---|---|
| `GapNarrativeView` | `POST /api/generate-gap-narrative/` | `GapNarrativeBuilder.tsx:59` |
| `MarketValueView` | `POST /api/estimate-market-value/` | `SalaryMarketEstimator.tsx:36` |
| `ProficiencyEstimationView` | `POST /api/estimate-proficiency/` | `SkillProficiencyEstimator.tsx:36` |
| `ProjectExtractionView` | `POST /api/analyze-projects/` | `ProjectPortfolioScorer.tsx:35` |
| `ToneAnalysisView` | `POST /api/analyze-tone/` | `ToneCultureFitAnalyzer.tsx:29` |

Five features that were reviewed, merged and are visible in the UI, where the user clicks the button and gets a 404. This is the same failure mode as #936 for the previous batch — that one was fixed by routing them, and the batch merged after it repeated the mistake with nobody re-running the guard.

## Routing them alone would have made things worse

None of the five sets `permission_classes` or `throttle_classes`, and `DEFAULT_PERMISSION_CLASSES` is `AllowAny`. Adding paths would have opened five unauthenticated endpoints that run regex passes over a caller-controlled body. `OpenEndpointThrottleTests` exists precisely to stop that and was already red for a different reason.

Each view gets an `AnonRateThrottle` subclass with an **explicit** `scope`, following `accessibility_views.py`. The explicit scope matters: every `AnonRateThrottle` subclass inherits `scope = "anon"` otherwise, so all five would have shared one bucket with each other and with unrelated endpoints. There is a test asserting the five scopes are distinct and that none is `"anon"`.

Rates are env-overridable, per the existing convention. `proficiency_estimation` is set lower than its neighbours because its cost is body size **times** skill count, not body size alone.

## All five leaked exception strings

```python
except Exception as e:
    return Response({"error": "...", "details": str(e)}, status=500)
```

`accessibility_views.py` had already removed this pattern, with a comment noting it hands the caller file paths, SQL and library internals. These five still carried it — and routing them is exactly what made it reachable. They now `logger.exception(...)` and return the message alone. Each has a test that injects a failure carrying a fake path and asserts it does not appear in the response.

## `GapNarrativeView` would have 500'd on every success

`GapNarrativeResponseSerializer` declares `total_narratives_generated` as required. The view never built it, so `is_valid(raise_exception=True)` threw — straight into the `except Exception` below it. Every **successful** analysis would have returned "an unexpected error occurred". Computed now, with a test that asserts the field is present.

This is the kind of thing only a request can find: the engine had unit tests, and none of them went through the view.

## Two more route-table problems the guards flagged

**`import-jd-url/` was lost in a merge.** Routed in ded2a8a (#777), absent from `urls.py` on `main`, with `import_jd_url_view` still sitting in `views.py` — the same conflict-residue shape as #872. Restored.

Restoring it turned `OpenEndpointThrottleTests` red again, correctly: it is the only open endpoint that makes an **outbound request to a caller-supplied URL**. Unthrottled it is a request forwarder — anyone can have the server issue GETs from its own address, 8s timeout each, at any rate. Given a deliberately low ceiling (20/hour).

**`check_availability` was an unbounded enumeration oracle.** `AllowAny`, answers "does an account with this username/email exist?", no rate limit — walk a wordlist or a breach dump and learn which addresses have accounts here. A throttle does not remove the oracle (the signup form needs the answer) but it puts a cost on walking it in bulk. Set higher than the analysis endpoints because the form calls it as the user types.

## Tests

Six paths added to the `ROUTES` contract table, plus **`tests_orphaned_endpoints.py`** — 19 tests driving each endpoint through its URL for the first time. `tests_api_routes` deliberately checks only that a path resolves, so it cannot distinguish a working route from one that resolves to a view which 500s on every call; that gap is what hid the `total_narratives_generated` bug.

Covered: response shape per endpoint; 400 on missing/blank fields; 405 on GET; no exception string in any 500; throttles actually engaging (not merely declared, so a scope name that never resolves to a rate cannot pass as protection); scopes distinct; `import-jd-url` reaching the view and rejecting non-HTTP schemes before any fetch.

```
analyzer.tests_api_routes            37 tests   OK
analyzer.tests_orphaned_endpoints    19 tests   OK
```

Full backend suite: both `tests_api_routes` failures gone, no new ones.

## Merge order

The seven failures still red on this branch are engine bugs in the modules behind these views, each with its own PR: #1010 (#1007), #1011 (#1008), #1012 (#1009).

**#1010 is worth merging before or with this one.** `detect_gaps` currently reports a gap for almost any two-role timeline and `generate_narratives` then raises `KeyError: 'certifications'`, so on `main` today `/api/generate-gap-narrative/` would 500 for most real input. Routing is still strictly better than a 404 and the endpoint is correct for single-role timelines, but the two together are what make the feature work. The other three are quality-of-output fixes and merge in any order.
