### PR TITLE
docs: link GitHub Discussions from README and CONTRIBUTING (#985)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,6 +335,6 @@ Make sure all commands complete successfully and coverage meets defined threshol
 
 # Need Help?
 
-If you have questions, feel free to open a discussion or issue.
+If you have questions, ideas, or want to share something, start a conversation in [GitHub Discussions](https://github.com/Muskankr/AI-Resume-Analyzer/discussions) (Q&A, Ideas, Show and Tell). For actionable bugs or scoped work, open an issue.
 
 Happy Contributing! 🚀

--- a/README.md
+++ b/README.md
@@ -675,4 +675,6 @@ A huge thanks to all the developers who have contributed code, fixed bugs, and i
 
 ## Community
 
+Have a question, idea, or something to show off? Use [GitHub Discussions](https://github.com/Muskankr/AI-Resume-Analyzer/discussions) for open-ended conversations (Q&A, Ideas, Show and Tell), and keep the [Issues](https://github.com/Muskankr/AI-Resume-Analyzer/issues) tab for actionable, scoped work items.
+
 Join our [Discord Community](YOUR_DISCORD_URL) to ask questions, discuss the project, and connect with contributors.


### PR DESCRIPTION
## Summary

Links GitHub Discussions from the README and CONTRIBUTING.md so open-ended questions, ideas, and show-and-tell have a home separate from the Issues tab, as requested in #985.

## Changes
- **README.md** – Added a line in the Community section pointing to GitHub Discussions (Q&A, Ideas, Show and Tell) and clarifying that Issues stay for actionable, scoped work.
- **CONTRIBUTING.md** – Updated the "Need Help?" section to link Discussions explicitly and distinguish it from opening an issue.

## Scope note
This PR covers the documentation-linking portion of the acceptance criteria (the part deliverable via a pull request). Enabling Discussions with starter categories and posting a pinned welcome discussion are repository-level actions performed in the GitHub UI by a maintainer.

Closes #985