### PR TITLE
feat(analyzer): add resume section analyzer with per-section scoring

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { WhatsNewModal } from './components/WhatsNewModal'
 import { shouldShowWhatsNew } from './data/whatsNewReleases'
 import { ShareResult } from './components/ShareResult'
 import { setResumeRoastConsent } from './utils/cookieConsent'
+import { SectionAnalyzer } from './components/SectionAnalyzer'
 
 type Theme = 'light' | 'dark'
 
@@ -1103,6 +1104,8 @@ function App() {
               <TimelinePanel timeline={timeline} />
 
               <ResumePreview text={resumeText} skills={skills} />
+
+              <SectionAnalyzer resumeText={resumeText} skills={skills} />
 
               {/*
                 Share controls. Previously there was no way to publish or

--- a/frontend/src/components/SectionAnalyzer.css
+++ b/frontend/src/components/SectionAnalyzer.css
@@ -1,0 +1,280 @@
+/* ── Section Analyzer ───────────────────────────────────────────────────────── */
+
+.section-analyzer {
+  margin-top: 20px;
+}
+
+/* ── Toggle ────────────────────────────────────────────────────────────────── */
+
+.sa-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface-soft-bg);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md, 8px);
+  padding: 14px 18px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.sa-toggle:hover {
+  background: var(--surface-strong-bg);
+  border-color: rgba(99, 102, 241, 0.3);
+}
+
+.sa-toggle:focus-visible {
+  outline: 2px solid var(--score-accent, #6366f1);
+  outline-offset: 2px;
+}
+
+.sa-toggle__text {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.sa-toggle__title {
+  font-size: var(--text-md, 1rem);
+  font-weight: 700;
+  color: var(--heading-text, #fff);
+}
+
+.sa-toggle__subtitle {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--muted-text, #94a3b8);
+  font-weight: 500;
+}
+
+.sa-toggle__chevron {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--muted-text, #94a3b8);
+}
+
+/* ── Panel ─────────────────────────────────────────────────────────────────── */
+
+.sa-panel {
+  animation: saPanelIn 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes saPanelIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Health bar ────────────────────────────────────────────────────────────── */
+
+.sa-health {
+  margin-top: 14px;
+  padding: 12px 16px;
+  background: var(--surface-soft-bg);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md, 8px);
+}
+
+.sa-health__label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  font-size: var(--text-sm, 0.875rem);
+}
+
+.sa-health__tag {
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sa-health__bar {
+  height: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+[data-theme='light'] .sa-health__bar {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.sa-health__fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ── Section card list ─────────────────────────────────────────────────────── */
+
+.sa-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.sa-card {
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md, 8px);
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+
+.sa-card:hover {
+  border-color: rgba(99, 102, 241, 0.25);
+}
+
+.sa-card--missing {
+  opacity: 0.6;
+}
+
+/* ── Card header ───────────────────────────────────────────────────────────── */
+
+.sa-card__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  background: var(--surface-soft-bg);
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  transition: background 0.2s ease;
+}
+
+.sa-card__header:hover {
+  background: var(--surface-strong-bg);
+}
+
+.sa-card__header:focus-visible {
+  outline: 2px solid var(--score-accent, #6366f1);
+  outline-offset: -2px;
+}
+
+.sa-card__icon {
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.sa-card__label {
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--heading-text, #fff);
+  flex: 1;
+}
+
+.sa-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.sa-card__words {
+  font-size: 11px;
+  color: var(--muted-text, #94a3b8);
+  font-weight: 500;
+}
+
+.sa-card__grade {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.sa-card__score {
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 800;
+  min-width: 28px;
+  text-align: right;
+}
+
+.sa-card__chevron {
+  font-size: 10px;
+  color: var(--muted-text, #94a3b8);
+  flex-shrink: 0;
+}
+
+/* ── Card body ─────────────────────────────────────────────────────────────── */
+
+.sa-card__body {
+  padding: 14px 16px;
+  background: rgba(0, 0, 0, 0.15);
+  animation: saCardExpand 0.25s ease-out;
+}
+
+[data-theme='light'] .sa-card__body {
+  background: rgba(0, 0, 0, 0.02);
+}
+
+@keyframes saCardExpand {
+  from { opacity: 0; max-height: 0; }
+  to { opacity: 1; max-height: 600px; }
+}
+
+.sa-card__tips {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sa-card__tip {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--body-text, #fff);
+  line-height: 1.5;
+}
+
+.sa-card__tip-icon {
+  flex-shrink: 0;
+  font-weight: 700;
+}
+
+.sa-card__content {
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--surface-border);
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-size: 11px;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow-y: auto;
+  color: var(--card-text, #e2e8f0);
+  font-family: inherit;
+  margin: 0;
+}
+
+[data-theme='light'] .sa-card__content {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.sa-card__empty {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--muted-text, #94a3b8);
+  font-style: italic;
+  margin: 0;
+}
+
+/* ── Responsive ────────────────────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .sa-card__meta {
+    gap: 4px;
+  }
+  .sa-card__words {
+    display: none;
+  }
+}

--- a/frontend/src/components/SectionAnalyzer.test.tsx
+++ b/frontend/src/components/SectionAnalyzer.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SectionAnalyzer } from './SectionAnalyzer'
+import { analyzeSections, overallSectionScore } from '../utils/sectionAnalyzer'
+
+// ── analyzeSections ──────────────────────────────────────────────────────────
+
+describe('analyzeSections', () => {
+  it('returns empty array for empty text', () => {
+    expect(analyzeSections({ resumeText: '', skills: [] })).toEqual([])
+  })
+
+  it('detects a single section', () => {
+    const text = 'Experience\n- Built a React app with TypeScript\n- Improved performance by 40%'
+    const sections = analyzeSections({ resumeText: text, skills: ['React'] })
+    expect(sections.length).toBeGreaterThanOrEqual(1)
+    const exp = sections.find((s) => s.key === 'experience')
+    expect(exp).toBeDefined()
+    expect(exp!.label).toBe('Work Experience')
+    expect(exp!.wordCount).toBeGreaterThan(0)
+  })
+
+  it('detects multiple sections', () => {
+    const text = `
+Summary
+Experienced developer with 5 years of expertise in React and Node.js.
+
+Experience
+- Led a team of 4 engineers
+- Deployed microservices on AWS
+
+Education
+Bachelor of Science in Computer Science, MIT
+
+Skills
+React, TypeScript, Docker, PostgreSQL
+    `
+    const sections = analyzeSections({ resumeText: text, skills: ['React', 'Docker'] })
+    expect(sections.length).toBeGreaterThanOrEqual(4)
+
+    const keys = sections.map((s) => s.key)
+    expect(keys).toContain('summary')
+    expect(keys).toContain('experience')
+    expect(keys).toContain('education')
+    expect(keys).toContain('skills')
+  })
+
+  it('marks missing sections', () => {
+    const text = 'Skills\nReact, Docker'
+    const sections = analyzeSections({ resumeText: text, skills: ['React'] })
+    const missing = sections.filter((s) => s.grade === 'Missing')
+    expect(missing.length).toBeGreaterThan(0)
+    expect(missing.map((s) => s.key)).toContain('experience')
+  })
+
+  it('scores a strong section higher than a weak one', () => {
+    const strong = `
+Experience
+- Built a production-grade React application serving 10k users daily
+- Reduced API latency by 60% through query optimization
+- Led migration from monolith to microservices architecture
+- Automated deployment pipeline reducing release time by 75%
+`
+    const weak = 'Experience\nstuff'
+    const strongSections = analyzeSections({ resumeText: strong, skills: [] })
+    const weakSections = analyzeSections({ resumeText: weak, skills: [] })
+
+    const strongExp = strongSections.find((s) => s.key === 'experience')
+    const weakExp = weakSections.find((s) => s.key === 'experience')
+
+    expect(strongExp!.score).toBeGreaterThan(weakExp!.score)
+  })
+
+  it('provides tips for weak sections', () => {
+    const text = 'Experience\nnothing useful'
+    const sections = analyzeSections({ resumeText: text, skills: [] })
+    const exp = sections.find((s) => s.key === 'experience')
+    expect(exp!.tips.length).toBeGreaterThan(0)
+  })
+})
+
+// ── overallSectionScore ──────────────────────────────────────────────────────
+
+describe('overallSectionScore', () => {
+  it('returns 0 for empty array', () => {
+    expect(overallSectionScore([])).toBe(0)
+  })
+
+  it('averages present section scores', () => {
+    const sections = analyzeSections({
+      resumeText: `
+Experience
+- Built a production-grade application with React and TypeScript
+- Reduced load time by 50% through code splitting
+- Led team of 5 engineers on enterprise migration
+- Deployed on AWS with full CI/CD pipeline
+- Managed PostgreSQL database serving 1M+ rows
+`,
+      skills: ['React', 'TypeScript', 'AWS'],
+    })
+    const score = overallSectionScore(sections)
+    expect(score).toBeGreaterThan(0)
+    expect(score).toBeLessThanOrEqual(100)
+  })
+})
+
+// ── Component render tests ───────────────────────────────────────────────────
+
+describe('SectionAnalyzer', () => {
+  it('renders nothing for empty text', () => {
+    const { container } = render(
+      <SectionAnalyzer resumeText="" skills={[]} />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the toggle button', () => {
+    render(
+      <SectionAnalyzer resumeText="Experience\nReact dev" skills={['React']} />,
+    )
+    expect(screen.getByText(/Section Analyzer/)).toBeDefined()
+  })
+
+  it('expands and shows section cards', () => {
+    render(
+      <SectionAnalyzer
+        resumeText="Experience\n- Built React app\nEducation\nBS Computer Science"
+        skills={['React']}
+      />,
+    )
+    screen.getByRole('button', { name: /Section Analyzer/ }).click()
+    expect(screen.getByText('Work Experience')).toBeDefined()
+    expect(screen.getByText('Education')).toBeDefined()
+  })
+
+  it('shows health bar after expansion', () => {
+    render(
+      <SectionAnalyzer resumeText="Skills\nReact Docker" skills={['React']} />,
+    )
+    screen.getByRole('button', { name: /Section Analyzer/ }).click()
+    expect(screen.getByText(/Overall:/)).toBeDefined()
+  })
+})

--- a/frontend/src/components/SectionAnalyzer.tsx
+++ b/frontend/src/components/SectionAnalyzer.tsx
@@ -1,0 +1,150 @@
+import { useMemo, useState } from 'react'
+import { analyzeSections, overallSectionScore, type ResumeSection } from '../utils/sectionAnalyzer'
+import './SectionAnalyzer.css'
+
+// ── Props ────────────────────────────────────────────────────────────────────
+
+export interface SectionAnalyzerProps {
+  resumeText: string
+  skills: string[]
+  defaultExpanded?: boolean
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const GRADE_COLOR: Record<ResumeSection['grade'], string> = {
+  Excellent: '#22c55e',
+  Good: '#3b82f6',
+  Fair: '#f59e0b',
+  Weak: '#ef4444',
+  Missing: '#64748b',
+}
+
+const GRADE_BG: Record<ResumeSection['grade'], string> = {
+  Excellent: 'rgba(34, 197, 94, 0.15)',
+  Good: 'rgba(59, 130, 246, 0.15)',
+  Fair: 'rgba(245, 158, 11, 0.15)',
+  Weak: 'rgba(239, 68, 68, 0.15)',
+  Missing: 'rgba(100, 116, 139, 0.1)',
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+/** Single section card. */
+function SectionCard({ section }: { section: ResumeSection }) {
+  const [open, setOpen] = useState(false)
+  const color = GRADE_COLOR[section.grade]
+
+  return (
+    <div className={`sa-card sa-card--${section.grade.toLowerCase()}`}>
+      <button
+        type="button"
+        className="sa-card__header"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <span className="sa-card__icon">{section.icon}</span>
+        <span className="sa-card__label">{section.label}</span>
+        <span className="sa-card__meta">
+          {section.wordCount > 0 && (
+            <span className="sa-card__words">{section.wordCount} words</span>
+          )}
+          <span
+            className="sa-card__grade"
+            style={{ background: GRADE_BG[section.grade], color }}
+          >
+            {section.grade}
+          </span>
+          <span className="sa-card__score" style={{ color }}>
+            {section.score}
+          </span>
+        </span>
+        <span className="sa-card__chevron">{open ? '▲' : '▼'}</span>
+      </button>
+
+      {open && (
+        <div className="sa-card__body">
+          {section.tips.length > 0 && (
+            <ul className="sa-card__tips">
+              {section.tips.map((tip, i) => (
+                <li key={i} className="sa-card__tip">
+                  <span className="sa-card__tip-icon" style={{ color }}>→</span>
+                  {tip}
+                </li>
+              ))}
+            </ul>
+          )}
+          {section.content ? (
+            <pre className="sa-card__content">{section.content.slice(0, 800)}{section.content.length > 800 ? '…' : ''}</pre>
+          ) : (
+            <p className="sa-card__empty">No content detected for this section.</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Health bar showing overall section score. */
+function HealthBar({ score }: { score: number }) {
+  const color = score >= 70 ? '#22c55e' : score >= 40 ? '#f59e0b' : '#ef4444'
+  const label = score >= 70 ? 'Strong' : score >= 40 ? 'Moderate' : 'Needs Work'
+  return (
+    <div className="sa-health">
+      <div className="sa-health__label">
+        <span style={{ fontWeight: 700, color }}>Overall: {score}/100</span>
+        <span className="sa-health__tag" style={{ color }}>{label}</span>
+      </div>
+      <div className="sa-health__bar" role="progressbar" aria-valuenow={score} aria-valuemin={0} aria-valuemax={100}>
+        <div className="sa-health__fill" style={{ width: `${score}%`, background: color }} />
+      </div>
+    </div>
+  )
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
+
+export function SectionAnalyzer({ resumeText, skills, defaultExpanded = false }: SectionAnalyzerProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+
+  const sections = useMemo(() => analyzeSections({ resumeText, skills }), [resumeText, skills])
+  const overallScore = useMemo(() => overallSectionScore(sections), [sections])
+
+  const presentCount = sections.filter((s) => s.grade !== 'Missing').length
+  const missingCount = sections.length - presentCount
+
+  if (!resumeText?.trim()) return null
+
+  return (
+    <section className="section-analyzer" aria-labelledby="sa-heading">
+      <button
+        type="button"
+        className="sa-toggle"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls="sa-panel"
+      >
+        <span className="sa-toggle__text">
+          <span id="sa-heading" className="sa-toggle__title">📑 Section Analyzer</span>
+          <span className="sa-toggle__subtitle">
+            {presentCount} found{missingCount > 0 ? ` • ${missingCount} missing` : ''}
+          </span>
+        </span>
+        <span className="sa-toggle__chevron">{expanded ? '▲' : '▼'}</span>
+      </button>
+
+      {expanded && (
+        <div id="sa-panel" className="sa-panel">
+          <HealthBar score={overallScore} />
+          <div className="sa-list">
+            {sections.map((s) => (
+              <SectionCard key={s.key} section={s} />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default SectionAnalyzer

--- a/frontend/src/utils/sectionAnalyzer.ts
+++ b/frontend/src/utils/sectionAnalyzer.ts
@@ -1,0 +1,275 @@
+/**
+ * Section Analyzer — parse raw resume text into labelled sections and
+ * score each one on content-quality signals.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ResumeSection {
+  /** Machine-readable key. */
+  key: string
+  /** Display label (e.g. "Professional Experience"). */
+  label: string
+  /** Emoji icon for the card header. */
+  icon: string
+  /** Raw text content of the section. */
+  content: string
+  /** Word count for this section. */
+  wordCount: number
+  /** Quality score 0-100. */
+  score: number
+  /** Quality grade. */
+  grade: 'Excellent' | 'Good' | 'Fair' | 'Weak' | 'Missing'
+  /** List of short actionable tips. */
+  tips: string[]
+}
+
+export interface SectionAnalysisInput {
+  resumeText: string
+  skills: string[]
+}
+
+// ── Section detection patterns ───────────────────────────────────────────────
+
+interface SectionDef {
+  key: string
+  label: string
+  icon: string
+  /** Regex that matches the heading line (case-insensitive). */
+  pattern: RegExp
+  /** Minimum expected word count for a "complete" section. */
+  minWords: number
+  /** Keywords that boost the quality score. */
+  powerWords: string[]
+}
+
+const SECTION_DEFS: SectionDef[] = [
+  {
+    key: 'summary',
+    label: 'Professional Summary',
+    icon: '📋',
+    pattern: /(?:^|\n)\s*(?:professional\s+)?summary\b/i,
+    minWords: 30,
+    powerWords: ['experienced', 'skilled', 'passionate', 'results', 'proven', 'expertise', 'specializing', 'background', 'track record'],
+  },
+  {
+    key: 'experience',
+    label: 'Work Experience',
+    icon: '💼',
+    pattern: /(?:^|\n)\s*(?:professional\s+)?experience\b/i,
+    minWords: 60,
+    powerWords: ['managed', 'led', 'built', 'designed', 'implemented', 'improved', 'reduced', 'increased', 'delivered', 'launched', 'scaled', 'automated'],
+  },
+  {
+    key: 'education',
+    label: 'Education',
+    icon: '🎓',
+    pattern: /(?:^|\n)\s*education\b/i,
+    minWords: 15,
+    powerWords: ['university', 'college', 'bachelor', 'master', 'phd', 'degree', 'gpa', 'honors', 'cum laude', 'dean'],
+  },
+  {
+    key: 'skills',
+    label: 'Skills',
+    icon: '🧩',
+    pattern: /(?:^|\n)\s*(?:technical\s+)?skills?\b/i,
+    minWords: 10,
+    powerWords: [],
+  },
+  {
+    key: 'projects',
+    label: 'Projects',
+    icon: '🚀',
+    pattern: /(?:^|\n)\s*projects?\b/i,
+    minWords: 30,
+    powerWords: ['built', 'deployed', 'open source', 'github', 'production', 'users', 'npm', 'maintained', 'contributed'],
+  },
+  {
+    key: 'certifications',
+    label: 'Certifications',
+    icon: '📜',
+    pattern: /(?:^|\n)\s*certifications?\b/i,
+    minWords: 5,
+    powerWords: ['aws', 'azure', 'google', 'certified', 'professional', 'associate', 'specialist'],
+  },
+  {
+    key: 'awards',
+    label: 'Awards & Honors',
+    icon: '🏆',
+    pattern: /(?:^|\n)\s*(?:awards?|honors?|achievements?)\b/i,
+    minWords: 10,
+    powerWords: ['winner', 'first place', 'top', 'best', 'award', 'honor', 'scholarship', 'recognition'],
+  },
+]
+
+// ── Scoring helpers ──────────────────────────────────────────────────────────
+
+/** Count action-verb bullet points. */
+function countActionBullets(text: string): { total: number; actionBullets: number } {
+  const lines = text.split('\n').map((l) => l.trim())
+  const bullets = lines.filter((l) => /^[•\-\*\u2022\u25CF]/.test(l))
+  if (bullets.length === 0) return { total: 0, actionBullets: 0 }
+
+  const verbs = new Set([
+    'achieved', 'administered', 'analyzed', 'automated', 'built',
+    'collaborated', 'consolidated', 'coordinated', 'created', 'debugged',
+    'delivered', 'deployed', 'designed', 'developed', 'drove',
+    'eliminated', 'engineered', 'established', 'executed', 'expanded',
+    'facilitated', 'generated', 'grew', 'guided', 'implemented',
+    'improved', 'increased', 'influenced', 'initiated', 'integrated',
+    'introduced', 'launched', 'led', 'leveraged', 'maintained',
+    'managed', 'mentored', 'migrated', 'modernized', 'negotiated',
+    'optimized', 'orchestrated', 'overhauled', 'oversaw', 'perfected',
+    'performed', 'pioneered', 'planned', 'prioritized', 'produced',
+    'programmed', 'proposed', 'reduced', 'refactored', 'resolved',
+    'revamped', 'scaled', 'simplified', 'spearheaded', 'standardized',
+    'streamlined', 'strengthened', 'supervised', 'transformed',
+    'troubleshot', 'unified', 'upgraded', 'utilized',
+  ])
+
+  let actionBullets = 0
+  for (const b of bullets) {
+    const cleaned = b.replace(/^[•\-\*\u2022\u25CF\u25CB\s]+/, '')
+    const first = cleaned.split(/\s+/)[0]?.toLowerCase().replace(/[^a-z]/g, '') ?? ''
+    if (verbs.has(first)) actionBullets++
+  }
+  return { total: bullets.length, actionBullets }
+}
+
+/** Count lines with measurable data (digits, %, $). */
+function countQuantified(text: string): { total: number; quantified: number } {
+  const lines = text.split('\n').map((l) => l.trim())
+  const bullets = lines.filter((l) => /^[•\-\*\u2022\u25CF]/.test(l))
+  if (bullets.length === 0) return { total: 0, quantified: 0 }
+  const quantified = bullets.filter((b) => /\d/.test(b)).length
+  return { total: bullets.length, quantified }
+}
+
+/** Score a section 0–100. */
+function scoreSection(def: SectionDef, content: string): { score: number; tips: string[] } {
+  const tips: string[] = []
+  const words = content.trim().split(/\s+/).length
+  const wcScore = Math.min(100, (words / def.minWords) * 60)
+
+  if (words < def.minWords * 0.5) {
+    tips.push(`Too short (${words} words) — aim for ${def.minWords}+ words.`)
+  } else if (words < def.minWords) {
+    tips.push(`Consider expanding (${words}/${def.minWords} words).`)
+  }
+
+  // Action verbs
+  const { total: bulletTotal, actionBullets } = countActionBullets(content)
+  const verbRatio = bulletTotal > 0 ? actionBullets / bulletTotal : 0
+  const verbScore = bulletTotal > 0 ? verbRatio * 40 : 20
+
+  if (bulletTotal > 0 && verbRatio < 0.5) {
+    tips.push(`Only ${Math.round(verbRatio * 100)}% of bullets use action verbs — aim for 70%+.`)
+  }
+
+  // Quantification
+  const { quantified } = countQuantified(content)
+  const quantRatio = bulletTotal > 0 ? quantified / bulletTotal : 0
+  const quantScore = bulletTotal > 0 ? quantRatio * 30 : 15
+
+  if (bulletTotal > 0 && quantRatio < 0.3) {
+    tips.push(`Only ${Math.round(quantRatio * 100)}% of bullets include metrics — add numbers.`)
+  }
+
+  // Power words
+  const lower = content.toLowerCase()
+  const powerHits = def.powerWords.filter((w) => lower.includes(w)).length
+  const powerScore = def.powerWords.length > 0
+    ? (powerHits / def.powerWords.length) * 30
+    : 15
+
+  if (powerHits === 0 && def.powerWords.length > 0) {
+    tips.push('Consider using stronger industry-relevant keywords.')
+  }
+
+  const raw = wcScore + verbScore + quantScore + powerScore
+  const score = Math.round(Math.min(100, Math.max(0, raw)))
+
+  return { score, tips }
+}
+
+// ── Main parser ──────────────────────────────────────────────────────────────
+
+/**
+ * Split resume text into sections and score each one.
+ *
+ * The parser scans for known heading patterns and captures text between
+ * consecutive headings. Unrecognised leading text is labelled "Header".
+ */
+export function analyzeSections(input: SectionAnalysisInput): ResumeSection[] {
+  const { resumeText } = input
+  if (!resumeText?.trim()) return []
+
+  // Find all heading positions
+  const headings: Array<{ idx: number; def: SectionDef }> = []
+  for (const def of SECTION_DEFS) {
+    const match = resumeText.match(def.pattern)
+    if (match && match.index !== undefined) {
+      headings.push({ idx: match.index, def })
+    }
+  }
+
+  // Sort by position
+  headings.sort((a, b) => a.idx - b.idx)
+
+  const sections: ResumeSection[] = []
+
+  // Extract text between headings
+  for (let i = 0; i < headings.length; i++) {
+    const start = headings[i].idx
+    const end = i + 1 < headings.length ? headings[i + 1].idx : resumeText.length
+    const content = resumeText.slice(start, end).trim()
+    const def = headings[i].def
+    const { score, tips } = scoreSection(def, content)
+    const wordCount = content.split(/\s+/).length
+
+    let grade: ResumeSection['grade'] = 'Missing'
+    if (score >= 80) grade = 'Excellent'
+    else if (score >= 60) grade = 'Good'
+    else if (score >= 40) grade = 'Fair'
+    else if (score > 0) grade = 'Weak'
+
+    sections.push({
+      key: def.key,
+      label: def.label,
+      icon: def.icon,
+      content,
+      wordCount,
+      score,
+      grade,
+      tips,
+    })
+  }
+
+  // Flag missing sections
+  for (const def of SECTION_DEFS) {
+    if (!headings.find((h) => h.def.key === def.key)) {
+      sections.push({
+        key: def.key,
+        label: def.label,
+        icon: def.icon,
+        content: '',
+        wordCount: 0,
+        score: 0,
+        grade: 'Missing',
+        tips: [`Section not detected — consider adding "${def.label}".`],
+      })
+    }
+  }
+
+  return sections
+}
+
+/**
+ * Compute an overall section-health score (average of non-missing sections,
+ * or 0 if none found).
+ */
+export function overallSectionScore(sections: ResumeSection[]): number {
+  const scored = sections.filter((s) => s.grade !== 'Missing')
+  if (scored.length === 0) return 0
+  return Math.round(scored.reduce((sum, s) => sum + s.score, 0) / scored.length)
+}


### PR DESCRIPTION
closes #1020 
Adds a complete Resume Section Analyzer that evaluates resume content at the individual section level and provides actionable feedback for improving overall resume quality.

The implementation automatically parses resume text into 7 standard sections: Summary, Experience, Education, Skills, Projects, Certifications, and Awards. It detects available sections and flags missing sections so users can quickly identify gaps in their resume structure.

Each section is evaluated using multiple quality signals, including action verbs, quantified achievements, word count, and relevant power keywords, producing a score between 0–100. Based on the score, sections are classified as Excellent, Good, Fair, Weak, or Missing.

The UI provides expandable section cards with detailed scoring information, content previews, and section-specific improvement tips. An overall resume health bar provides a quick summary of the document's section quality.

The feature also includes a comprehensive test suite covering section detection, scoring logic, grading, missing-section handling, and component rendering states.

Branch: feature/section-analyzer
Commit: 1218bec