### PR TITLE
feat: add /assign-me self-service issue claiming bot (#981)

### DIFF
--- a/.github/workflows/assign-me.yml
+++ b/.github/workflows/assign-me.yml
@@ -1,0 +1,81 @@
+name: Self-service issue assignment
+
+# Lets contributors claim an unassigned issue by commenting "/assign-me".
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  assign:
+    # Only run on comments made on issues (not pull requests) that contain the command.
+    if: >-
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '/assign-me')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign issue to commenter
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+            const { owner, repo } = context.repo;
+
+            // Re-fetch the issue to get the current assignee state.
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+
+            if (issue.state !== 'open') {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: `@${commenter} this issue is closed, so it can't be claimed.`,
+              });
+              return;
+            }
+
+            const assignees = issue.assignees || [];
+
+            // Already claimed by someone else — reply with a clear message.
+            if (assignees.length > 0) {
+              const alreadyByCommenter = assignees.some(a => a.login === commenter);
+              if (alreadyByCommenter) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: `@${commenter} you're already assigned to this issue. 🎉`,
+                });
+              } else {
+                const names = assignees.map(a => `@${a.login}`).join(', ');
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: `@${commenter} this issue is already claimed by ${names}. Please pick another unassigned issue, or ask in the comments if you'd like to collaborate.`,
+                });
+              }
+              return;
+            }
+
+            // Unassigned and open — assign it to the commenter.
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              assignees: [commenter],
+            });
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body: `Assigned to @${commenter}. Thanks for picking this up! 🚀`,
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Please read this guide before contributing.
 - Commit Message Guidelines
 - Coding Standards
 - Reporting Issues
+- Claiming an Issue
 - Pull Request Process
 - Semantic Versioning
 - Contributor Checklist
@@ -248,6 +249,19 @@ is:issue is:open label:bug login
 
 This searches for open issues labeled `bug` containing the keyword `login`. You can replace `bug` and `login` with labels or keywords relevant to your issue.
 
+
+---
+
+# Claiming an Issue
+
+Before you start working on something, please claim the issue so others don't duplicate your effort.
+
+The **preferred way to claim an issue** is to comment `/assign-me` on it. A GitHub Action handles the rest:
+
+- If the issue is **open and unassigned**, it is assigned to you automatically and the bot confirms with a comment.
+- If the issue is **already claimed**, the bot replies letting you know who has it, so you can pick another one.
+
+Only work on issues that are assigned to you, and please avoid claiming more issues than you can actively work on at once.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a GitHub Action so contributors can claim an unassigned issue instantly by commenting `/assign-me`, instead of waiting for a maintainer, as requested in #981.

## Changes
- **.github/workflows/assign-me.yml** — New workflow triggered on `issue_comment`:
  - Runs only on issue comments (not PRs) containing `/assign-me`.
  - If the issue is **open and unassigned**, assigns it to the commenter and confirms with a comment.
  - If the issue is **already claimed**, replies with a clear message naming the current assignee(s) instead.
  - Uses `actions/github-script@v7` with least-privilege `issues: write` permission.
- **CONTRIBUTING.md** — New "Claiming an Issue" section documenting `/assign-me` as the preferred claiming method, added to the Table of Contents.

## Acceptance criteria
- [x] Commenting `/assign-me` on an open, unassigned issue assigns it to that commenter.
- [x] Already-assigned issues reply with a clear "already claimed" message instead.
- [x] Documented in CONTRIBUTING.md as the preferred claiming method.

## Verification
Workflow YAML validated with a YAML parser (parses cleanly; `on`, `permissions`, job `if` condition, and `actions/github-script@v7` step confirmed). Note: workflow permissions/behavior take effect once merged into the default branch.

Closes #981