### PR TITLE
feat(profile): implement public opt-in profile pages with shareable URLs

### DIFF
--- a/backend/controllers/profileController.js
+++ b/backend/controllers/profileController.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const router = express.Router();
+const UserProfile = require('../models/UserProfile');
+const { requireAuth } = require('../middleware/auth'); // Mock application auth guard
+
+/**
+ * Endpoint 1: Toggle public visibility state setting
+ */
+router.patch('/api/profile/privacy', requireAuth, async (req, res) => {
+  const { isPublic, customSlug } = req.body;
+  try {
+    const slugValue = customSlug ? customSlug.toLowerCase().replace(/[^a-z0-9-]/g, '') : `user-${req.user.id}`;
+    
+    const profile = await UserProfile.findOneAndUpdate(
+      { userId: req.user.id },
+      { $set: { isPubliclyVisible: isPublic, publicSlug: isPublic ? slugValue : null } },
+      { new: true, upsert: true }
+    );
+    res.json({ message: 'Privacy configuration synchronized.', profile });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update visibility preferences.' });
+  }
+});
+
+/**
+ * Endpoint 2: Fetch Public Profile Profile by unique shareable slug (No Auth Required)
+ */
+router.get('/api/profiles/public/:slug', async (req, res) => {
+  try {
+    const profile = await UserProfile.findOne({ publicSlug: req.params.slug.toLowerCase() })
+      .populate('userId', 'username avatarUrl');
+
+    // Strict Data Block Leak Checks
+    if (!profile || !profile.isPubliclyVisible) {
+      return res.status(404).json({ error: 'Public profile not found or set to private.' });
+    }
+
+    // Explicitly return white-listed data parameters (Strictly excluding resume logs)
+    res.json({
+      username: profile.userId.username,
+      avatarUrl: profile.userId.avatarUrl,
+      bio: profile.bio,
+      scoreBadges: profile.scoreBadges
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Internal failure resolving public record indices.' });
+  }
+});
+
+module.exports = router;

--- a/backend/models/UserProfile.js
+++ b/backend/models/UserProfile.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const UserProfileSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true },
+  bio: { type: String, default: '' },
+  scoreBadges: [{
+    subject: String,
+    improvementDelta: Number,
+    unlockedAt: { type: Date, default: Date.now }
+  }],
+  // Acceptance Criteria: Secure visibility flags, private by default
+  isPubliclyVisible: { type: Boolean, default: false },
+  publicSlug: { type: String, unique: true, sparse: true } // Clean URL sharing hook
+}, { timestamps: true });
+
+module.exports = mongoose.model('UserProfile', UserProfileSchema);

--- a/frontend/src/components/profile/PrivacySettings.jsx
+++ b/frontend/src/components/profile/PrivacySettings.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+export default function PrivacySettings({ initialProfile }) {
+  const [isPublic, setIsPublic] = useState(initialProfile?.isPubliclyVisible || false);
+  const [slug, setSlug] = useState(initialProfile?.publicSlug || '');
+
+  const handleTogglePrivacy = async () => {
+    const nextState = !isPublic;
+    setIsPublic(nextState);
+
+    try {
+      const response = await fetch('/api/profile/privacy', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ isPublic: nextState, customSlug: slug })
+      });
+      const data = await response.json();
+      if (data.profile) setSlug(data.profile.publicSlug);
+    } catch (err) {
+      console.error('Failed to sync privacy preferences:', err);
+    }
+  };
+
+  const shareableUrl = `${window.location.origin}/p/${slug}`;
+
+  return (
+    <div className="p-6 bg-slate-900 border border-slate-800 rounded-xl text-white max-w-md">
+      <h3 className="text-md font-bold mb-2">Public Profile Visibility</h3>
+      <p className="text-xs text-slate-400 mb-4">Share your exam scores, improvement milestones, and bio page with recruiters or peers publicly.</p>
+
+      <div className="flex items-center justify-between mb-6">
+        <span className="text-sm font-medium">Make Profile Public</span>
+        <button
+          onClick={handleTogglePrivacy}
+          className={`w-11 h-6 flex items-center rounded-full p-1 transition-colors ${isPublic ? 'bg-blue-600' : 'bg-slate-700'}`}
+        >
+          <div className={`bg-white w-4 h-4 rounded-full shadow-md transform transition-transform ${isPublic ? 'translate-x-5' : 'translate-x-0'}`} />
+        </button>
+      </div>
+
+      {isPublic && slug && (
+        <div className="bg-slate-950 p-3 rounded-lg border border-slate-800 text-xs font-mono">
+          <p className="text-slate-500 mb-1">Your Shareable Public Link:</p>
+          <div className="flex items-center justify-between">
+            <span className="text-blue-400 truncate mr-2">{shareableUrl}</span>
+            <button 
+              onClick={() => navigator.clipboard.writeText(shareableUrl)}
+              className="px-2 py-1 bg-slate-800 text-slate-300 rounded hover:bg-slate-700 transition"
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 Description

<!-- Briefly describe what this PR does and why. -->

## 🔗 Related Issue

<!-- Replace XX with the issue number, e.g. Closes #12 or Fixes #34 -->
Closes #

## ✅ Type of Change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 💅 UI/UX improvement
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement

## 🧪 How Has This Been Tested?

<!-- Describe the steps you took to verify your change. -->
- [ ] Frontend builds (`npm run build`) and lints (`npm run lint`) clean
- [ ] Backend tests pass (`python manage.py test analyzer`)
- [ ] Manually tested in the browser / API client

## 📸 Screenshots (if applicable)

<!-- Drag & drop screenshots or a GIF here. -->

## 📋 Checklist

- [ ] My code follows the project's style and conventions
- [ ] I have linked the related issue above
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
## Description
Implements a public profile system allowing users to opt-in to sharing their exam prep progress and achievement badges via a public link (#970).

## Scope of Modifications
- **Privacy Access Control Controls**: Expanded user schemas to support default-private visibility profiles (`isPubliclyVisible`).
- **Data-Leak Safeguards**: Enforced a strict whitelist filter on public API delivery paths to completely isolate internal document assets (like resumes).
- **Slug Normalization**: Deployed clean unique shareable routing parameters (`/p/:slug`) supporting clean external asset access.

Closes #970
