### PR TITLE
feat: add job board integration for real open roles (Closes #998)

### DIFF
--- a/backend/analyzer/job_board_views.py
+++ b/backend/analyzer/job_board_views.py
@@ -1,0 +1,88 @@
+import os
+import requests
+import urllib.parse
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.response import Response
+from rest_framework import status
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def suggest_roles(request):
+    """
+    Fetch open roles from Adzuna API based on detected skills and career track.
+    Expected query params:
+      - track: str (e.g. "Software Engineer")
+      - skills: str (comma-separated skills, e.g. "Python,Django,React")
+      - country: str (default 'us')
+    """
+    app_id = os.environ.get('ADZUNA_APP_ID')
+    app_key = os.environ.get('ADZUNA_APP_KEY')
+    
+    track = request.GET.get('track', '')
+    skills = request.GET.get('skills', '')
+    country = request.GET.get('country', 'us')
+    
+    if not track and not skills:
+        return Response({"error": "Please provide 'track' or 'skills' query parameters."}, status=status.HTTP_400_BAD_REQUEST)
+
+    # Use Adzuna API if keys are present, else fallback to mock for development/review
+    if app_id and app_key:
+        query_parts = []
+        if track:
+            query_parts.append(track)
+        if skills:
+            query_parts.extend(skills.split(','))
+            
+        what_query = " ".join(query_parts)
+        
+        encoded_what = urllib.parse.quote(what_query)
+        url = f"https://api.adzuna.com/v1/api/jobs/{country}/search/1?app_id={app_id}&app_key={app_key}&results_per_page=5&what={encoded_what}"
+        
+        try:
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            jobs = []
+            for item in data.get('results', []):
+                jobs.append({
+                    'title': item.get('title'),
+                    'company': item.get('company', {}).get('display_name'),
+                    'location': item.get('location', {}).get('display_name'),
+                    'url': item.get('redirect_url'),
+                    'description': item.get('description'),
+                    'source': 'Adzuna'
+                })
+            
+            return Response({
+                "source": "Adzuna",
+                "attribution": "Job listings provided by Adzuna",
+                "jobs": jobs
+            })
+        except requests.RequestException as e:
+            return Response({"error": f"Failed to fetch jobs: {str(e)}"}, status=status.HTTP_502_BAD_GATEWAY)
+    else:
+        # Mock data fallback when API keys are not provided
+        mock_jobs = [
+            {
+                'title': f'Senior {track or "Developer"}',
+                'company': 'Tech Innovations Inc.',
+                'location': 'Remote',
+                'url': '#',
+                'description': f'Looking for an experienced professional with skills in {skills}.',
+                'source': 'Adzuna (Mock)'
+            },
+            {
+                'title': f'{track or "Engineer"} Role',
+                'company': 'Future Solutions',
+                'location': 'New York, NY',
+                'url': '#',
+                'description': f'Join our dynamic team. Requirements: {skills}.',
+                'source': 'Adzuna (Mock)'
+            }
+        ]
+        return Response({
+            "source": "Adzuna (Mocked)",
+            "attribution": "Job listings provided by Adzuna API (Mock Mode: Keys not configured)",
+            "jobs": mock_jobs
+        })

--- a/backend/analyzer/tests_job_board.py
+++ b/backend/analyzer/tests_job_board.py
@@ -1,0 +1,49 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+from rest_framework import status
+from unittest.mock import patch
+
+class JobBoardIntegrationTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse('suggest_roles')
+
+    def test_suggest_roles_missing_params(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch('analyzer.job_board_views.requests.get')
+    def test_suggest_roles_with_mocked_adzuna(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {
+            "results": [
+                {
+                    "title": "Software Engineer",
+                    "company": {"display_name": "Test Co"},
+                    "location": {"display_name": "London"},
+                    "redirect_url": "http://test.com",
+                    "description": "Test job"
+                }
+            ]
+        }
+        
+        with patch('os.environ.get') as mock_env:
+            def side_effect(key, default=None):
+                if key == 'ADZUNA_APP_ID': return 'test_id'
+                if key == 'ADZUNA_APP_KEY': return 'test_key'
+                return default
+            mock_env.side_effect = side_effect
+            
+            response = self.client.get(self.url, {'track': 'Software Engineer', 'skills': 'Python'})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data['source'], 'Adzuna')
+            self.assertEqual(len(response.data['jobs']), 1)
+            self.assertEqual(response.data['jobs'][0]['title'], 'Software Engineer')
+
+    def test_suggest_roles_fallback_mock(self):
+        with patch('os.environ.get', return_value=None):
+            response = self.client.get(self.url, {'track': 'Software Engineer'})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data['source'], 'Adzuna (Mocked)')
+            self.assertTrue(len(response.data['jobs']) > 0)

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -63,9 +63,11 @@ from .cliche_views import ClicheDetectorView
 from .linkedin_views import LinkedInOptimizationView, LinkedInConsistencyView
 from .sanitizer_views import FileMetadataView, SanitizeResumeView
 from .ats_simulator_views import list_ats_profiles, simulate_ats
+from .job_board_views import suggest_roles
 
 urlpatterns = [
     path("upload/", upload_resume),
+    path("job-board/suggest/", suggest_roles, name="suggest_roles"),
     path("preview-level/", preview_experience_level_view),
     path("status/<str:task_id>/", task_status),
     path("mock-interview/", mock_interview_view),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -70,6 +70,7 @@ import InterviewPrepCoach from './components/InterviewPrepCoach'
 import PortfolioShowcaseBuilder from './components/PortfolioShowcaseBuilder'
 
 import SkillGapAnalyzer from './components/SkillGapAnalyzer'
+import { JobBoardSuggestions } from './components/JobBoardSuggestions'
 
 import { setResumeRoastConsent } from './utils/cookieConsent'
 import { JobDescriptionInput } from './components/JobDescriptionInput'
@@ -1978,6 +1979,7 @@ function App() {
                 </div>
               </div>
 
+              <JobBoardSuggestions skills={skills} track={targetRole} />
               <InterviewQuestionsPanel questions={interviewQuestions} />
             </>
           )}{' '}

--- a/frontend/src/components/JobBoardSuggestions.tsx
+++ b/frontend/src/components/JobBoardSuggestions.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect } from 'react'
+import axios from 'axios'
+import { api } from '../api/client'
+
+export interface JobListing {
+  title: string
+  company: string
+  location: string
+  url: string
+  description: string
+  source: string
+}
+
+interface JobBoardSuggestionsProps {
+  skills: string[]
+  track: string
+}
+
+export function JobBoardSuggestions({ skills, track }: JobBoardSuggestionsProps) {
+  const [jobs, setJobs] = useState<JobListing[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [attribution, setAttribution] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchJobs() {
+      if (!track && skills.length === 0) return
+
+      setLoading(true)
+      setError(null)
+
+      try {
+        const response = await api.get('/job-board/suggest/', {
+          params: {
+            track: track || undefined,
+            skills: skills.length > 0 ? skills.join(',') : undefined,
+          },
+        })
+        setJobs(response.data.jobs || [])
+        setAttribution(response.data.attribution || null)
+      } catch (err) {
+        setError('Failed to fetch job suggestions. Please try again later.')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchJobs()
+  }, [skills, track])
+
+  if (loading) {
+    return (
+      <div className="card mt-4 p-4 shadow-sm">
+        <h4>🔍 Finding open roles...</h4>
+        <div className="spinner-border text-primary" role="status">
+          <span className="visually-hidden">Loading...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="card mt-4 p-4 shadow-sm">
+        <h4>💼 Suggested Open Roles</h4>
+        <p className="text-danger">{error}</p>
+      </div>
+    )
+  }
+
+  if (jobs.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="card mt-4 p-4 shadow-sm job-suggestions">
+      <h4>💼 Suggested Open Roles</h4>
+      <p className="text-muted small mb-3">
+        Based on your detected skills and {track ? `career track (${track})` : 'profile'}.
+      </p>
+
+      <div className="list-group mb-3">
+        {jobs.map((job, idx) => (
+          <a
+            key={idx}
+            href={job.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="list-group-item list-group-item-action flex-column align-items-start mb-2 border rounded"
+          >
+            <div className="d-flex w-100 justify-content-between">
+              <h5 className="mb-1 text-primary">{job.title}</h5>
+              <small>{job.location}</small>
+            </div>
+            <p className="mb-1 fw-bold">{job.company}</p>
+            <p className="mb-1 text-muted small">
+              {job.description.length > 150
+                ? job.description.substring(0, 150) + '...'
+                : job.description}
+            </p>
+          </a>
+        ))}
+      </div>
+
+      {attribution && <div className="text-end text-muted small fst-italic">* {attribution}</div>}
+    </div>
+  )
+}


### PR DESCRIPTION

    ## 📝 Description

    This PR implements the job board integration as requested in issue
  #998. It introduces a new backend endpoint (`/api/job-board/suggest/`)
  that uses the Adzuna API (or falls back to mock data if API keys aren't
  set) to fetch real open roles based on the user's detected skills and
  selected career track. On the frontend, a new `JobBoardSuggestions`
  component is displayed below the suggestions box to present these
  relevant job opportunities with clear attribution to Adzuna.

    ## 🔗 Related Issue

    Closes #998

    ## ✅ Type of Change

    - [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
    - [x] ✨ New feature (non-breaking change that adds functionality)
    - [ ] 📚 Documentation update
    - [ ] 💅 UI/UX improvement
    - [ ] ♻️ Refactor (no functional change)
    - [ ] ⚡ Performance improvement

    ## 🧪 How Has This Been Tested?

    - [x] Frontend builds (`npm run build`) and lints (`npm run lint`)
  clean
    - [x] Backend tests pass (`python manage.py test analyzer`)
    - [x] Manually tested in the browser / API client
    - [x] Wrote automated tests for the new `job_board_views.py` backend
  endpoint

    ## 📋 Checklist

    - [x] My code follows the project's style and conventions
    - [x] I have linked the related issue above
    - [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
