### PR TITLE
Fix #999: Add "apply directly" deep links to matched job postings

### DIFF
--- a/backend/deep_links/__init__.py
+++ b/backend/deep_links/__init__.py
@@ -1,0 +1,9 @@
+"""
+Deep Links App for AI Resume Analyzer
+Handles "apply directly" deep links to matched job postings.
+"""
+
+default_app_config = 'deep_links.apps.DeepLinksConfig'
+
+__version__ = '1.0.0'
+__author__ = 'AI Resume Analyzer Team'

--- a/backend/deep_links/admin.py
+++ b/backend/deep_links/admin.py
@@ -1,0 +1,66 @@
+"""
+Admin Configuration for Deep Links
+"""
+
+from django.contrib import admin
+from django.utils.html import format_html
+from .models import (
+    DeepLink,
+    DeepLinkClick,
+    JobPosting,
+    JobMatch,
+    DeepLinkAnalytics,
+    DeepLinkDomain
+)
+
+
+@admin.register(DeepLink)
+class DeepLinkAdmin(admin.ModelAdmin):
+    list_display = ['id', 'job_posting_title', 'short_code', 'click_count', 'is_active', 'created_at']
+    list_filter = ['is_active', 'created_at']
+    search_fields = ['title', 'short_code', 'original_url']
+    readonly_fields = ['id', 'short_code', 'created_at', 'updated_at']
+    
+    def job_posting_title(self, obj):
+        return obj.title[:50]
+    job_posting_title.short_description = 'Job Title'
+
+
+@admin.register(DeepLinkClick)
+class DeepLinkClickAdmin(admin.ModelAdmin):
+    list_display = ['id', 'deep_link', 'clicked_at', 'ip_address', 'user_agent']
+    list_filter = ['clicked_at']
+    search_fields = ['deep_link__title', 'ip_address']
+    readonly_fields = ['id', 'clicked_at']
+
+
+@admin.register(JobPosting)
+class JobPostingAdmin(admin.ModelAdmin):
+    list_display = ['title', 'company', 'location', 'is_active', 'created_at']
+    list_filter = ['is_active', 'created_at', 'source']
+    search_fields = ['title', 'company', 'description']
+    readonly_fields = ['id', 'created_at', 'updated_at']
+
+
+@admin.register(JobMatch)
+class JobMatchAdmin(admin.ModelAdmin):
+    list_display = ['user_id', 'job_posting', 'match_score', 'is_applied', 'created_at']
+    list_filter = ['is_applied', 'created_at']
+    search_fields = ['user_id', 'job_posting__title']
+    readonly_fields = ['id', 'created_at']
+
+
+@admin.register(DeepLinkAnalytics)
+class DeepLinkAnalyticsAdmin(admin.ModelAdmin):
+    list_display = ['deep_link', 'total_clicks', 'unique_clicks', 'click_rate', 'date']
+    list_filter = ['date']
+    search_fields = ['deep_link__title']
+    readonly_fields = ['id', 'date']
+
+
+@admin.register(DeepLinkDomain)
+class DeepLinkDomainAdmin(admin.ModelAdmin):
+    list_display = ['domain', 'is_trusted', 'is_active', 'click_count']
+    list_filter = ['is_trusted', 'is_active']
+    search_fields = ['domain']
+    readonly_fields = ['id', 'created_at', 'updated_at']

--- a/backend/deep_links/apps.py
+++ b/backend/deep_links/apps.py
@@ -1,0 +1,18 @@
+"""
+Deep Links App Configuration
+"""
+
+from django.apps import AppConfig
+
+
+class DeepLinksConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'deep_links'
+    verbose_name = 'Deep Links & Job Postings'
+    
+    def ready(self):
+        """Initialize app when ready."""
+        try:
+            import deep_links.signals  # noqa
+        except ImportError:
+            pass

--- a/backend/deep_links/models.py
+++ b/backend/deep_links/models.py
@@ -1,0 +1,392 @@
+"""
+Deep Links Models for "Apply Directly" Feature
+"""
+
+import uuid
+import hashlib
+import random
+import string
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+from django.core.validators import MinValueValidator, MaxValueValidator, URLValidator
+from django.core.exceptions import ValidationError
+from datetime import datetime, timedelta
+
+
+class DeepLink(models.Model):
+    """
+    Deep link to a job posting.
+    """
+    
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    
+    # Job details
+    title = models.CharField(max_length=255, db_index=True)
+    company = models.CharField(max_length=255, db_index=True)
+    location = models.CharField(max_length=255, blank=True)
+    original_url = models.URLField(max_length=1000, validators=[URLValidator()])
+    
+    # Deep link
+    short_code = models.CharField(max_length=20, unique=True, db_index=True)
+    redirect_url = models.URLField(max_length=1000, blank=True)
+    
+    # Metadata
+    source = models.CharField(max_length=100, blank=True, help_text="Source of job posting")
+    job_id = models.CharField(max_length=255, blank=True, help_text="External job ID")
+    
+    # Match data
+    match_score = models.FloatField(default=0, validators=[MinValueValidator(0), MaxValueValidator(100)])
+    match_metadata = models.JSONField(default=dict, blank=True)
+    
+    # Engagement
+    click_count = models.IntegerField(default=0)
+    unique_click_count = models.IntegerField(default=0)
+    last_clicked_at = models.DateTimeField(null=True, blank=True)
+    
+    # Status
+    is_active = models.BooleanField(default=True)
+    is_featured = models.BooleanField(default=False)
+    
+    # Expiry
+    expires_at = models.DateTimeField(null=True, blank=True)
+    
+    # Consent tracking
+    consent_required = models.BooleanField(default=True)
+    consent_obtained = models.BooleanField(default=False)
+    
+    # Timestamps
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    
+    class Meta:
+        db_table = 'deep_links'
+        indexes = [
+            models.Index(fields=['short_code']),
+            models.Index(fields=['title']),
+            models.Index(fields=['company']),
+            models.Index(fields=['-created_at']),
+            models.Index(fields=['is_active']),
+        ]
+        verbose_name = _("Deep Link")
+        verbose_name_plural = _("Deep Links")
+        ordering = ['-created_at']
+    
+    def __str__(self):
+        return f"{self.title} at {self.company}"
+    
+    def save(self, *args, **kwargs):
+        if not self.short_code:
+            self.short_code = self._generate_short_code()
+        if not self.redirect_url:
+            self.redirect_url = self._generate_redirect_url()
+        super().save(*args, **kwargs)
+    
+    def _generate_short_code(self, length: int = 8) -> str:
+        """Generate a unique short code."""
+        characters = string.ascii_letters + string.digits
+        code = ''.join(random.choices(characters, k=length))
+        
+        # Ensure uniqueness
+        while DeepLink.objects.filter(short_code=code).exists():
+            code = ''.join(random.choices(characters, k=length))
+        
+        return code
+    
+    def _generate_redirect_url(self) -> str:
+        """Generate redirect URL."""
+        return f"/apply/{self.short_code}"
+    
+    def get_absolute_url(self) -> str:
+        """Get absolute URL for the deep link."""
+        return f"/apply/{self.short_code}"
+    
+    def increment_click(self, user_id: str = None, ip_address: str = None) -> None:
+        """Increment click count."""
+        self.click_count += 1
+        
+        # Track unique clicks
+        if user_id:
+            has_clicked = DeepLinkClick.objects.filter(
+                deep_link=self,
+                user_id=user_id
+            ).exists()
+            if not has_clicked:
+                self.unique_click_count += 1
+        else:
+            # Track by IP if no user
+            if ip_address:
+                has_clicked = DeepLinkClick.objects.filter(
+                    deep_link=self,
+                    ip_address=ip_address
+                ).exists()
+                if not has_clicked:
+                    self.unique_click_count += 1
+        
+        self.last_clicked_at = datetime.now()
+        self.save(update_fields=['click_count', 'unique_click_count', 'last_clicked_at'])
+    
+    def is_expired(self) -> bool:
+        """Check if the deep link is expired."""
+        if self.expires_at:
+            return datetime.now() > self.expires_at
+        return False
+
+
+class DeepLinkClick(models.Model):
+    """
+    Track clicks on deep links.
+    """
+    
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    
+    # Relationship
+    deep_link = models.ForeignKey(DeepLink, on_delete=models.CASCADE, related_name='clicks')
+    
+    # User tracking
+    user_id = models.UUIDField(null=True, blank=True, db_index=True)
+    session_id = models.CharField(max_length=255, blank=True)
+    
+    # Context
+    ip_address = models.GenericIPAddressField(null=True, blank=True)
+    user_agent = models.TextField(blank=True)
+    referer = models.URLField(max_length=500, blank=True)
+    
+    # Consent
+    consent_given = models.BooleanField(default=False)
+    
+    # Engagement
+    time_on_page = models.IntegerField(default=0, help_text="Time spent on page in seconds")
+    scrolled = models.BooleanField(default=False)
+    interacted = models.BooleanField(default=False)
+    
+    # Location (optional)
+    country = models.CharField(max_length=100, blank=True)
+    city = models.CharField(max_length=100, blank=True)
+    
+    # Metadata
+    metadata = models.JSONField(default=dict, blank=True)
+    
+    # Timestamps
+    clicked_at = models.DateTimeField(auto_now_add=True)
+    
+    class Meta:
+        db_table = 'deep_link_clicks'
+        indexes = [
+            models.Index(fields=['deep_link']),
+            models.Index(fields=['user_id']),
+            models.Index(fields=['session_id']),
+            models.Index(fields=['-clicked_at']),
+        ]
+        verbose_name = _("Deep Link Click")
+        verbose_name_plural = _("Deep Link Clicks")
+        ordering = ['-clicked_at']
+    
+    def __str__(self):
+        return f"Click on {self.deep_link.title} at {self.clicked_at}"
+
+
+class JobPosting(models.Model):
+    """
+    Job posting model for storing job data.
+    """
+    
+    SOURCE_CHOICES = [
+        ('manual', 'Manual'),
+        ('api', 'API'),
+        ('scraped', 'Scraped'),
+        ('imported', 'Imported'),
+        ('user', 'User Submitted'),
+    ]
+    
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    
+    # Job details
+    title = models.CharField(max_length=255, db_index=True)
+    company = models.CharField(max_length=255, db_index=True)
+    location = models.CharField(max_length=255, blank=True)
+    description = models.TextField(blank=True)
+    requirements = models.TextField(blank=True)
+    salary_range = models.CharField(max_length=100, blank=True)
+    
+    # External
+    external_id = models.CharField(max_length=255, blank=True, db_index=True)
+    external_url = models.URLField(max_length=1000, blank=True)
+    source = models.CharField(max_length=20, choices=SOURCE_CHOICES, default='manual')
+    
+    # Deep link
+    deep_link = models.OneToOneField(DeepLink, on_delete=models.SET_NULL, null=True, blank=True, related_name='job_posting')
+    
+    # Status
+    is_active = models.BooleanField(default=True)
+    is_remote = models.BooleanField(default=False)
+    is_featured = models.BooleanField(default=False)
+    
+    # Categories
+    category = models.CharField(max_length=100, blank=True)
+    seniority_level = models.CharField(max_length=50, blank=True)
+    employment_type = models.CharField(max_length=50, blank=True)
+    
+    # Metadata
+    skills = models.JSONField(default=list, blank=True)
+    benefits = models.JSONField(default=list, blank=True)
+    metadata = models.JSONField(default=dict, blank=True)
+    
+    # Timestamps
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    expires_at = models.DateTimeField(null=True, blank=True)
+    
+    class Meta:
+        db_table = 'job_postings'
+        indexes = [
+            models.Index(fields=['title']),
+            models.Index(fields=['company']),
+            models.Index(fields=['external_id']),
+            models.Index(fields=['-created_at']),
+            models.Index(fields=['is_active']),
+        ]
+        verbose_name = _("Job Posting")
+        verbose_name_plural = _("Job Postings")
+        ordering = ['-created_at']
+    
+    def __str__(self):
+        return f"{self.title} at {self.company}"
+
+
+class JobMatch(models.Model):
+    """
+    Job match between a user/resume and a job posting.
+    """
+    
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    
+    # Relationships
+    user_id = models.UUIDField(db_index=True)
+    resume_id = models.UUIDField(null=True, blank=True)
+    job_posting = models.ForeignKey(JobPosting, on_delete=models.CASCADE, related_name='matches')
+    deep_link = models.ForeignKey(DeepLink, on_delete=models.CASCADE, related_name='matches')
+    
+    # Match score
+    match_score = models.FloatField(default=0, validators=[MinValueValidator(0), MaxValueValidator(100)])
+    skills_match = models.FloatField(default=0, validators=[MinValueValidator(0), MaxValueValidator(100)])
+    experience_match = models.FloatField(default=0, validators=[MinValueValidator(0), MaxValueValidator(100)])
+    education_match = models.FloatField(default=0, validators=[MinValueValidator(0), MaxValueValidator(100)])
+    
+    # Match details
+    matched_skills = models.JSONField(default=list, blank=True)
+    missing_skills = models.JSONField(default=list, blank=True)
+    match_metadata = models.JSONField(default=dict, blank=True)
+    
+    # Status
+    is_applied = models.BooleanField(default=False)
+    applied_at = models.DateTimeField(null=True, blank=True)
+    is_viewed = models.BooleanField(default=False)
+    viewed_at = models.DateTimeField(null=True, blank=True)
+    
+    # Application tracking
+    application_status = models.CharField(max_length=50, blank=True)
+    application_notes = models.TextField(blank=True)
+    
+    # Timestamps
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    
+    class Meta:
+        db_table = 'job_matches'
+        indexes = [
+            models.Index(fields=['user_id']),
+            models.Index(fields=['job_posting']),
+            models.Index(fields=['-match_score']),
+            models.Index(fields=['-created_at']),
+        ]
+        unique_together = [['user_id', 'job_posting']]
+        verbose_name = _("Job Match")
+        verbose_name_plural = _("Job Matches")
+        ordering = ['-match_score']
+    
+    def __str__(self):
+        return f"Match {self.match_score}% - {self.user_id} to {self.job_posting.title}"
+    
+    def mark_as_applied(self):
+        """Mark match as applied."""
+        self.is_applied = True
+        self.applied_at = datetime.now()
+        self.save(update_fields=['is_applied', 'applied_at'])
+    
+    def mark_as_viewed(self):
+        """Mark match as viewed."""
+        self.is_viewed = True
+        self.viewed_at = datetime.now()
+        self.save(update_fields=['is_viewed', 'viewed_at'])
+
+
+class DeepLinkAnalytics(models.Model):
+    """
+    Analytics data for deep links.
+    """
+    
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    
+    # Relationship
+    deep_link = models.ForeignKey(DeepLink, on_delete=models.CASCADE, related_name='analytics')
+    
+    # Date
+    date = models.DateField(db_index=True)
+    
+    # Metrics
+    total_clicks = models.IntegerField(default=0)
+    unique_clicks = models.IntegerField(default=0)
+    click_rate = models.FloatField(default=0)
+    
+    # Breakdown
+    by_source = models.JSONField(default=dict, blank=True)
+    by_device = models.JSONField(default=dict, blank=True)
+    by_location = models.JSONField(default=dict, blank=True)
+    
+    # Engagement
+    avg_time_on_page = models.IntegerField(default=0)
+    interaction_rate = models.FloatField(default=0)
+    
+    # Timestamps
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    
+    class Meta:
+        db_table = 'deep_link_analytics'
+        indexes = [
+            models.Index(fields=['deep_link']),
+            models.Index(fields=['date']),
+            models.Index(fields=['-created_at']),
+        ]
+        unique_together = [['deep_link', 'date']]
+        verbose_name = _("Deep Link Analytics")
+        verbose_name_plural = _("Deep Link Analytics")
+        ordering = ['-date']
+
+
+class DeepLinkDomain(models.Model):
+    """
+    Trusted domains for deep links.
+    """
+    
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    domain = models.CharField(max_length=255, unique=True, db_index=True)
+    is_trusted = models.BooleanField(default=True)
+    is_active = models.BooleanField(default=True)
+    click_count = models.IntegerField(default=0)
+    
+    # Security
+    requires_consent = models.BooleanField(default=True)
+    allowed_paths = models.JSONField(default=list, blank=True)
+    
+    # Timestamps
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    
+    class Meta:
+        db_table = 'deep_link_domains'
+        verbose_name = _("Deep Link Domain")
+        verbose_name_plural = _("Deep Link Domains")
+    
+    def __str__(self):
+        return self.domain

--- a/backend/deep_links/serializers.py
+++ b/backend/deep_links/serializers.py
@@ -1,0 +1,167 @@
+"""
+Deep Links Serializers for API
+"""
+
+from rest_framework import serializers
+from .models import (
+    DeepLink,
+    DeepLinkClick,
+    JobPosting,
+    JobMatch,
+    DeepLinkAnalytics,
+    DeepLinkDomain
+)
+
+
+class DeepLinkSerializer(serializers.ModelSerializer):
+    """Serializer for deep links."""
+    
+    full_url = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = DeepLink
+        fields = [
+            'id', 'title', 'company', 'location',
+            'short_code', 'redirect_url', 'original_url',
+            'source', 'job_id', 'match_score',
+            'click_count', 'unique_click_count', 'last_clicked_at',
+            'is_active', 'is_featured', 'expires_at',
+            'created_at', 'updated_at', 'full_url'
+        ]
+        read_only_fields = [
+            'id', 'short_code', 'click_count', 'unique_click_count',
+            'last_clicked_at', 'created_at', 'updated_at'
+        ]
+    
+    def get_full_url(self, obj):
+        """Get full URL for the deep link."""
+        request = self.context.get('request')
+        if request:
+            return request.build_absolute_uri(f'/apply/{obj.short_code}')
+        return f'/apply/{obj.short_code}'
+
+
+class DeepLinkClickSerializer(serializers.ModelSerializer):
+    """Serializer for deep link clicks."""
+    
+    class Meta:
+        model = DeepLinkClick
+        fields = [
+            'id', 'deep_link', 'user_id', 'session_id',
+            'ip_address', 'user_agent', 'referer',
+            'consent_given', 'time_on_page', 'scrolled', 'interacted',
+            'country', 'city', 'metadata',
+            'clicked_at'
+        ]
+        read_only_fields = ['id', 'clicked_at']
+
+
+class JobPostingSerializer(serializers.ModelSerializer):
+    """Serializer for job postings."""
+    
+    deep_link = DeepLinkSerializer(read_only=True)
+    
+    class Meta:
+        model = JobPosting
+        fields = [
+            'id', 'title', 'company', 'location',
+            'description', 'requirements', 'salary_range',
+            'external_id', 'external_url', 'source',
+            'deep_link', 'is_active', 'is_remote', 'is_featured',
+            'category', 'seniority_level', 'employment_type',
+            'skills', 'benefits', 'metadata',
+            'created_at', 'updated_at', 'expires_at'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+
+class JobMatchSerializer(serializers.ModelSerializer):
+    """Serializer for job matches."""
+    
+    job_title = serializers.CharField(source='job_posting.title', read_only=True)
+    company = serializers.CharField(source='job_posting.company', read_only=True)
+    location = serializers.CharField(source='job_posting.location', read_only=True)
+    deep_link = DeepLinkSerializer(read_only=True)
+    
+    class Meta:
+        model = JobMatch
+        fields = [
+            'id', 'user_id', 'resume_id',
+            'job_posting', 'job_title', 'company', 'location',
+            'deep_link',
+            'match_score', 'skills_match', 'experience_match', 'education_match',
+            'matched_skills', 'missing_skills', 'match_metadata',
+            'is_applied', 'applied_at', 'is_viewed', 'viewed_at',
+            'application_status', 'application_notes',
+            'created_at', 'updated_at'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+
+class DeepLinkAnalyticsSerializer(serializers.ModelSerializer):
+    """Serializer for deep link analytics."""
+    
+    class Meta:
+        model = DeepLinkAnalytics
+        fields = [
+            'id', 'deep_link', 'date',
+            'total_clicks', 'unique_clicks', 'click_rate',
+            'by_source', 'by_device', 'by_location',
+            'avg_time_on_page', 'interaction_rate',
+            'created_at', 'updated_at'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+
+class DeepLinkDomainSerializer(serializers.ModelSerializer):
+    """Serializer for deep link domains."""
+    
+    class Meta:
+        model = DeepLinkDomain
+        fields = [
+            'id', 'domain', 'is_trusted', 'is_active',
+            'click_count', 'requires_consent', 'allowed_paths',
+            'created_at', 'updated_at'
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+
+class DeepLinkRequestSerializer(serializers.Serializer):
+    """Serializer for creating a deep link."""
+    title = serializers.CharField(max_length=255)
+    company = serializers.CharField(max_length=255)
+    location = serializers.CharField(max_length=255, required=False)
+    original_url = serializers.URLField(max_length=1000)
+    source = serializers.CharField(max_length=100, required=False)
+    job_id = serializers.CharField(max_length=255, required=False)
+    match_score = serializers.FloatField(default=0, min_value=0, max_value=100)
+
+
+class DeepLinkClickRequestSerializer(serializers.Serializer):
+    """Serializer for tracking a click."""
+    deep_link_id = serializers.UUIDField()
+    consent_given = serializers.BooleanField(default=False)
+    time_on_page = serializers.IntegerField(default=0)
+    scrolled = serializers.BooleanField(default=False)
+    interacted = serializers.BooleanField(default=False)
+
+
+class JobMatchRequestSerializer(serializers.Serializer):
+    """Serializer for job match request."""
+    user_id = serializers.UUIDField()
+    job_posting_id = serializers.UUIDField(required=False)
+    title = serializers.CharField(max_length=255, required=False)
+    company = serializers.CharField(max_length=255, required=False)
+    original_url = serializers.URLField(required=False)
+
+
+class DeepLinkStatsSerializer(serializers.Serializer):
+    """Serializer for deep link statistics."""
+    total_links = serializers.IntegerField()
+    total_clicks = serializers.IntegerField()
+    unique_clicks = serializers.IntegerField()
+    average_match_score = serializers.FloatField()
+    click_through_rate = serializers.FloatField()
+    top_performing = serializers.ListField()
+    by_source = serializers.DictField()
+    by_date = serializers.DictField()

--- a/backend/deep_links/services.py
+++ b/backend/deep_links/services.py
@@ -1,0 +1,526 @@
+"""
+Deep Links Services for "Apply Directly" Feature
+"""
+
+import logging
+import re
+from datetime import datetime, timedelta
+from typing import Dict, Any, Optional, List
+from urllib.parse import urlparse
+from django.db import transaction
+from django.contrib.auth import get_user_model
+
+from .models import (
+    DeepLink,
+    DeepLinkClick,
+    JobPosting,
+    JobMatch,
+    DeepLinkAnalytics,
+    DeepLinkDomain
+)
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+class DeepLinkService:
+    """Core service for deep link management."""
+    
+    def __init__(self):
+        pass
+    
+    def create_deep_link(
+        self,
+        title: str,
+        company: str,
+        original_url: str,
+        location: str = '',
+        source: str = '',
+        job_id: str = '',
+        match_score: float = 0,
+        created_by: str = None
+    ) -> Dict[str, Any]:
+        """
+        Create a new deep link.
+        
+        Args:
+            title: Job title
+            company: Company name
+            original_url: Original job posting URL
+            location: Job location
+            source: Source of the job
+            job_id: External job ID
+            match_score: Match score
+            created_by: User ID
+        
+        Returns:
+            Result dictionary
+        """
+        # Validate domain
+        domain_check = self._validate_domain(original_url)
+        if not domain_check['valid']:
+            return {
+                'success': False,
+                'error': domain_check['message']
+            }
+        
+        try:
+            # Check if deep link already exists for this URL
+            existing = DeepLink.objects.filter(
+                original_url=original_url,
+                is_active=True
+            ).first()
+            
+            if existing:
+                return {
+                    'success': True,
+                    'data': {
+                        'id': str(existing.id),
+                        'short_code': existing.short_code,
+                        'redirect_url': existing.redirect_url,
+                        'original_url': existing.original_url
+                    },
+                    'message': 'Deep link already exists'
+                }
+            
+            # Create deep link
+            deep_link = DeepLink.objects.create(
+                title=title,
+                company=company,
+                location=location,
+                original_url=original_url,
+                source=source,
+                job_id=job_id,
+                match_score=match_score
+            )
+            
+            # Create job posting
+            job_posting = JobPosting.objects.create(
+                title=title,
+                company=company,
+                location=location,
+                external_url=original_url,
+                source='manual' if not source else source,
+                deep_link=deep_link,
+                external_id=job_id
+            )
+            
+            logger.info(f"Created deep link for {title} at {company}")
+            
+            return {
+                'success': True,
+                'data': {
+                    'id': str(deep_link.id),
+                    'short_code': deep_link.short_code,
+                    'redirect_url': deep_link.redirect_url,
+                    'original_url': deep_link.original_url,
+                    'job_posting_id': str(job_posting.id)
+                },
+                'message': 'Deep link created successfully'
+            }
+            
+        except Exception as e:
+            logger.error(f"Failed to create deep link: {e}")
+            return {
+                'success': False,
+                'error': str(e)
+            }
+    
+    def track_click(
+        self,
+        short_code: str,
+        user_id: str = None,
+        ip_address: str = None,
+        user_agent: str = '',
+        consent_given: bool = False,
+        referer: str = '',
+        session_id: str = ''
+    ) -> Dict[str, Any]:
+        """
+        Track a deep link click.
+        
+        Args:
+            short_code: Deep link short code
+            user_id: User ID
+            ip_address: IP address
+            user_agent: User agent string
+            consent_given: Whether user gave consent
+            referer: Referer URL
+            session_id: Session ID
+        
+        Returns:
+            Result dictionary
+        """
+        try:
+            deep_link = DeepLink.objects.get(short_code=short_code, is_active=True)
+        except DeepLink.DoesNotExist:
+            return {
+                'success': False,
+                'error': 'Deep link not found'
+            }
+        
+        # Check if expired
+        if deep_link.is_expired():
+            return {
+                'success': False,
+                'error': 'Deep link has expired'
+            }
+        
+        try:
+            with transaction.atomic():
+                # Create click record
+                click = DeepLinkClick.objects.create(
+                    deep_link=deep_link,
+                    user_id=user_id,
+                    ip_address=ip_address,
+                    user_agent=user_agent,
+                    referer=referer,
+                    consent_given=consent_given,
+                    session_id=session_id
+                )
+                
+                # Increment click count
+                deep_link.increment_click(user_id, ip_address)
+                
+                # Update analytics
+                self._update_analytics(deep_link)
+                
+                logger.info(f"Tracked click for deep link {short_code}")
+                
+                return {
+                    'success': True,
+                    'deep_link': deep_link,
+                    'click_id': str(click.id)
+                }
+                
+        except Exception as e:
+            logger.error(f"Failed to track click: {e}")
+            return {
+                'success': False,
+                'error': str(e)
+            }
+    
+    def track_engagement(
+        self,
+        deep_link_id: str,
+        user_id: str = None,
+        consent_given: bool = False,
+        time_on_page: int = 0,
+        scrolled: bool = False,
+        interacted: bool = False
+    ) -> Dict[str, Any]:
+        """
+        Track engagement with a deep link.
+        
+        Args:
+            deep_link_id: Deep link ID
+            user_id: User ID
+            consent_given: Whether user gave consent
+            time_on_page: Time spent on page in seconds
+            scrolled: Whether user scrolled
+            interacted: Whether user interacted
+        
+        Returns:
+            Result dictionary
+        """
+        try:
+            # Find the most recent click for this user and deep link
+            click = DeepLinkClick.objects.filter(
+                deep_link_id=deep_link_id,
+                user_id=user_id if user_id else None
+            ).order_by('-clicked_at').first()
+            
+            if not click:
+                return {
+                    'success': False,
+                    'error': 'No click found for this user'
+                }
+            
+            # Update engagement metrics
+            click.time_on_page = time_on_page
+            click.scrolled = scrolled
+            click.interacted = interacted
+            click.save(update_fields=['time_on_page', 'scrolled', 'interacted'])
+            
+            # Update analytics
+            deep_link = DeepLink.objects.get(id=deep_link_id)
+            self._update_analytics(deep_link)
+            
+            return {
+                'success': True,
+                'message': 'Engagement tracked successfully'
+            }
+            
+        except Exception as e:
+            logger.error(f"Failed to track engagement: {e}")
+            return {
+                'success': False,
+                'error': str(e)
+            }
+    
+    def create_job_match(
+        self,
+        user_id: str,
+        job_posting_id: str,
+        match_score: float = 0,
+        matched_skills: List[str] = None,
+        missing_skills: List[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Create a job match for a user.
+        
+        Args:
+            user_id: User ID
+            job_posting_id: Job posting ID
+            match_score: Match score
+            matched_skills: List of matched skills
+            missing_skills: List of missing skills
+        
+        Returns:
+            Result dictionary
+        """
+        try:
+            job_posting = JobPosting.objects.get(id=job_posting_id)
+        except JobPosting.DoesNotExist:
+            return {
+                'success': False,
+                'error': 'Job posting not found'
+            }
+        
+        try:
+            match, created = JobMatch.objects.get_or_create(
+                user_id=user_id,
+                job_posting=job_posting,
+                defaults={
+                    'match_score': match_score,
+                    'matched_skills': matched_skills or [],
+                    'missing_skills': missing_skills or [],
+                    'deep_link': job_posting.deep_link
+                }
+            )
+            
+            if not created:
+                # Update existing match
+                match.match_score = match_score
+                match.matched_skills = matched_skills or []
+                match.missing_skills = missing_skills or []
+                match.save(update_fields=['match_score', 'matched_skills', 'missing_skills'])
+            
+            return {
+                'success': True,
+                'data': {
+                    'match_id': str(match.id),
+                    'created': created,
+                    'deep_link': DeepLinkSerializer(job_posting.deep_link).data if job_posting.deep_link else None
+                }
+            }
+            
+        except Exception as e:
+            logger.error(f"Failed to create job match: {e}")
+            return {
+                'success': False,
+                'error': str(e)
+            }
+    
+    def create_job_posting_match(
+        self,
+        user_id: str,
+        title: str,
+        company: str,
+        original_url: str,
+        location: str = '',
+        match_score: float = 0,
+        matched_skills: List[str] = None,
+        missing_skills: List[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Create a job posting and match.
+        
+        Args:
+            user_id: User ID
+            title: Job title
+            company: Company name
+            original_url: Original URL
+            location: Location
+            match_score: Match score
+            matched_skills: Matched skills
+            missing_skills: Missing skills
+        
+        Returns:
+            Result dictionary
+        """
+        # Create deep link first
+        link_result = self.create_deep_link(
+            title=title,
+            company=company,
+            original_url=original_url,
+            location=location
+        )
+        
+        if not link_result['success']:
+            return link_result
+        
+        job_posting = JobPosting.objects.filter(
+            deep_link_id=link_result['data']['id']
+        ).first()
+        
+        if not job_posting:
+            return {
+                'success': False,
+                'error': 'Job posting not found'
+            }
+        
+        return self.create_job_match(
+            user_id=user_id,
+            job_posting_id=job_posting.id,
+            match_score=match_score,
+            matched_skills=matched_skills,
+            missing_skills=missing_skills
+        )
+    
+    def get_stats(self) -> Dict[str, Any]:
+        """Get overall deep link statistics."""
+        total_links = DeepLink.objects.count()
+        total_clicks = DeepLinkClick.objects.count()
+        unique_clicks = DeepLinkClick.objects.values('user_id').distinct().count()
+        
+        # Top performing links
+        top_links = DeepLink.objects.filter(
+            is_active=True
+        ).order_by('-click_count')[:10]
+        
+        return {
+            'total_links': total_links,
+            'total_clicks': total_clicks,
+            'unique_clicks': unique_clicks,
+            'click_through_rate': (total_clicks / total_links * 100) if total_links > 0 else 0,
+            'top_performing': [
+                {
+                    'title': link.title,
+                    'company': link.company,
+                    'clicks': link.click_count,
+                    'short_code': link.short_code
+                }
+                for link in top_links
+            ],
+            'by_source': self._get_stats_by_source(),
+            'by_date': self._get_stats_by_date()
+        }
+    
+    def _get_stats_by_source(self) -> Dict[str, int]:
+        """Get statistics by source."""
+        return DeepLink.objects.values('source').annotate(
+            count=Count('id'),
+            clicks=Sum('click_count')
+        )
+    
+    def _get_stats_by_date(self) -> Dict[str, int]:
+        """Get statistics by date."""
+        last_7_days = datetime.now() - timedelta(days=7)
+        clicks = DeepLinkClick.objects.filter(
+            clicked_at__gte=last_7_days
+        ).extra({'date': "date(clicked_at)"}).values('date').annotate(
+            count=Count('id')
+        )
+        return {str(item['date']): item['count'] for item in clicks}
+    
+    def _validate_domain(self, url: str) -> Dict[str, Any]:
+        """Validate the domain of a URL."""
+        try:
+            parsed = urlparse(url)
+            domain = parsed.netloc
+            
+            if not domain:
+                return {
+                    'valid': False,
+                    'message': 'Invalid URL - no domain found'
+                }
+            
+            # Remove www prefix for comparison
+            clean_domain = domain.replace('www.', '')
+            
+            # Check if domain is trusted
+            trusted = DeepLinkDomain.objects.filter(
+                domain__iexact=clean_domain,
+                is_trusted=True,
+                is_active=True
+            ).exists()
+            
+            if not trusted:
+                return {
+                    'valid': False,
+                    'message': f'Domain "{domain}" is not trusted. Please use an approved domain.'
+                }
+            
+            return {
+                'valid': True,
+                'domain': domain
+            }
+            
+        except Exception as e:
+            return {
+                'valid': False,
+                'message': f'Invalid URL: {str(e)}'
+            }
+    
+    def _update_analytics(self, deep_link: DeepLink) -> None:
+        """Update analytics for a deep link."""
+        today = datetime.now().date()
+        
+        analytics, created = DeepLinkAnalytics.objects.get_or_create(
+            deep_link=deep_link,
+            date=today
+        )
+        
+        # Update counts
+        analytics.total_clicks = DeepLinkClick.objects.filter(
+            deep_link=deep_link,
+            clicked_at__date=today
+        ).count()
+        
+        analytics.unique_clicks = DeepLinkClick.objects.filter(
+            deep_link=deep_link,
+            clicked_at__date=today
+        ).values('user_id').distinct().count()
+        
+        analytics.click_rate = (analytics.total_clicks / analytics.unique_clicks * 100) if analytics.unique_clicks > 0 else 0
+        
+        # Update engagement
+        clicks = DeepLinkClick.objects.filter(
+            deep_link=deep_link,
+            clicked_at__date=today
+        )
+        
+        if clicks.exists():
+            analytics.avg_time_on_page = clicks.aggregate(avg=models.Avg('time_on_page'))['avg'] or 0
+            analytics.interaction_rate = (clicks.filter(interacted=True).count() / clicks.count() * 100) if clicks.count() > 0 else 0
+        
+        analytics.save()
+    
+    def get_user_matches(self, user_id: str) -> List[Dict[str, Any]]:
+        """Get job matches for a user."""
+        matches = JobMatch.objects.filter(
+            user_id=user_id
+        ).select_related('job_posting', 'deep_link').order_by('-match_score')
+        
+        return [
+            {
+                'id': str(match.id),
+                'job_title': match.job_posting.title,
+                'company': match.job_posting.company,
+                'location': match.job_posting.location,
+                'match_score': match.match_score,
+                'matched_skills': match.matched_skills,
+                'missing_skills': match.missing_skills,
+                'deep_link': {
+                    'short_code': match.deep_link.short_code,
+                    'url': match.deep_link.redirect_url,
+                    'original_url': match.deep_link.original_url
+                } if match.deep_link else None,
+                'is_applied': match.is_applied,
+                'is_viewed': match.is_viewed,
+                'created_at': match.created_at.isoformat()
+            }
+            for match in matches
+        ]

--- a/backend/deep_links/urls.py
+++ b/backend/deep_links/urls.py
@@ -1,0 +1,26 @@
+"""
+Deep Links URL Configuration
+"""
+
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    # Deep link redirect
+    path('apply/<str:short_code>/', views.DeepLinkRedirectView.as_view(), name='deep-link-redirect'),
+    
+    # Deep link management
+    path('api/deep-links/create/', views.DeepLinkCreateView.as_view(), name='deep-link-create'),
+    path('api/deep-links/list/', views.DeepLinkListView.as_view(), name='deep-link-list'),
+    path('api/deep-links/stats/', views.DeepLinkStatsView.as_view(), name='deep-link-stats'),
+    
+    # Job matches
+    path('api/job-matches/', views.JobMatchView.as_view(), name='job-matches'),
+    path('api/job-matches/<uuid:match_id>/apply/', views.JobMatchApplyView.as_view(), name='job-match-apply'),
+    
+    # Engagement tracking
+    path('api/deep-links/engagement/', views.DeepLinkEngagementView.as_view(), name='deep-link-engagement'),
+    
+    # Domains (admin only)
+    path('api/deep-links/domains/', views.DeepLinkDomainView.as_view(), name='deep-link-domains'),
+]

--- a/backend/deep_links/utils.py
+++ b/backend/deep_links/utils.py
@@ -1,0 +1,249 @@
+"""
+Deep Links Utilities
+"""
+
+import re
+import json
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+from typing import Dict, Any, Optional, List
+import hashlib
+
+
+def extract_domain(url: str) -> Optional[str]:
+    """
+    Extract domain from URL.
+    
+    Args:
+        url: Full URL
+    
+    Returns:
+        Domain string or None
+    """
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc
+        # Remove www prefix
+        domain = domain.replace('www.', '')
+        return domain
+    except:
+        return None
+
+
+def normalize_url(url: str) -> str:
+    """
+    Normalize URL for consistent comparison.
+    
+    Args:
+        url: URL to normalize
+    
+    Returns:
+        Normalized URL
+    """
+    try:
+        parsed = urlparse(url)
+        
+        # Lowercase scheme and netloc
+        scheme = parsed.scheme.lower()
+        netloc = parsed.netloc.lower()
+        
+        # Remove trailing slash
+        path = parsed.path.rstrip('/')
+        
+        # Sort query parameters
+        query_params = parse_qs(parsed.query, keep_blank_values=True)
+        sorted_params = sorted(query_params.items())
+        query = urlencode(sorted_params, doseq=True)
+        
+        # Rebuild URL
+        normalized = urlunparse((scheme, netloc, path, parsed.params, query, parsed.fragment))
+        return normalized
+    except:
+        return url
+
+
+def generate_tracking_id(user_id: str, deep_link_id: str) -> str:
+    """
+    Generate a tracking ID for a click.
+    
+    Args:
+        user_id: User ID
+        deep_link_id: Deep link ID
+    
+    Returns:
+        Tracking ID
+    """
+    data = f"{user_id}_{deep_link_id}_{datetime.now().isoformat()}"
+    return hashlib.md5(data.encode()).hexdigest()[:16]
+
+
+def get_click_analytics_data(click_data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Process click data for analytics.
+    
+    Args:
+        click_data: Raw click data
+    
+    Returns:
+        Processed analytics data
+    """
+    # Extract device info from user agent
+    user_agent = click_data.get('user_agent', '')
+    device = detect_device(user_agent)
+    
+    # Extract location from IP (would use a geolocation service)
+    ip_address = click_data.get('ip_address', '')
+    
+    return {
+        'device': device,
+        'timestamp': click_data.get('clicked_at'),
+        'referer': click_data.get('referer', ''),
+        'user_id': click_data.get('user_id'),
+        'consent_given': click_data.get('consent_given', False)
+    }
+
+
+def detect_device(user_agent: str) -> Dict[str, str]:
+    """
+    Detect device type from user agent.
+    
+    Args:
+        user_agent: User agent string
+    
+    Returns:
+        Device information
+    """
+    device = {
+        'type': 'unknown',
+        'os': 'unknown',
+        'browser': 'unknown'
+    }
+    
+    if not user_agent:
+        return device
+    
+    user_agent = user_agent.lower()
+    
+    # Detect device type
+    if 'mobile' in user_agent or 'android' in user_agent or 'iphone' in user_agent:
+        device['type'] = 'mobile'
+    elif 'tablet' in user_agent or 'ipad' in user_agent:
+        device['type'] = 'tablet'
+    else:
+        device['type'] = 'desktop'
+    
+    # Detect OS
+    if 'windows' in user_agent:
+        device['os'] = 'windows'
+    elif 'mac' in user_agent:
+        device['os'] = 'macos'
+    elif 'linux' in user_agent:
+        device['os'] = 'linux'
+    elif 'android' in user_agent:
+        device['os'] = 'android'
+    elif 'ios' in user_agent or 'iphone' in user_agent or 'ipad' in user_agent:
+        device['os'] = 'ios'
+    
+    # Detect browser
+    if 'chrome' in user_agent:
+        device['browser'] = 'chrome'
+    elif 'firefox' in user_agent:
+        device['browser'] = 'firefox'
+    elif 'safari' in user_agent:
+        device['browser'] = 'safari'
+    elif 'edge' in user_agent:
+        device['browser'] = 'edge'
+    elif 'opera' in user_agent:
+        device['browser'] = 'opera'
+    
+    return device
+
+
+def is_valid_url(url: str) -> bool:
+    """
+    Check if a URL is valid.
+    
+    Args:
+        url: URL to validate
+    
+    Returns:
+        True if valid
+    """
+    pattern = r'^https?://[^\s/$.?#].[^\s]*$'
+    return bool(re.match(pattern, url))
+
+
+def extract_job_id_from_url(url: str) -> Optional[str]:
+    """
+    Extract job ID from URL.
+    
+    Args:
+        url: Job posting URL
+    
+    Returns:
+        Job ID or None
+    """
+    # Common job ID patterns
+    patterns = [
+        r'/jobs/([a-zA-Z0-9_-]+)',
+        r'/job/([a-zA-Z0-9_-]+)',
+        r'jobId=([a-zA-Z0-9_-]+)',
+        r'id=([a-zA-Z0-9_-]+)',
+    ]
+    
+    for pattern in patterns:
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1)
+    
+    return None
+
+
+def generate_short_code(title: str, company: str) -> str:
+    """
+    Generate a short code from title and company.
+    
+    Args:
+        title: Job title
+        company: Company name
+    
+    Returns:
+        Short code
+    """
+    # Take first letters of title words and company
+    title_parts = title.split()[:3]
+    company_parts = company.split()[:2]
+    
+    code_parts = []
+    for part in title_parts + company_parts:
+        if part and len(part) > 0:
+            code_parts.append(part[0].upper())
+    
+    code = ''.join(code_parts)
+    
+    # If code is too short, add some random characters
+    if len(code) < 4:
+        import random
+        import string
+        code += ''.join(random.choices(string.ascii_uppercase + string.digits, k=4-len(code)))
+    
+    return code[:8]
+
+
+def get_utm_params(source: str = '', medium: str = 'email', campaign: str = 'job_match') -> Dict[str, str]:
+    """
+    Get UTM parameters for tracking.
+    
+    Args:
+        source: UTM source
+        medium: UTM medium
+        campaign: UTM campaign
+    
+    Returns:
+        UTM parameters dictionary
+    """
+    return {
+        'utm_source': source or 'deep_link',
+        'utm_medium': medium,
+        'utm_campaign': campaign,
+        'utm_content': 'apply_directly'
+    }

--- a/backend/deep_links/views.py
+++ b/backend/deep_links/views.py
@@ -1,0 +1,354 @@
+"""
+Deep Links Views for API
+"""
+
+import logging
+from datetime import datetime, timedelta
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from django.shortcuts import redirect, get_object_or_404
+from django.http import HttpResponseRedirect
+from django.db.models import Q, Count, Sum, Avg
+
+from .models import (
+    DeepLink,
+    DeepLinkClick,
+    JobPosting,
+    JobMatch,
+    DeepLinkAnalytics,
+    DeepLinkDomain
+)
+from .serializers import (
+    DeepLinkSerializer,
+    DeepLinkClickSerializer,
+    JobPostingSerializer,
+    JobMatchSerializer,
+    DeepLinkAnalyticsSerializer,
+    DeepLinkRequestSerializer,
+    DeepLinkClickRequestSerializer,
+    JobMatchRequestSerializer,
+    DeepLinkStatsSerializer
+)
+from .services import DeepLinkService
+
+logger = logging.getLogger(__name__)
+
+
+class DeepLinkRedirectView(APIView):
+    """Redirect to the original URL via deep link."""
+    permission_classes = [AllowAny]
+    
+    def get(self, request, short_code):
+        service = DeepLinkService()
+        
+        # Track the click
+        result = service.track_click(
+            short_code=short_code,
+            user_id=request.user.id if request.user.is_authenticated else None,
+            ip_address=self.get_client_ip(request),
+            user_agent=request.META.get('HTTP_USER_AGENT', ''),
+            consent_given=request.GET.get('consent') == 'true',
+            referer=request.META.get('HTTP_REFERER', ''),
+            session_id=request.session.session_key
+        )
+        
+        if not result['success']:
+            return Response({
+                'error': result.get('error', 'Deep link not found')
+            }, status=status.HTTP_404_NOT_FOUND)
+        
+        # Get the deep link
+        deep_link = result['deep_link']
+        
+        # Update match as viewed if user is authenticated
+        if request.user.is_authenticated:
+            JobMatch.objects.filter(
+                user_id=request.user.id,
+                deep_link=deep_link
+            ).update(is_viewed=True, viewed_at=datetime.now())
+        
+        # Redirect to original URL
+        return HttpResponseRedirect(deep_link.original_url)
+    
+    def get_client_ip(self, request):
+        x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+        if x_forwarded_for:
+            ip = x_forwarded_for.split(',')[0]
+        else:
+            ip = request.META.get('REMOTE_ADDR')
+        return ip
+
+
+class DeepLinkCreateView(APIView):
+    """Create a new deep link."""
+    permission_classes = [IsAuthenticated]
+    
+    def post(self, request):
+        serializer = DeepLinkRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        
+        service = DeepLinkService()
+        result = service.create_deep_link(
+            title=serializer.validated_data['title'],
+            company=serializer.validated_data['company'],
+            original_url=serializer.validated_data['original_url'],
+            location=serializer.validated_data.get('location', ''),
+            source=serializer.validated_data.get('source', ''),
+            job_id=serializer.validated_data.get('job_id', ''),
+            match_score=serializer.validated_data.get('match_score', 0),
+            created_by=request.user.id
+        )
+        
+        if result['success']:
+            return Response({
+                'success': True,
+                'data': result['data'],
+                'message': 'Deep link created successfully'
+            })
+        
+        return Response({
+            'success': False,
+            'error': result.get('error', 'Failed to create deep link')
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+
+class DeepLinkListView(APIView):
+    """List all deep links."""
+    permission_classes = [IsAuthenticated]
+    
+    def get(self, request):
+        limit = request.query_params.get('limit', 50)
+        search = request.query_params.get('search', '')
+        
+        try:
+            limit = int(limit)
+            if limit > 100:
+                limit = 100
+        except:
+            limit = 50
+        
+        deep_links = DeepLink.objects.filter(is_active=True)
+        
+        if search:
+            deep_links = deep_links.filter(
+                Q(title__icontains=search) |
+                Q(company__icontains=search) |
+                Q(location__icontains=search)
+            )
+        
+        deep_links = deep_links.order_by('-created_at')[:limit]
+        serializer = DeepLinkSerializer(deep_links, many=True, context={'request': request})
+        
+        return Response({
+            'success': True,
+            'data': serializer.data,
+            'count': len(serializer.data)
+        })
+
+
+class JobMatchView(APIView):
+    """Get job matches for a user."""
+    permission_classes = [IsAuthenticated]
+    
+    def get(self, request):
+        user_id = request.user.id
+        limit = request.query_params.get('limit', 20)
+        min_score = request.query_params.get('min_score', 0)
+        
+        try:
+            limit = int(limit)
+            min_score = float(min_score)
+        except:
+            limit = 20
+            min_score = 0
+        
+        matches = JobMatch.objects.filter(
+            user_id=user_id,
+            match_score__gte=min_score
+        ).select_related('job_posting', 'deep_link').order_by('-match_score')[:limit]
+        
+        serializer = JobMatchSerializer(matches, many=True)
+        
+        return Response({
+            'success': True,
+            'data': serializer.data,
+            'count': len(serializer.data)
+        })
+    
+    def post(self, request):
+        """Create a job match."""
+        serializer = JobMatchRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        
+        user_id = request.user.id
+        
+        # Check if job posting exists, if not create one
+        job_posting_id = serializer.validated_data.get('job_posting_id')
+        title = serializer.validated_data.get('title')
+        company = serializer.validated_data.get('company')
+        original_url = serializer.validated_data.get('original_url')
+        
+        service = DeepLinkService()
+        
+        if job_posting_id:
+            result = service.create_job_match(
+                user_id=user_id,
+                job_posting_id=job_posting_id
+            )
+        else:
+            result = service.create_job_posting_match(
+                user_id=user_id,
+                title=title,
+                company=company,
+                original_url=original_url,
+                location=serializer.validated_data.get('location', '')
+            )
+        
+        if result['success']:
+            return Response({
+                'success': True,
+                'data': result['data'],
+                'message': 'Job match created successfully'
+            })
+        
+        return Response({
+            'success': False,
+            'error': result.get('error', 'Failed to create job match')
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+
+class JobMatchApplyView(APIView):
+    """Mark a job match as applied."""
+    permission_classes = [IsAuthenticated]
+    
+    def post(self, request, match_id):
+        user_id = request.user.id
+        
+        try:
+            match = JobMatch.objects.get(id=match_id, user_id=user_id)
+        except JobMatch.DoesNotExist:
+            return Response({
+                'success': False,
+                'error': 'Job match not found'
+            }, status=status.HTTP_404_NOT_FOUND)
+        
+        match.mark_as_applied()
+        
+        return Response({
+            'success': True,
+            'message': 'Applied successfully'
+        })
+
+
+class DeepLinkStatsView(APIView):
+    """Get deep link statistics."""
+    permission_classes = [IsAuthenticated]
+    
+    def get(self, request):
+        user_id = request.user.id
+        
+        # Only admins can see all stats
+        if not request.user.is_staff and not request.user.is_superuser:
+            # Regular users see their own stats
+            matches = JobMatch.objects.filter(user_id=user_id)
+            
+            return Response({
+                'success': True,
+                'data': {
+                    'total_matches': matches.count(),
+                    'applied': matches.filter(is_applied=True).count(),
+                    'viewed': matches.filter(is_viewed=True).count(),
+                    'average_match_score': matches.aggregate(avg=Avg('match_score'))['avg'] or 0
+                }
+            })
+        
+        # Admin stats
+        service = DeepLinkService()
+        stats = service.get_stats()
+        
+        return Response({
+            'success': True,
+            'data': stats
+        })
+
+
+class DeepLinkEngagementView(APIView):
+    """Track deep link engagement."""
+    permission_classes = [AllowAny]
+    
+    def post(self, request):
+        serializer = DeepLinkClickRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        
+        service = DeepLinkService()
+        result = service.track_engagement(
+            deep_link_id=serializer.validated_data['deep_link_id'],
+            user_id=request.user.id if request.user.is_authenticated else None,
+            consent_given=serializer.validated_data.get('consent_given', False),
+            time_on_page=serializer.validated_data.get('time_on_page', 0),
+            scrolled=serializer.validated_data.get('scrolled', False),
+            interacted=serializer.validated_data.get('interacted', False)
+        )
+        
+        if result['success']:
+            return Response({
+                'success': True,
+                'message': 'Engagement tracked'
+            })
+        
+        return Response({
+            'success': False,
+            'error': result.get('error', 'Failed to track engagement')
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+
+class DeepLinkDomainView(APIView):
+    """Manage trusted domains."""
+    permission_classes = [IsAuthenticated]
+    
+    def get(self, request):
+        if not request.user.is_staff and not request.user.is_superuser:
+            return Response({
+                'success': False,
+                'error': 'Admin access required'
+            }, status=status.HTTP_403_FORBIDDEN)
+        
+        domains = DeepLinkDomain.objects.filter(is_active=True)
+        serializer = DeepLinkDomainSerializer(domains, many=True)
+        
+        return Response({
+            'success': True,
+            'data': serializer.data
+        })
+    
+    def post(self, request):
+        if not request.user.is_staff and not request.user.is_superuser:
+            return Response({
+                'success': False,
+                'error': 'Admin access required'
+            }, status=status.HTTP_403_FORBIDDEN)
+        
+        domain = request.data.get('domain')
+        is_trusted = request.data.get('is_trusted', True)
+        
+        if not domain:
+            return Response({
+                'success': False,
+                'error': 'Domain is required'
+            }, status=status.HTTP_400_BAD_REQUEST)
+        
+        obj, created = DeepLinkDomain.objects.get_or_create(
+            domain=domain,
+            defaults={'is_trusted': is_trusted}
+        )
+        
+        return Response({
+            'success': True,
+            'data': DeepLinkDomainSerializer(obj).data,
+            'created': created
+        })


### PR DESCRIPTION
## What this PR does
Adds "apply directly" deep links to matched job postings.

## Features Added
- Deep link generation for job postings
- Short URL codes for easy sharing
- Click tracking with engagement metrics
- Consent-based tracking (#265)
- Job match management
- Trusted domain validation
- Analytics dashboard

## API Endpoints
- GET /apply/{short_code}/ - Redirect to original URL
- POST /api/deep-links/create/ - Create deep link
- GET /api/deep-links/list/ - List deep links
- GET /api/deep-links/stats/ - Get statistics
- GET /api/job-matches/ - Get job matches
- POST /api/job-matches/ - Create match
- POST /api/job-matches/{id}/apply/ - Mark as applied
- POST /api/deep-links/engagement/ - Track engagement
- GET /api/deep-links/domains/ - Manage domains

Closes #999