### PR TITLE
feat(analyzer): add interactive skills radar visualization

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { WhatsNewModal } from './components/WhatsNewModal'
 import { shouldShowWhatsNew } from './data/whatsNewReleases'
 import { ShareResult } from './components/ShareResult'
 import { setResumeRoastConsent } from './utils/cookieConsent'
+import { SkillsRadarChart } from './components/SkillsRadarChart'
 
 type Theme = 'light' | 'dark'
 
@@ -1201,6 +1202,9 @@ function App() {
                   </div>
                 </div>
               </div>
+
+              {/* Skills Radar Chart */}
+              <SkillsRadarChart skills={skills} />
 
               {/* Skills You're Closest to Matching (Partial Credit Suggestions) */}
               {partialSkills.length > 0 && (

--- a/frontend/src/components/SkillsRadar.css
+++ b/frontend/src/components/SkillsRadar.css
@@ -1,0 +1,413 @@
+/* ── Skills Radar Chart ─────────────────────────────────────────────────────── */
+
+.skills-radar {
+  margin-top: 20px;
+}
+
+/* ── Toggle Header (matches ScoreBreakdown pattern) ─────────────────────── */
+
+.skills-radar__toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface-soft-bg);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md, 8px);
+  padding: 14px 18px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.skills-radar__toggle:hover {
+  background: var(--surface-strong-bg);
+  border-color: rgba(99, 102, 241, 0.3);
+}
+
+.skills-radar__toggle:focus-visible {
+  outline: 2px solid var(--score-accent, #6366f1);
+  outline-offset: 2px;
+}
+
+.skills-radar__toggle-text {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.skills-radar__title {
+  font-size: var(--text-md, 1rem);
+  font-weight: 700;
+  color: var(--heading-text, #fff);
+}
+
+.skills-radar__subtitle {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--muted-text, #94a3b8);
+  font-weight: 500;
+}
+
+.skills-radar__chevron {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--muted-text, #94a3b8);
+  transition: transform 0.2s ease;
+}
+
+/* ── Panel ────────────────────────────────────────────────────────────────── */
+
+.skills-radar__panel {
+  animation: radarPanelSlideIn 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes radarPanelSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.skills-radar__content {
+  display: flex;
+  gap: 24px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+/* ── SVG Chart ────────────────────────────────────────────────────────────── */
+
+.skills-radar__chart-wrapper {
+  position: relative;
+  flex: 0 0 auto;
+  width: 360px;
+  max-width: 100%;
+}
+
+.skills-radar__svg {
+  width: 100%;
+  height: auto;
+}
+
+.skills-radar__ring {
+  fill: none;
+  stroke: var(--surface-border, rgba(255, 255, 255, 0.1));
+  stroke-width: 1;
+}
+
+.skills-radar__axis {
+  stroke: var(--surface-border, rgba(255, 255, 255, 0.1));
+  stroke-width: 0.8;
+}
+
+.skills-radar__polygon {
+  fill: rgba(99, 102, 241, 0.2);
+  stroke: var(--color-primary, #6366f1);
+  stroke-width: 2;
+  transition: fill 0.3s ease;
+}
+
+.skills-radar__hit-area {
+  fill: transparent;
+  cursor: pointer;
+}
+
+.skills-radar__dot {
+  stroke: var(--surface-bg, rgba(2, 6, 23, 0.8));
+  stroke-width: 2;
+  transition: r 0.2s ease;
+}
+
+.skills-radar__dot--filled {
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.2));
+}
+
+.skills-radar__label {
+  font-size: 11px;
+  font-weight: 600;
+  fill: var(--muted-text, #94a3b8);
+  cursor: pointer;
+  transition: fill 0.2s ease;
+  pointer-events: all;
+  user-select: none;
+}
+
+.skills-radar__label--active {
+  fill: var(--heading-text, #fff);
+}
+
+.skills-radar__ring-label {
+  font-size: 8px;
+  fill: var(--muted-text, #94a3b8);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+/* ── Tooltip ──────────────────────────────────────────────────────────────── */
+
+.radar-tooltip {
+  position: absolute;
+  background: var(--tooltip-bg, #1e293b);
+  color: var(--tooltip-text, #f8fafc);
+  border: 1px solid var(--surface-border, rgba(255, 255, 255, 0.15));
+  border-radius: var(--radius-md, 8px);
+  padding: 10px 14px;
+  min-width: 160px;
+  max-width: 240px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  z-index: 50;
+  pointer-events: none;
+  animation: radarTooltipFadeIn 0.15s ease-out;
+}
+
+@keyframes radarTooltipFadeIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -100%) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -100%) translateY(0);
+  }
+}
+
+.radar-tooltip__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.radar-tooltip__icon {
+  font-size: 14px;
+}
+
+.radar-tooltip__domain {
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.radar-tooltip__count {
+  margin-left: auto;
+  font-size: 11px;
+  opacity: 0.7;
+  font-weight: 500;
+}
+
+.radar-tooltip__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.radar-tooltip__list li::before {
+  content: '• ';
+  opacity: 0.5;
+}
+
+.radar-tooltip__more {
+  font-style: italic;
+  opacity: 0.6;
+}
+
+/* ── Sidebar ──────────────────────────────────────────────────────────────── */
+
+.skills-radar__sidebar {
+  flex: 1;
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ── Coverage Badge ───────────────────────────────────────────────────────── */
+
+.coverage-badge {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid var(--surface-border, rgba(255, 255, 255, 0.1));
+  background: var(--surface-soft-bg);
+  transition: border-color 0.2s ease;
+}
+
+.coverage-badge__score {
+  font-size: 1.6rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.coverage-badge__label {
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.coverage-badge--excellent {
+  border-color: rgba(34, 197, 94, 0.4);
+}
+.coverage-badge--excellent .coverage-badge__score {
+  color: #22c55e;
+}
+
+.coverage-badge--good {
+  border-color: rgba(59, 130, 246, 0.4);
+}
+.coverage-badge--good .coverage-badge__score {
+  color: #3b82f6;
+}
+
+.coverage-badge--narrow {
+  border-color: rgba(245, 158, 11, 0.4);
+}
+.coverage-badge--narrow .coverage-badge__score {
+  color: #f59e0b;
+}
+
+.coverage-badge--sparse {
+  border-color: rgba(239, 68, 68, 0.4);
+}
+.coverage-badge--sparse .coverage-badge__score {
+  color: #ef4444;
+}
+
+/* ── Insights ─────────────────────────────────────────────────────────────── */
+
+.skills-radar__insight {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skills-radar__insight-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 14px;
+  background: var(--surface-soft-bg);
+  border: 1px solid var(--surface-border, rgba(255, 255, 255, 0.1));
+  border-radius: var(--radius-md, 8px);
+}
+
+.skills-radar__insight-icon {
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.skills-radar__insight-value {
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--heading-text, #fff);
+}
+
+.skills-radar__insight-count {
+  font-weight: 400;
+  opacity: 0.65;
+  font-size: var(--text-xs, 0.75rem);
+}
+
+/* ── Legend ────────────────────────────────────────────────────────────────── */
+
+.radar-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--surface-border, rgba(255, 255, 255, 0.1));
+}
+
+.radar-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--surface-soft-bg);
+  border: 1px solid var(--surface-border, rgba(255, 255, 255, 0.1));
+  border-radius: 20px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--body-text, #fff);
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.radar-legend__item:hover,
+.radar-legend__item--active {
+  background: var(--surface-strong-bg);
+  border-color: rgba(99, 102, 241, 0.4);
+  transform: translateY(-1px);
+}
+
+.radar-legend__item--empty {
+  opacity: 0.4;
+}
+
+.radar-legend__item--empty:hover {
+  opacity: 0.7;
+}
+
+.radar-legend__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.radar-legend__icon {
+  font-size: 13px;
+}
+
+.radar-legend__label {
+  font-size: 12px;
+}
+
+.radar-legend__count {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 18px;
+  text-align: center;
+}
+
+[data-theme='dark'] .radar-legend__count {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme='light'] .radar-legend__count {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .skills-radar__content {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .skills-radar__chart-wrapper {
+    width: 300px;
+  }
+
+  .skills-radar__sidebar {
+    width: 100%;
+    min-width: unset;
+  }
+
+  .radar-legend {
+    justify-content: center;
+  }
+}

--- a/frontend/src/components/SkillsRadar.test.tsx
+++ b/frontend/src/components/SkillsRadar.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SkillsRadarChart } from './SkillsRadarChart'
+import {
+  SKILL_DOMAINS,
+  categoriseSkills,
+  polarToCartesian,
+  buildRadarPolygon,
+  buildRadarRings,
+  buildRadarAxes,
+  verticesToPoints,
+  domainCoverageScore,
+  domainExtremes,
+} from '../utils/skillsRadar'
+
+// ── Utility function tests ───────────────────────────────────────────────────
+
+describe('categoriseSkills', () => {
+  it('groups skills into the correct domains', () => {
+    const skills = ['React', 'Docker', 'PostgreSQL', 'Jest']
+    const result = categoriseSkills(skills)
+
+    expect(result.get('frontend')?.has('React')).toBe(true)
+    expect(result.get('devops')?.has('Docker')).toBe(true)
+    expect(result.get('database')?.has('PostgreSQL')).toBe(true)
+    expect(result.get('testing')?.has('Jest')).toBe(true)
+  })
+
+  it('handles case-insensitive matching', () => {
+    const skills = ['PYTHON', 'pyTorch', 'Next.js']
+    const result = categoriseSkills(skills)
+
+    expect(result.get('languages')?.has('PYTHON')).toBe(true)
+    expect(result.get('aiml')?.has('pyTorch')).toBe(true)
+    expect(result.get('frontend')?.has('Next.js')).toBe(true)
+  })
+
+  it('assigns each skill to at most one domain', () => {
+    // "SQL" could match languages or database; first match wins
+    const skills = ['SQL', 'TypeScript']
+    const result = categoriseSkills(skills)
+
+    const sqlDomains = SKILL_DOMAINS.filter(
+      (d) => result.get(d.key)?.has('SQL'),
+    )
+    expect(sqlDomains.length).toBe(1)
+  })
+
+  it('returns empty sets for unknown skills', () => {
+    const result = categoriseSkills(['zzzznotaskill'])
+    for (const domain of SKILL_DOMAINS) {
+      expect(result.get(domain.key)?.size).toBe(0)
+    }
+  })
+
+  it('returns all domain keys', () => {
+    const result = categoriseSkills([])
+    for (const domain of SKILL_DOMAINS) {
+      expect(result.has(domain.key)).toBe(true)
+    }
+  })
+})
+
+describe('polarToCartesian', () => {
+  it('returns centre when radius is 0', () => {
+    const pt = polarToCartesian(100, 100, 0, 0)
+    expect(pt.x).toBe(100)
+    expect(pt.y).toBe(100)
+  })
+
+  it('returns top point for angle 0', () => {
+    const pt = polarToCartesian(0, 0, 0, 50)
+    expect(pt.x).toBeCloseTo(0)
+    expect(pt.y).toBeCloseTo(-50)
+  })
+
+  it('returns right point for angle 90', () => {
+    const pt = polarToCartesian(0, 0, 90, 50)
+    expect(pt.x).toBeCloseTo(50)
+    expect(pt.y).toBeCloseTo(0)
+  })
+})
+
+describe('buildRadarPolygon', () => {
+  it('returns empty array for empty values', () => {
+    expect(buildRadarPolygon([], 100, 100, 50)).toEqual([])
+  })
+
+  it('returns n vertices for n values', () => {
+    const pts = buildRadarPolygon([0.5, 0.8, 0.3, 0.6, 0.9], 100, 100, 50)
+    expect(pts).toHaveLength(5)
+  })
+
+  it('clamps values to 0–1', () => {
+    const pts = buildRadarPolygon([1.5, -0.3], 0, 0, 100)
+    // First point should be at maxRadius, second at 0
+    expect(pts[0].x).not.toBeNaN()
+    expect(pts[1].x).not.toBeNaN()
+  })
+})
+
+describe('buildRadarRings', () => {
+  it('returns the correct number of rings', () => {
+    const rings = buildRadarRings(100, 100, 80, 5)
+    expect(rings).toHaveLength(5)
+  })
+
+  it('each ring has as many vertices as domains', () => {
+    const rings = buildRadarRings(100, 100, 80, 3)
+    for (const ring of rings) {
+      expect(ring).toHaveLength(SKILL_DOMAINS.length)
+    }
+  })
+})
+
+describe('buildRadarAxes', () => {
+  it('returns one axis per domain', () => {
+    const axes = buildRadarAxes(100, 100, 80)
+    expect(axes).toHaveLength(SKILL_DOMAINS.length)
+  })
+
+  it('every axis starts at the centre', () => {
+    const axes = buildRadarAxes(50, 50, 40)
+    for (const axis of axes) {
+      expect(axis.from.x).toBe(50)
+      expect(axis.from.y).toBe(50)
+    }
+  })
+})
+
+describe('verticesToPoints', () => {
+  it('produces a valid SVG points string', () => {
+    const pts = verticesToPoints([
+      { x: 10.123, y: 20.456 },
+      { x: 30.789, y: 40.012 },
+    ])
+    expect(pts).toBe('10.12,20.46 30.79,40.01')
+  })
+
+  it('returns empty string for empty array', () => {
+    expect(verticesToPoints([])).toBe('')
+  })
+})
+
+describe('domainCoverageScore', () => {
+  it('returns 100 when all domains have at least one skill', () => {
+    const counts = new Map<string, Set<string>>()
+    for (const d of SKILL_DOMAINS) {
+      counts.set(d.key, new Set(['skill']))
+    }
+    expect(domainCoverageScore(counts)).toBe(100)
+  })
+
+  it('returns 0 when no domain has any skill', () => {
+    const counts = new Map<string, Set<string>>()
+    for (const d of SKILL_DOMAINS) {
+      counts.set(d.key, new Set())
+    }
+    expect(domainCoverageScore(counts)).toBe(0)
+  })
+
+  it('returns proportional score', () => {
+    const counts = new Map<string, Set<string>>()
+    const half = Math.ceil(SKILL_DOMAINS.length / 2)
+    for (let i = 0; i < SKILL_DOMAINS.length; i++) {
+      counts.set(
+        SKILL_DOMAINS[i].key,
+        i < half ? new Set(['a']) : new Set(),
+      )
+    }
+    const expected = Math.round((half / SKILL_DOMAINS.length) * 100)
+    expect(domainCoverageScore(counts)).toBe(expected)
+  })
+})
+
+describe('domainExtremes', () => {
+  it('returns strongest and weakest indices', () => {
+    const values = [0.1, 0.9, 0.5, 0.3, 0.7, 0.2, 0.8, 0.4, 0.6, 0.0]
+    const { strongest, weakest } = domainExtremes(values)
+    expect(strongest).toBe(1) // 0.9
+    expect(weakest).toBe(9) // 0.0
+  })
+})
+
+// ── Component render tests ───────────────────────────────────────────────────
+
+describe('SkillsRadarChart', () => {
+  it('renders nothing when skills array is empty', () => {
+    const { container } = render(<SkillsRadarChart skills={[]} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the toggle button with skill count', () => {
+    render(<SkillsRadarChart skills={['React', 'Docker']} />)
+    expect(screen.getByText(/Skills Radar/)).toBeDefined()
+  })
+
+  it('expands the panel on toggle click', () => {
+    render(<SkillsRadarChart skills={['React', 'Docker', 'SQL']} />)
+    const toggle = screen.getByRole('button', { name: /Skills Radar/ })
+    toggle.click()
+
+    expect(screen.getByRole('img', { name: /Radar chart/ })).toBeDefined()
+  })
+
+  it('shows legend after expansion', () => {
+    render(<SkillsRadarChart skills={['React', 'Python', 'AWS']} />)
+    screen.getByRole('button', { name: /Skills Radar/ }).click()
+
+    expect(screen.getByRole('list', { name: /Skill domains/ })).toBeDefined()
+  })
+
+  it('displays coverage badge after expansion', () => {
+    render(<SkillsRadarChart skills={['React', 'Docker']} />)
+    screen.getByRole('button', { name: /Skills Radar/ }).click()
+
+    expect(screen.getByText(/Coverage/)).toBeDefined()
+  })
+})

--- a/frontend/src/components/SkillsRadarChart.tsx
+++ b/frontend/src/components/SkillsRadarChart.tsx
@@ -1,0 +1,371 @@
+import { useMemo, useState, useCallback } from 'react'
+import {
+  SKILL_DOMAINS,
+  categoriseSkills,
+  buildRadarPolygon,
+  buildRadarRings,
+  buildRadarAxes,
+  verticesToPoints,
+  domainCoverageScore,
+  domainExtremes,
+  type RadarPoint,
+} from '../utils/skillsRadar'
+import './SkillsRadar.css'
+
+// ── Chart constants ──────────────────────────────────────────────────────────
+
+const CHART_SIZE = 360
+const CX = CHART_SIZE / 2
+const CY = CHART_SIZE / 2
+const MAX_RADIUS = 140
+const LABEL_OFFSET = 18
+
+// ── Props ────────────────────────────────────────────────────────────────────
+
+export interface SkillsRadarChartProps {
+  /** Flat list of detected skills (e.g. `["React", "Docker", "SQL"]`). */
+  skills: string[]
+  /** Domain keys the user wants to highlight. Empty = show all. */
+  highlightDomains?: string[]
+}
+
+// ── Helper: domain label position (pushed out beyond the vertex) ─────────────
+
+function labelPosition(idx: number, total: number): RadarPoint {
+  const step = 360 / total
+  const rad = (((step * idx) - 90) * Math.PI) / 180
+  const r = MAX_RADIUS + LABEL_OFFSET
+  return {
+    x: CX + r * Math.cos(rad),
+    y: CY + r * Math.sin(rad),
+  }
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+/** Tooltip shown on hover over a polygon vertex. */
+function RadarTooltip({
+  domainKey,
+  skillCount,
+  skills,
+  position,
+}: {
+  domainKey: string
+  skillCount: number
+  skills: string[]
+  position: RadarPoint
+}) {
+  const domain = SKILL_DOMAINS.find((d) => d.key === domainKey)
+  if (!domain) return null
+  const displayed = skills.slice(0, 6)
+  const remaining = skills.length - displayed.length
+
+  return (
+    <div
+      className="radar-tooltip"
+      style={{
+        left: `${position.x}px`,
+        top: `${position.y - 8}px`,
+        transform: 'translate(-50%, -100%)',
+      }}
+      role="tooltip"
+    >
+      <div className="radar-tooltip__header">
+        <span className="radar-tooltip__icon">{domain.icon}</span>
+        <span className="radar-tooltip__domain">{domain.label}</span>
+        <span className="radar-tooltip__count">{skillCount} skill{skillCount !== 1 ? 's' : ''}</span>
+      </div>
+      {skills.length > 0 && (
+        <ul className="radar-tooltip__list">
+          {displayed.map((s) => (
+            <li key={s}>{s}</li>
+          ))}
+          {remaining > 0 && <li className="radar-tooltip__more">+{remaining} more</li>}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+/** Legend below the chart. */
+function RadarLegend({
+  domainCounts,
+  hoveredDomain,
+  onHover,
+  onLeave,
+}: {
+  domainCounts: Map<string, Set<string>>
+  hoveredDomain: string | null
+  onHover: (key: string) => void
+  onLeave: () => void
+}) {
+  return (
+    <div className="radar-legend" role="list" aria-label="Skill domains">
+      {SKILL_DOMAINS.map((domain) => {
+        const count = domainCounts.get(domain.key)?.size ?? 0
+        const isHovered = hoveredDomain === domain.key
+        const isEmpty = count === 0
+        return (
+          <button
+            key={domain.key}
+            type="button"
+            className={`radar-legend__item${isHovered ? ' radar-legend__item--active' : ''}${isEmpty ? ' radar-legend__item--empty' : ''}`}
+            onMouseEnter={() => onHover(domain.key)}
+            onMouseLeave={onLeave}
+            role="listitem"
+            aria-label={`${domain.label}: ${count} skills`}
+          >
+            <span
+              className="radar-legend__dot"
+              style={{ background: domain.color }}
+            />
+            <span className="radar-legend__icon">{domain.icon}</span>
+            <span className="radar-legend__label">{domain.label}</span>
+            <span className="radar-legend__count">{count}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Coverage badge showing how many domains have at least one skill. */
+function CoverageBadge({ score }: { score: number }) {
+  const label = score >= 80 ? 'Excellent' : score >= 50 ? 'Good' : score >= 25 ? 'Narrow' : 'Sparse'
+  const cls = score >= 80 ? 'coverage-badge--excellent' : score >= 50 ? 'coverage-badge--good' : score >= 25 ? 'coverage-badge--narrow' : 'coverage-badge--sparse'
+  return (
+    <div className={`coverage-badge ${cls}`}>
+      <span className="coverage-badge__score">{score}%</span>
+      <span className="coverage-badge__label">{label} Coverage</span>
+    </div>
+  )
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
+
+export function SkillsRadarChart({ skills, highlightDomains = [] }: SkillsRadarChartProps) {
+  const [hoveredDomain, setHoveredDomain] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState(false)
+
+  const domainCounts = useMemo(() => categoriseSkills(skills), [skills])
+
+  const normalisedValues = useMemo(() => {
+    const maxCount = Math.max(
+      1,
+      ...Array.from(domainCounts.values()).map((s) => s.size),
+    )
+    return SKILL_DOMAINS.map((d) => (domainCounts.get(d.key)?.size ?? 0) / maxCount)
+  }, [domainCounts])
+
+  const coverage = useMemo(() => domainCoverageScore(domainCounts), [domainCounts])
+  const { strongest, weakest } = useMemo(() => domainExtremes(normalisedValues), [normalisedValues])
+
+  const dataPolygon = useMemo(
+    () => buildRadarPolygon(normalisedValues, CX, CY, MAX_RADIUS),
+    [normalisedValues],
+  )
+
+  const rings = useMemo(() => buildRadarRings(CX, CY, MAX_RADIUS), [])
+  const axes = useMemo(() => buildRadarAxes(CX, CY, MAX_RADIUS), [])
+
+  const handleDomainHover = useCallback((key: string) => setHoveredDomain(key), [])
+  const handleDomainLeave = useCallback(() => setHoveredDomain(null), [])
+
+  if (skills.length === 0) return null
+
+  const highlightSet = new Set(highlightDomains)
+
+  return (
+    <section className="skills-radar" aria-label="Skills radar chart">
+      {/* Toggle header */}
+      <button
+        type="button"
+        className="skills-radar__toggle"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls="skills-radar-panel"
+      >
+        <span className="skills-radar__toggle-text">
+          <span id="skills-radar-heading" className="skills-radar__title">
+            🕸️ Skills Radar
+          </span>
+          <span className="skills-radar__subtitle">
+            {skills.length} skills across {Array.from(domainCounts.values()).filter((s) => s.size > 0).length} domains
+          </span>
+        </span>
+        <span className="skills-radar__chevron" aria-hidden="true">
+          {expanded ? '▲' : '▼'}
+        </span>
+      </button>
+
+      {expanded && (
+        <div id="skills-radar-panel" className="skills-radar__panel">
+          <div className="skills-radar__content">
+            {/* SVG chart */}
+            <div className="skills-radar__chart-wrapper">
+              <svg
+                viewBox={`0 0 ${CHART_SIZE} ${CHART_SIZE}`}
+                className="skills-radar__svg"
+                role="img"
+                aria-label="Radar chart of skill domains"
+              >
+                {/* Guide rings */}
+                {rings.map((ring, ri) => (
+                  <polygon
+                    key={`ring-${ri}`}
+                    points={verticesToPoints(ring)}
+                    className="skills-radar__ring"
+                  />
+                ))}
+
+                {/* Axis lines */}
+                {axes.map((axis, ai) => (
+                  <line
+                    key={`axis-${ai}`}
+                    x1={axis.from.x}
+                    y1={axis.from.y}
+                    x2={axis.to.x}
+                    y2={axis.to.y}
+                    className="skills-radar__axis"
+                  />
+                ))}
+
+                {/* Data polygon */}
+                <polygon
+                  points={verticesToPoints(dataPolygon)}
+                  className="skills-radar__polygon"
+                />
+
+                {/* Data vertices (interactive) */}
+                {dataPolygon.map((pt, i) => {
+                  const domain = SKILL_DOMAINS[i]
+                  const isHovered = hoveredDomain === domain.key
+                  const isHighlighted = highlightSet.has(domain.key)
+                  const hasSkills = (domainCounts.get(domain.key)?.size ?? 0) > 0
+                  return (
+                    <g key={domain.key}>
+                      {/* Larger invisible hit area */}
+                      <circle
+                        cx={pt.x}
+                        cy={pt.y}
+                        r={14}
+                        className="skills-radar__hit-area"
+                        onMouseEnter={() => handleDomainHover(domain.key)}
+                        onMouseLeave={handleDomainLeave}
+                      />
+                      {/* Visible dot */}
+                      <circle
+                        cx={pt.x}
+                        cy={pt.y}
+                        r={isHovered || isHighlighted ? 6 : 4}
+                        className={`skills-radar__dot${hasSkills ? ' skills-radar__dot--filled' : ''}`}
+                        style={{ fill: domain.color }}
+                        onMouseEnter={() => handleDomainHover(domain.key)}
+                        onMouseLeave={handleDomainLeave}
+                      />
+                    </g>
+                  )
+                })}
+
+                {/* Domain labels */}
+                {SKILL_DOMAINS.map((domain, i) => {
+                  const pos = labelPosition(i, SKILL_DOMAINS.length)
+                  const isHovered = hoveredDomain === domain.key
+                  return (
+                    <text
+                      key={`label-${domain.key}`}
+                      x={pos.x}
+                      y={pos.y}
+                      className={`skills-radar__label${isHovered ? ' skills-radar__label--active' : ''}`}
+                      textAnchor="middle"
+                      dominantBaseline="central"
+                      onMouseEnter={() => handleDomainHover(domain.key)}
+                      onMouseLeave={handleDomainLeave}
+                    >
+                      {domain.icon} {domain.label}
+                    </text>
+                  )
+                })}
+
+                {/* Ring value labels (20%, 40%, 60%, 80%, 100%) */}
+                {[0.2, 0.4, 0.6, 0.8, 1.0].map((pct, ri) => (
+                  <text
+                    key={`ring-label-${ri}`}
+                    x={CX + 4}
+                    y={CY - pct * MAX_RADIUS + 4}
+                    className="skills-radar__ring-label"
+                  >
+                    {Math.round(pct * 100)}
+                  </text>
+                ))}
+              </svg>
+
+              {/* Tooltip overlay */}
+              {hoveredDomain && (() => {
+                const idx = SKILL_DOMAINS.findIndex((d) => d.key === hoveredDomain)
+                if (idx === -1) return null
+                const pt = dataPolygon[idx]
+                if (!pt) return null
+                const skillsInDomain = Array.from(domainCounts.get(hoveredDomain) ?? [])
+                return (
+                  <RadarTooltip
+                    domainKey={hoveredDomain}
+                    skillCount={skillsInDomain.length}
+                    skills={skillsInDomain}
+                    position={pt}
+                  />
+                )
+              })()}
+            </div>
+
+            {/* Side panel */}
+            <div className="skills-radar__sidebar">
+              <CoverageBadge score={coverage} />
+
+              <div className="skills-radar__insight">
+                {SKILL_DOMAINS[strongest] && (
+                  <div className="skills-radar__insight-row">
+                    <span className="skills-radar__insight-icon" style={{ color: SKILL_DOMAINS[strongest].color }}>
+                      ▲ Strongest
+                    </span>
+                    <span className="skills-radar__insight-value">
+                      {SKILL_DOMAINS[strongest].icon} {SKILL_DOMAINS[strongest].label}
+                      {' '}
+                      <span className="skills-radar__insight-count">
+                        ({(domainCounts.get(SKILL_DOMAINS[strongest].key)?.size ?? 0)} skills)
+                      </span>
+                    </span>
+                  </div>
+                )}
+                {SKILL_DOMAINS[weakest] && (
+                  <div className="skills-radar__insight-row">
+                    <span className="skills-radar__insight-icon" style={{ color: SKILL_DOMAINS[weakest].color }}>
+                      ▼ Weakest
+                    </span>
+                    <span className="skills-radar__insight-value">
+                      {SKILL_DOMAINS[weakest].icon} {SKILL_DOMAINS[weakest].label}
+                      {' '}
+                      <span className="skills-radar__insight-count">
+                        ({(domainCounts.get(SKILL_DOMAINS[weakest].key)?.size ?? 0)} skills)
+                      </span>
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Legend */}
+          <RadarLegend
+            domainCounts={domainCounts}
+            hoveredDomain={hoveredDomain}
+            onHover={handleDomainHover}
+            onLeave={handleDomainLeave}
+          />
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default SkillsRadarChart

--- a/frontend/src/utils/skillsRadar.ts
+++ b/frontend/src/utils/skillsRadar.ts
@@ -1,0 +1,256 @@
+/**
+ * Skills Radar — categorisation & geometry helpers.
+ *
+ * Each detected skill is mapped into one of a fixed set of domains. The
+ * count per domain (normalised to 0-1) drives the spider / radar chart.
+ */
+
+// ── Domain definitions ───────────────────────────────────────────────────────
+
+export interface SkillDomain {
+  /** Machine-readable key (also used as CSS class suffix). */
+  key: string
+  /** Human-readable label shown on the chart axis. */
+  label: string
+  /** Hex colour for the radar fill / stroke. */
+  color: string
+  /** Emoji icon for the legend. */
+  icon: string
+}
+
+export const SKILL_DOMAINS: SkillDomain[] = [
+  { key: 'frontend', label: 'Frontend', color: '#6366f1', icon: '🎨' },
+  { key: 'backend', label: 'Backend', color: '#22c55e', icon: '⚙️' },
+  { key: 'database', label: 'Database', color: '#f59e0b', icon: '🗄️' },
+  { key: 'devops', label: 'DevOps', color: '#ef4444', icon: '🚀' },
+  { key: 'cloud', label: 'Cloud', color: '#06b6d4', icon: '☁️' },
+  { key: 'aiml', label: 'AI / ML', color: '#a855f7', icon: '🤖' },
+  { key: 'testing', label: 'Testing', color: '#ec4899', icon: '🧪' },
+  { key: 'tools', label: 'Tools', color: '#14b8a6', icon: '🔧' },
+  { key: 'languages', label: 'Languages', color: '#f97316', icon: '📝' },
+  { key: 'soft', label: 'Soft Skills', color: '#84cc16', icon: '💬' },
+]
+
+// ── Skill → Domain mapping ───────────────────────────────────────────────────
+
+/**
+ * Each entry maps one or more keywords (lower-cased) to a domain key.
+ * Order matters: the first match wins, so more specific keywords should
+ * come before broader ones.
+ */
+const SKILL_KEYWORD_MAP: Array<{ patterns: string[]; domain: string }> = [
+  // ── Frontend ──
+  { patterns: ['react', 'reactjs', 'react.js', 'nextjs', 'next.js', 'vue', 'vuejs', 'vue.js', 'angular', 'svelte', 'sveltekit'], domain: 'frontend' },
+  { patterns: ['html', 'html5', 'css', 'css3', 'sass', 'scss', 'less', 'tailwind', 'tailwindcss', 'bootstrap', 'material ui', 'chakra ui'], domain: 'frontend' },
+  { patterns: ['typescript', 'javascript', 'js', 'tsx', 'jsx', 'web components', 'webpack', 'vite', 'esbuild', 'rollup'], domain: 'frontend' },
+  { patterns: ['redux', 'zustand', 'mobx', 'recoil', 'jotai', 'pinia', 'vuex', 'ngrx', 'context api'], domain: 'frontend' },
+  { patterns: ['d3', 'd3.js', 'three.js', 'threejs', 'webgl', 'canvas', 'svg animation', 'framer motion', 'gsap', 'lottie'], domain: 'frontend' },
+  { patterns: ['figma', 'storybook', 'chromatic', 'playwright visual', 'screenshot', 'responsive design', 'mobile-first', 'a11y', 'accessibility', 'wcag'], domain: 'frontend' },
+
+  // ── Backend ──
+  { patterns: ['django', 'flask', 'fastapi', 'express', 'expressjs', 'nestjs', 'nest.js', 'koa', 'hapi'], domain: 'backend' },
+  { patterns: ['spring', 'spring boot', 'springboot', 'springframework', '.net', 'dotnet', 'asp.net', 'c#'], domain: 'backend' },
+  { patterns: ['rails', 'ruby on rails', 'sinatra', 'laravel', 'symfony', 'codeigniter'], domain: 'backend' },
+  { patterns: ['graphql', 'rest', 'restful', 'grpc', 'websocket', 'websockets', 'api design', 'api gateway', 'oauth', 'jwt'], domain: 'backend' },
+  { patterns: ['microservices', 'message queue', 'rabbitmq', 'kafka', 'redis', 'celery', 'sidekiq', 'background jobs', 'worker'], domain: 'backend' },
+  { patterns: ['gin', 'fiber', 'echo', 'actix', 'axum', 'rocket', 'rust', 'go', 'golang', 'java', 'kotlin', 'scala', 'php'], domain: 'backend' },
+
+  // ── Database ──
+  { patterns: ['postgres', 'postgresql', 'mysql', 'mariadb', 'sqlite', 'sql server', 'mssql', 'oracle db'], domain: 'database' },
+  { patterns: ['mongodb', 'mongo', 'cassandra', 'dynamodb', 'dynamo', 'couchdb', 'cosmos db', 'firebase', 'supabase', 'planetscale'], domain: 'database' },
+  { patterns: ['redis', 'memcached', 'elasticsearch', 'opensearch', 'solr', 'neo4j', 'arangodb', 'influxdb', 'timescaledb'], domain: 'database' },
+  { patterns: ['sql', 'nosql', 'orm', 'prisma', 'sequelize', 'typeorm', 'mongoose', 'sqlalchemy', 'hibernate', 'knex'], domain: 'database' },
+  { patterns: ['database design', 'data modeling', 'etl', 'data warehouse', 'data lake'], domain: 'database' },
+
+  // ── DevOps ──
+  { patterns: ['docker', 'dockerfile', 'docker-compose', 'container', 'containers', 'kubernetes', 'k8s', 'helm'], domain: 'devops' },
+  { patterns: ['ci/cd', 'cicd', 'continuous integration', 'continuous deployment', 'jenkins', 'gitlab ci', 'github actions', 'circleci', 'travis', 'bitbucket pipeline'], domain: 'devops' },
+  { patterns: ['terraform', 'ansible', 'puppet', 'chef', 'pulumi', 'cloudformation', 'infrastructure as code', 'iac'], domain: 'devops' },
+  { patterns: ['nginx', 'apache', 'caddy', 'load balancer', 'reverse proxy', 'haproxy'], domain: 'devops' },
+  { patterns: ['monitoring', 'prometheus', 'grafana', 'datadog', 'new relic', 'splunk', 'logging', 'observability', 'sentry', 'opentelemetry'], domain: 'devops' },
+
+  // ── Cloud ──
+  { patterns: ['aws', 'amazon web services', 'ec2', 's3', 'lambda', 'ecs', 'eks', 'sqs', 'sns', 'cloudfront', 'rds', 'aurora'], domain: 'cloud' },
+  { patterns: ['azure', 'azure devops', 'app service', 'azure functions', 'cosmos db', 'azure ad', 'bicep'], domain: 'cloud' },
+  { patterns: ['gcp', 'google cloud', 'cloud run', 'cloud functions', 'bigquery', 'cloud storage', 'cloud sql', 'firebase', 'vertex ai'], domain: 'cloud' },
+  { patterns: ['vercel', 'netlify', 'cloudflare', 'heroku', 'railway', 'render', 'digitalocean', 'fly.io', 'docker hub'], domain: 'cloud' },
+
+  // ── AI / ML ──
+  { patterns: ['machine learning', 'ml', 'deep learning', 'neural network', 'nlp', 'natural language', 'computer vision', 'cv'], domain: 'aiml' },
+  { patterns: ['tensorflow', 'pytorch', 'keras', 'scikit-learn', 'sklearn', 'xgboost', 'lightgbm', 'hugging face', 'huggingface', 'transformers'], domain: 'aiml' },
+  { patterns: ['openai', 'gpt', 'llm', 'large language model', 'langchain', 'llamaindex', 'rag', 'retrieval augmented', 'prompt engineering', 'chatgpt', 'copilot'], domain: 'aiml' },
+  { patterns: ['pandas', 'numpy', 'scipy', 'matplotlib', 'seaborn', 'jupyter', 'notebook', 'data science', 'data analysis', 'statistics'], domain: 'aiml' },
+  { patterns: ['stable diffusion', 'midjourney', 'image generation', 'generative ai', 'gen ai', 'diffusion model', 'embedding', 'vector database', 'pinecone', 'weaviate', 'chroma', 'faiss', 'milvus'], domain: 'aiml' },
+
+  // ── Testing ──
+  { patterns: ['jest', 'mocha', 'vitest', 'jasmine', 'karma', 'chai', 'enzyme'], domain: 'testing' },
+  { patterns: ['pytest', 'unittest', 'nose', 'tox', 'coverage.py', 'behave', 'robot framework'], domain: 'testing' },
+  { patterns: ['cypress', 'playwright', 'selenium', 'puppeteer', 'webdriver', 'appium', 'detox', 'maestro'], domain: 'testing' },
+  { patterns: ['testing', 'test', 'tdd', 'bdd', 'unit test', 'integration test', 'e2e', 'end to end', 'test driven', 'mock', 'stub', 'test coverage'], domain: 'testing' },
+  { patterns: ['postman', 'insomnia', 'api testing', 'load testing', 'jmeter', 'k6', 'gatling', 'stress test', 'performance testing'], domain: 'testing' },
+
+  // ── Tools ──
+  { patterns: ['git', 'github', 'gitlab', 'bitbucket', 'svn', 'version control'], domain: 'tools' },
+  { patterns: ['linux', 'unix', 'bash', 'shell', 'powershell', 'zsh', 'command line', 'terminal', 'cli'], domain: 'tools' },
+  { patterns: ['vscode', 'visual studio code', 'intellij', 'vim', 'neovim', 'emacs', 'webstorm', 'pycharm', 'ide'], domain: 'tools' },
+  { patterns: ['npm', 'yarn', 'pnpm', 'pip', 'poetry', 'pdm', 'conda', 'maven', 'gradle', 'nuget', 'composer'], domain: 'tools' },
+  { patterns: ['eslint', 'prettier', 'black', 'ruff', 'rubocop', 'sonarqube', 'lint', 'format'], domain: 'tools' },
+  { patterns: ['agile', 'scrum', 'kanban', 'jira', 'trello', 'asana', 'linear', 'notion', 'confluence', 'project management'], domain: 'tools' },
+
+  // ── Languages (programming) ──
+  { patterns: ['python', 'javascript', 'typescript', 'java', 'c++', 'c#', 'go', 'golang', 'rust', 'ruby', 'php', 'swift', 'kotlin', 'scala', 'r', 'matlab', 'dart', 'lua', 'perl', 'haskell', 'elixir', 'clojure', 'f#', 'fortran', 'cobol', 'assembly', 'asm', 'sql'], domain: 'languages' },
+
+  // ── Soft Skills ──
+  { patterns: ['leadership', 'communication', 'teamwork', 'team lead', 'mentoring', 'mentoring', 'collaboration', 'problem solving', 'critical thinking', 'time management', 'adaptability', 'creativity', 'presentation', 'negotiation', 'stakeholder', 'cross-functional', 'self-motivated', 'detail-oriented', 'analytical', 'strategic'], domain: 'soft' },
+]
+
+/**
+ * Categorise a flat list of detected skills into domain buckets.
+ *
+ * Each skill string is matched case-insensitively against the keyword map.
+ * A skill can appear in at most one domain (first match wins). Unknown
+ * skills are silently skipped.
+ *
+ * @returns A map from domain key → Set of matched skill names.
+ */
+export function categoriseSkills(skills: string[]): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>()
+  for (const domain of SKILL_DOMAINS) {
+    result.set(domain.key, new Set())
+  }
+
+  for (const raw of skills) {
+    const skill = raw.toLowerCase().trim()
+    if (!skill) continue
+
+    for (const entry of SKILL_KEYWORD_MAP) {
+      if (entry.patterns.some((p) => skill === p || skill.includes(p) || p.includes(skill))) {
+        result.get(entry.domain)?.add(raw)
+        break // first match only
+      }
+    }
+  }
+
+  return result
+}
+
+// ── Radar geometry ───────────────────────────────────────────────────────────
+
+export interface RadarPoint {
+  x: number
+  y: number
+}
+
+/**
+ * Convert polar (angle, radius) to cartesian (x, y).
+ * Angle 0 = top (−Y), increasing clockwise.
+ */
+export function polarToCartesian(
+  cx: number,
+  cy: number,
+  angleDeg: number,
+  radius: number,
+): RadarPoint {
+  const rad = ((angleDeg - 90) * Math.PI) / 180
+  return {
+    x: cx + radius * Math.cos(rad),
+    y: cy + radius * Math.sin(rad),
+  }
+}
+
+/**
+ * Build the SVG polygon points string for a radar data polygon.
+ *
+ * @param values   Normalised values (0–1) in domain order.
+ * @param cx       Centre X of the chart.
+ * @param cy       Centre Y of the chart.
+ * @param maxRadius  Maximum radius of the chart.
+ * @returns An array of polygon vertices (one per domain).
+ */
+export function buildRadarPolygon(
+  values: number[],
+  cx: number,
+  cy: number,
+  maxRadius: number,
+): RadarPoint[] {
+  const n = values.length
+  if (n === 0) return []
+  const step = 360 / n
+  return values.map((v, i) => {
+    const clamped = Math.max(0, Math.min(1, v))
+    return polarToCartesian(cx, cy, step * i, clamped * maxRadius)
+  })
+}
+
+/**
+ * Build concentric guide rings (20 %, 40 %, 60 %, 80 %, 100 %).
+ */
+export function buildRadarRings(
+  cx: number,
+  cy: number,
+  maxRadius: number,
+  levels: number = 5,
+): RadarPoint[][] {
+  const rings: RadarPoint[][] = []
+  for (let l = 1; l <= levels; l++) {
+    const r = (l / levels) * maxRadius
+    const step = 360 / SKILL_DOMAINS.length
+    const ring: RadarPoint[] = SKILL_DOMAINS.map((_, i) =>
+      polarToCartesian(cx, cy, step * i, r),
+    )
+    rings.push(ring)
+  }
+  return rings
+}
+
+/**
+ * Build axis lines from centre to each vertex.
+ */
+export function buildRadarAxes(
+  cx: number,
+  cy: number,
+  maxRadius: number,
+): Array<{ from: RadarPoint; to: RadarPoint }> {
+  const step = 360 / SKILL_DOMAINS.length
+  return SKILL_DOMAINS.map((_, i) => ({
+    from: { x: cx, y: cy },
+    to: polarToCartesian(cx, cy, step * i, maxRadius),
+  }))
+}
+
+/** Convert polygon vertices to an SVG `points` attribute string. */
+export function verticesToPoints(pts: RadarPoint[]): string {
+  return pts.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(' ')
+}
+
+/**
+ * Compute a summary score for how well the detected skills cover the domains.
+ *
+ * Returns 0–100 where 100 = every domain has at least one skill.
+ */
+export function domainCoverageScore(domainCounts: Map<string, Set<string>>): number {
+  const total = SKILL_DOMAINS.length
+  if (total === 0) return 0
+  let covered = 0
+  for (const domain of SKILL_DOMAINS) {
+    if ((domainCounts.get(domain.key)?.size ?? 0) > 0) covered++
+  }
+  return Math.round((covered / total) * 100)
+}
+
+/**
+ * Determine the "strongest" and "weakest" domains from the normalised values.
+ */
+export function domainExtremes(
+  normalisedValues: number[],
+): { strongest: number; weakest: number } {
+  let strongest = 0
+  let weakest = 0
+  let maxVal = -1
+  let minVal = 2
+  normalisedValues.forEach((v, i) => {
+    if (v > maxVal) { maxVal = v; strongest = i }
+    if (v < minVal) { minVal = v; weakest = i }
+  })
+  return { strongest, weakest }
+}


### PR DESCRIPTION
closes #1018 
Adds a complete interactive Skills Radar Visualization to the analyzer, giving users a visual overview of their detected skills and identifying areas of strength and potential improvement.

The feature introduces an SVG-based spider/radar chart that categorizes detected skills across 10 domains: Frontend, Backend, Database, DevOps, Cloud, AI/ML, Testing, Tools, Languages, and Soft Skills. The categorization system includes approximately 200 keyword patterns to map detected skills into the appropriate domains.

The radar chart includes interactive hover tooltips that display the skills detected within each domain. A coverage badge provides an overall view of skill coverage, while the insights section highlights the strongest and weakest domains for easier interpretation.

The visualization is integrated into the existing application through a collapsible panel that follows the current ScoreBreakdown toggle convention, keeping the experience consistent with the rest of the analyzer UI.

Comprehensive tests have also been added covering skill categorization, polar coordinate calculations, radar polygon generation, coverage scoring, and component rendering states.

Branch: feature/skills-radar-viz
Commit: 0918895