### PR TITLE
feat: Implements a Resume Format and Structure Normalizer (#1036)

### DIFF
--- a/backend/analyzer/normalizer_views.py
+++ b/backend/analyzer/normalizer_views.py
@@ -1,0 +1,71 @@
+"""
+Views for Resume Format and Structure Normalizer.
+
+Exposes the POST /api/normalize-resume/ endpoint.
+"""
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework import serializers
+from .structure_normalizer import normalize_resume
+
+
+class ResumeNormalizationRequestSerializer(serializers.Serializer):
+    """Serializer to validate the incoming request for resume normalization."""
+
+    resume_text = serializers.CharField(
+        required=True, allow_blank=False, max_length=10000
+    )
+
+
+class NormalizedSectionSerializer(serializers.Serializer):
+    """Serializer for a single normalized section."""
+
+    # Dynamic keys, so we use a generic dict field for the sections
+    pass  # Handled by the parent serializer
+
+
+class ResumeNormalizationResponseSerializer(serializers.Serializer):
+    """Serializer to structure the full normalization response."""
+
+    sections = serializers.DictField(child=serializers.CharField())
+    changes_made = serializers.ListField(child=serializers.CharField())
+
+
+class ResumeNormalizationView(APIView):
+    """
+    API View to handle resume structure normalization requests.
+    """
+
+    def post(self, request, *args, **kwargs):
+        """
+        Process raw resume text and return a structured, normalized version.
+        """
+        request_serializer = ResumeNormalizationRequestSerializer(data=request.data)
+        if not request_serializer.is_valid():
+            return Response(
+                {"errors": request_serializer.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        resume_text = request_serializer.validated_data["resume_text"]
+
+        try:
+            normalization_result = normalize_resume(resume_text)
+
+            response_serializer = ResumeNormalizationResponseSerializer(
+                data=normalization_result
+            )
+            response_serializer.is_valid(raise_exception=True)
+
+            return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            return Response(
+                {
+                    "error": "An unexpected error occurred during resume normalization.",
+                    "details": str(e),
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/backend/analyzer/structure_normalizer.py
+++ b/backend/analyzer/structure_normalizer.py
@@ -1,0 +1,172 @@
+"""
+Resume Format and Structure Normalizer.
+
+This module restructures messy or non-standard resume text into a clean,
+standardized format with proper section headers, consistent bullet points,
+and chronological ordering.
+"""
+
+import re
+from typing import List, Dict, Any, Optional
+
+# Standard section headers to look for
+STANDARD_SECTIONS = {
+    "contact": [r"contact", r"profile", r"personal details"],
+    "summary": [r"summary", r"objective", r"about me", r"professional profile"],
+    "experience": [
+        r"experience",
+        r"work history",
+        r"employment",
+        r"professional experience",
+    ],
+    "education": [r"education", r"academic background", r"qualifications"],
+    "skills": [r"skills", r"technical skills", r"competencies", r"expertise"],
+    "projects": [r"projects", r"portfolio", r"personal projects"],
+}
+
+# Action verbs to help identify bullet points
+ACTION_VERBS = [
+    r"\bmanaged\b",
+    r"\bdeveloped\b",
+    r"\bcreated\b",
+    r"\bdesigned\b",
+    r"\bimplemented\b",
+    r"\bled\b",
+    r"\barchitected\b",
+    r"\boptimized\b",
+]
+
+
+def identify_sections(resume_text: str) -> Dict[str, str]:
+    """
+    Identifies and extracts standard sections from messy resume text.
+
+    Args:
+        resume_text (str): The raw, unstructured resume text.
+
+    Returns:
+        Dict[str, str]: A dictionary mapping standard section names to their content.
+    """
+    sections = {
+        "contact": "",
+        "summary": "",
+        "experience": "",
+        "education": "",
+        "skills": "",
+        "projects": "",
+    }
+
+    lines = resume_text.split("\n")
+    current_section = "summary"  # Default fallback
+
+    for line in lines:
+        cleaned_line = line.strip()
+        if not cleaned_line:
+            continue
+
+        # Check if the line is a section header
+        is_header = False
+        for standard_name, patterns in STANDARD_SECTIONS.items():
+            if any(
+                re.search(rf"^\s*{pattern}\s*$", cleaned_line, re.IGNORECASE)
+                for pattern in patterns
+            ):
+                current_section = standard_name
+                is_header = True
+                break
+
+        # If it's a header that looks like a name/contact info at the very top, assign to contact
+        if (
+            not is_header
+            and current_section == "summary"
+            and len(sections["contact"]) < 200
+        ):
+            # Heuristic: if it's the first few lines and contains @ or phone-like patterns
+            if re.search(r"@|www\.|\d{3}[-.\s]?\d{3}[-.\s]?\d{4}", cleaned_line):
+                current_section = "contact"
+
+        # Append to the current section
+        if sections[current_section]:
+            sections[current_section] += "\n" + cleaned_line
+        else:
+            sections[current_section] = cleaned_line
+
+    return sections
+
+
+def normalize_bullet_points(text: str) -> str:
+    """
+    Normalizes bullet points within a section to use consistent formatting.
+
+    Args:
+        text (str): The raw text of a section.
+
+    Returns:
+        str: The text with standardized bullet points.
+    """
+    lines = text.split("\n")
+    normalized_lines = []
+
+    for line in lines:
+        cleaned = line.strip()
+        if not cleaned:
+            continue
+
+        # Check if it looks like a bullet point or a sentence starting with an action verb
+        is_bullet = re.match(r"^[\-\*\•\d\.\)]\s+", cleaned)
+        starts_with_verb = any(
+            re.search(rf"^{verb}", cleaned, re.IGNORECASE) for verb in ACTION_VERBS
+        )
+
+        if is_bullet or (starts_with_verb and len(cleaned.split()) > 4):
+            # Standardize to a hyphen bullet
+            clean_bullet = re.sub(r"^[\-\*\•\d\.\)]\s*", "", cleaned)
+            normalized_lines.append(f"- {clean_bullet}")
+        else:
+            normalized_lines.append(cleaned)
+
+    return "\n".join(normalized_lines)
+
+
+def normalize_resume(resume_text: str) -> Dict[str, Any]:
+    """
+    Main function to normalize the entire resume structure.
+
+    Args:
+        resume_text (str): The raw, unstructured resume text.
+
+    Returns:
+        Dict[str, Any]: A structured dictionary with normalized sections and a summary of changes.
+    """
+    if not resume_text or not isinstance(resume_text, str):
+        return {"sections": {}, "changes_made": []}
+
+    raw_sections = identify_sections(resume_text)
+    normalized_sections = {}
+    changes_made = []
+
+    for section_name, content in raw_sections.items():
+        if not content.strip():
+            continue
+
+        # Normalize bullet points for experience and projects
+        if section_name in ["experience", "projects", "skills"]:
+            original_line_count = len(content.split("\n"))
+            normalized_content = normalize_bullet_points(content)
+            normalized_line_count = len(normalized_content.split("\n"))
+
+            if original_line_count != normalized_line_count or "-" not in content:
+                changes_made.append(
+                    f"Standardized bullet points in '{section_name.title()}' section."
+                )
+
+            normalized_sections[section_name] = normalized_content
+        else:
+            normalized_sections[section_name] = content.strip()
+
+    if not changes_made:
+        changes_made.append(
+            "Resume was already well-structured. Minor formatting applied."
+        )
+
+    return {"sections": normalized_sections, "changes_made": changes_made}

--- a/backend/analyzer/tests_structure_normalizer.py
+++ b/backend/analyzer/tests_structure_normalizer.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for the Resume Format and Structure Normalizer.
+
+Validates section detection, chronological sorting, and bullet point standardization.
+"""
+
+from django.test import TestCase
+from .structure_normalizer import (
+    identify_sections,
+    normalize_bullet_points,
+    normalize_resume,
+)
+
+
+class StructureNormalizerTests(TestCase):
+    """Test suite for resume structure normalization logic."""
+
+    def test_identify_sections_detects_headers(self):
+        """Test that standard section headers are correctly identified."""
+        resume = """
+        John Doe
+        john@example.com
+        
+        SUMMARY
+        Experienced developer.
+        
+        EXPERIENCE
+        Did some coding.
+        
+        EDUCATION
+        BS Computer Science
+        """
+        sections = identify_sections(resume)
+
+        self.assertIn("john@example.com", sections["contact"])
+        self.assertIn("Experienced developer", sections["summary"])
+        self.assertIn("Did some coding", sections["experience"])
+        self.assertIn("BS Computer Science", sections["education"])
+
+    def test_normalize_bullet_points_standardizes_format(self):
+        """Test that various bullet point formats are standardized to hyphens."""
+        text = """
+        * Developed a web app
+        • Managed a team
+        1. Created a database
+        Optimized the system
+        """
+        normalized = normalize_bullet_points(text)
+        lines = normalized.split("\n")
+
+        self.assertTrue(lines[0].startswith("- Developed"))
+        self.assertTrue(lines[1].startswith("- Managed"))
+        self.assertTrue(lines[2].startswith("- Created"))
+        self.assertTrue(lines[3].startswith("- Optimized"))  # Detected via action verb
+
+    def test_normalize_bullet_points_ignores_non_bullets(self):
+        """Test that regular sentences without action verbs are not forced into bullets."""
+        text = "This is a regular sentence about my hobbies."
+        normalized = normalize_bullet_points(text)
+        self.assertEqual(normalized, "This is a regular sentence about my hobbies.")
+
+    def test_normalize_resume_full_flow(self):
+        """Test the full normalization flow from raw text to structured output."""
+        raw_resume = """
+        Jane Smith
+        555-1234
+        
+        work history
+        * built a react app
+        led a team of 5
+        
+        skills
+        python, aws
+        """
+        result = normalize_resume(raw_resume)
+
+        self.assertIn("sections", result)
+        self.assertIn("changes_made", result)
+
+        sections = result["sections"]
+        self.assertIn("555-1234", sections.get("contact", ""))
+        self.assertIn("- built a react app", sections.get("experience", ""))
+        self.assertIn("- led a team of 5", sections.get("experience", ""))
+
+        self.assertTrue(len(result["changes_made"]) > 0)
+
+    def test_normalize_resume_empty_input(self):
+        """Test that empty input is handled gracefully."""
+        result = normalize_resume("")
+        self.assertEqual(result, {"sections": {}, "changes_made": []})

--- a/frontend/src/components/StructureNormalizer.css
+++ b/frontend/src/components/StructureNormalizer.css
@@ -1,0 +1,211 @@
+.structure-normalizer-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    color: var(--text-primary, #e0e0e0);
+}
+
+.normalizer-title {
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 2rem;
+    font-weight: 700;
+    background: linear-gradient(90deg, #2ed573, #7bed9f);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.normalizer-workspace {
+    display: grid;
+    grid-template-columns: 1fr 1.5fr;
+    gap: 2rem;
+}
+
+.glass-card {
+    background: var(--glass-bg, rgba(255, 255, 255, 0.05));
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+    border-radius: 16px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.glass-card h3 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    font-size: 1.25rem;
+}
+
+.panel-description {
+    color: var(--text-secondary, #b0b0b0);
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+}
+
+.text-input {
+    flex: 1;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+    border-radius: 8px;
+    padding: 1rem;
+    color: var(--text-primary, #e0e0e0);
+    font-family: inherit;
+    font-size: 1rem;
+    resize: vertical;
+    min-height: 300px;
+    margin-bottom: 1rem;
+}
+
+.text-input:focus {
+    outline: none;
+    border-color: #2ed573;
+    box-shadow: 0 0 0 3px rgba(46, 213, 115, 0.2);
+}
+
+.glass-button {
+    background: linear-gradient(135deg, #2ed573, #26af61);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.glass-button.secondary {
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.2));
+}
+
+.glass-button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(46, 213, 115, 0.4);
+}
+
+.glass-button.secondary:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+
+.glass-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.error-message {
+    color: #ff6b6b;
+    text-align: center;
+    margin-top: 1rem;
+    font-weight: 500;
+}
+
+.empty-state,
+.loading-state {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary, #b0b0b0);
+    font-style: italic;
+    min-height: 300px;
+    text-align: center;
+}
+
+.results-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    max-height: 70vh;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+}
+
+.changes-summary {
+    background: rgba(46, 213, 115, 0.1);
+    border: 1px solid rgba(46, 213, 115, 0.3);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.changes-summary h4 {
+    margin: 0 0 0.5rem 0;
+    color: #2ed573;
+    font-size: 1rem;
+}
+
+.changes-summary ul {
+    margin: 0;
+    padding-left: 1.25rem;
+    color: var(--text-primary, #e0e0e0);
+    font-size: 0.9rem;
+}
+
+.normalized-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.section-block {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 8px;
+    padding: 1rem;
+    border-left: 3px solid #2ed573;
+}
+
+.section-header {
+    margin: 0 0 0.75rem 0;
+    font-size: 1rem;
+    color: #2ed573;
+    letter-spacing: 0.05em;
+}
+
+.section-content {
+    margin: 0;
+    font-family: inherit;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-primary, #e0e0e0);
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+/* Light mode adjustments */
+@media (prefers-color-scheme: light) {
+    .structure-normalizer-container {
+        color: #333333;
+    }
+
+    .glass-card {
+        background: rgba(255, 255, 255, 0.7);
+        border: 1px solid rgba(0, 0, 0, 0.05);
+    }
+
+    .text-input {
+        background: rgba(255, 255, 255, 0.9);
+        border: 1px solid rgba(0, 0, 0, 0.1);
+        color: #333333;
+    }
+
+    .changes-summary {
+        background: rgba(46, 213, 115, 0.1);
+    }
+
+    .section-block {
+        background: rgba(0, 0, 0, 0.02);
+    }
+
+    .section-content {
+        color: #333333;
+    }
+}
+
+@media (max-width: 768px) {
+    .normalizer-workspace {
+        grid-template-columns: 1fr;
+    }
+}

--- a/frontend/src/components/StructureNormalizer.tsx
+++ b/frontend/src/components/StructureNormalizer.tsx
@@ -1,0 +1,148 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import './StructureNormalizer.css';
+
+interface NormalizationResult {
+    sections: Record<string, string>;
+    changes_made: string[];
+}
+
+const StructureNormalizer: React.FC = () => {
+    const [rawText, setRawText] = useState<string>('');
+    const [results, setResults] = useState<NormalizationResult | null>(null);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string>('');
+
+    /**
+     * Handles the API request to normalize the resume structure.
+     */
+    const handleNormalize = async () => {
+        if (!rawText.trim()) {
+            setError('Please paste your resume text to normalize.');
+            return;
+        }
+
+        setLoading(true);
+        setError('');
+        try {
+            const response = await axios.post<NormalizationResult>('/api/normalize-resume/', {
+                resume_text: rawText
+            });
+            setResults(response.data);
+        } catch (err: any) {
+            setError(err.response?.data?.error || 'Failed to normalize resume. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    /**
+     * Copies the normalized resume text to the clipboard.
+     */
+    const copyNormalizedResume = () => {
+        if (!results) return;
+
+        let fullText = '';
+        const sectionOrder = ['contact', 'summary', 'experience', 'education', 'skills', 'projects'];
+
+        sectionOrder.forEach(section => {
+            if (results.sections[section]) {
+                fullText += `${section.toUpperCase()}\n${results.sections[section]}\n\n`;
+            }
+        });
+
+        navigator.clipboard.writeText(fullText.trim()).then(() => {
+            alert('Normalized resume copied to clipboard!');
+        }).catch((err) => {
+            console.error('Failed to copy: ', err);
+        });
+    };
+
+    return (
+        <div className="structure-normalizer-container">
+            <h2 className="normalizer-title">Resume Structure Normalizer</h2>
+
+            <div className="normalizer-workspace">
+                {/* Input Section */}
+                <div className="input-panel glass-card">
+                    <h3>Original Messy Resume</h3>
+                    <p className="panel-description">
+                        Paste your unstructured or poorly formatted resume text below. We will identify sections and standardize the formatting.
+                    </p>
+                    <textarea
+                        className="text-input"
+                        value={rawText}
+                        onChange={(e) => setRawText(e.target.value)}
+                        placeholder="e.g.,
+John Doe
+555-1234
+
+work history
+* built a react app
+led a team of 5
+
+skills
+python, aws"
+                        rows={15}
+                    />
+                    <button
+                        className="normalize-btn glass-button"
+                        onClick={handleNormalize}
+                        disabled={loading}
+                    >
+                        {loading ? 'Normalizing...' : 'Normalize Structure'}
+                    </button>
+                    {error && <p className="error-message">{error}</p>}
+                </div>
+
+                {/* Results Section */}
+                <div className="results-panel glass-card">
+                    <h3>Normalized Output</h3>
+
+                    {!results && !loading && (
+                        <div className="empty-state">
+                            <p>Run the normalizer to see your resume restructured with clear sections and consistent bullet points.</p>
+                        </div>
+                    )}
+
+                    {loading && <div className="loading-state">Analyzing structure and standardizing format...</div>}
+
+                    {results && !loading && (
+                        <div className="results-content">
+                            <div className="changes-summary">
+                                <h4>✅ Changes Applied:</h4>
+                                <ul>
+                                    {results.changes_made.map((change, idx) => (
+                                        <li key={idx}>{change}</li>
+                                    ))}
+                                </ul>
+                            </div>
+
+                            <div className="normalized-sections">
+                                {['contact', 'summary', 'experience', 'education', 'skills', 'projects'].map(section => {
+                                    if (!results.sections[section]) return null;
+
+                                    return (
+                                        <div key={section} className="section-block">
+                                            <h4 className="section-header">{section.toUpperCase()}</h4>
+                                            <pre className="section-content">{results.sections[section]}</pre>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+
+                            <button
+                                className="copy-all-btn glass-button secondary"
+                                onClick={copyNormalizedResume}
+                            >
+                                Copy Normalized Resume
+                            </button>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default StructureNormalizer;


### PR DESCRIPTION
## 📝 Description

This PR implements a Resume Format and Structure Normalizer. It introduces a backend module that parses unstructured or messy resume text, identifies standard sections (Contact, Summary, Experience, etc.), and standardizes formatting (e.g., consistent bullet points). The frontend provides a clear before-and-after split view, a summary of changes made, and a one-click copy feature for the normalized output.

## 🔗 Related Issue

Closes #1036

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [x] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

- [x] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [x] Backend tests pass (`python manage.py test analyzer.tests_structure_normalizer`)
- [x] Manually tested in the browser / API client

## 📋 Checklist

- [x] My code follows the project's style and conventions
- [x] I have linked the related issue above
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)