### PR TITLE
feat: add stale-assignment nudge and auto-unassign workflow (#982)

### DIFF
--- a/.github/workflows/stale-assignment.yml
+++ b/.github/workflows/stale-assignment.yml
@@ -1,0 +1,122 @@
+name: Stale assignment nudge and unassign
+
+# Nudges assignees on inactive issues, then unassigns after a grace period.
+#
+# Thresholds (calendar days):
+#   INACTIVITY_DAYS = 14  -> after this much inactivity, post a friendly check-in.
+#   GRACE_DAYS      = 7   -> if still inactive this long after the nudge, unassign.
+# These are intentionally generous so slow-but-active contributors are not pushed out.
+on:
+  schedule:
+    # Runs once a day at 06:00 UTC.
+    - cron: '0 6 * * *'
+  # Allows manual runs from the Actions tab for testing.
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+env:
+  INACTIVITY_DAYS: '14'
+  GRACE_DAYS: '7'
+  # Hidden marker so the workflow can recognise its own nudge comments.
+  NUDGE_MARKER: '<!-- stale-assignment-nudge -->'
+
+jobs:
+  stale-assignments:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Nudge or unassign stale assigned issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const inactivityDays = Number(process.env.INACTIVITY_DAYS);
+            const graceDays = Number(process.env.GRACE_DAYS);
+            const marker = process.env.NUDGE_MARKER;
+            const now = Date.now();
+            const dayMs = 24 * 60 * 60 * 1000;
+
+            // All open issues that have at least one assignee (excludes PRs below).
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              assignee: '*',
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              // listForRepo returns PRs too; skip them.
+              if (issue.pull_request) continue;
+
+              const assignees = (issue.assignees || []).map(a => a.login);
+              if (assignees.length === 0) continue;
+
+              const daysSinceUpdate = (now - new Date(issue.updated_at).getTime()) / dayMs;
+
+              // Find our most recent nudge comment, if any.
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const nudges = comments.filter(c => (c.body || '').includes(marker));
+              const lastNudge = nudges.length ? nudges[nudges.length - 1] : null;
+
+              if (!lastNudge) {
+                // No nudge yet: post one once the issue has been inactive long enough.
+                if (daysSinceUpdate >= inactivityDays) {
+                  const mentions = assignees.map(a => `@${a}`).join(', ');
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    body:
+                      `${marker}\n` +
+                      `👋 ${mentions}, this issue has had no activity for ${inactivityDays} days. ` +
+                      `Are you still working on it? A quick comment keeps it assigned to you.\n\n` +
+                      `If we don't hear back within ${graceDays} days, we'll unassign it so someone else can pick it up. ` +
+                      `No pressure — just keeping things moving. 🙂`,
+                  });
+                  console.log(`Nudged #${issue.number}`);
+                }
+                continue;
+              }
+
+              // A nudge already exists. Has the assignee responded since it was posted?
+              const nudgeTime = new Date(lastNudge.created_at).getTime();
+              const daysSinceNudge = (now - nudgeTime) / dayMs;
+
+              const responded = comments.some(c =>
+                new Date(c.created_at).getTime() > nudgeTime &&
+                assignees.includes(c.user.login)
+              );
+
+              if (responded) {
+                console.log(`#${issue.number}: assignee responded after nudge; leaving assigned.`);
+                continue;
+              }
+
+              // No response within the grace period -> unassign and explain.
+              if (daysSinceNudge >= graceDays) {
+                await github.rest.issues.removeAssignees({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  assignees,
+                });
+                const mentions = assignees.map(a => `@${a}`).join(', ');
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body:
+                    `${marker}\n` +
+                    `Unassigning ${mentions} due to inactivity (no response for ${graceDays} days after the check-in). ` +
+                    `This issue is now open for anyone to claim. Thanks for your interest — feel free to pick it back up anytime! 🙌`,
+                });
+                console.log(`Unassigned #${issue.number}`);
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Please read this guide before contributing.
 - Coding Standards
 - Reporting Issues
 - Claiming an Issue
+- Issue Assignment Activity
 - Pull Request Process
 - Semantic Versioning
 - Contributor Checklist
@@ -263,6 +264,17 @@ The **preferred way to claim an issue** is to comment `/assign-me` on it. A GitH
 - If the issue is **already claimed**, the bot replies letting you know who has it, so you can pick another one.
 
 Only work on issues that are assigned to you, and please avoid claiming more issues than you can actively work on at once.
+
+---
+
+# Issue Assignment Activity
+
+To keep assigned issues from getting stuck, an automated workflow checks for inactivity on assigned issues:
+
+- **After 14 days** with no activity on an assigned issue, the bot posts a friendly check-in comment asking whether you're still working on it. A quick reply keeps it assigned to you.
+- **After a further 7-day grace period** with no response, the bot automatically unassigns the issue so it's free for others to pick up.
+
+These thresholds are intentionally generous so slow-but-active contributors aren't pushed out — just leave a short comment if you're still on it. You can always claim an unassigned issue again later.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Action that keeps assigned issues from getting stuck: it posts a friendly check-in on inactive assigned issues and unassigns them after a grace period with no response, as requested in #982.

## Changes
- **.github/workflows/stale-assignment.yml** — New scheduled workflow (daily cron + `workflow_dispatch`):
  - Scans open, assigned issues (skips PRs).
  - After **14 days** of inactivity, posts a friendly check-in comment (once, tracked via a hidden marker so it isn't reposted).
  - After a further **7-day grace period** with no response from the assignee, automatically unassigns and comments that the issue is open again.
  - If the assignee comments after the nudge, the issue is left assigned.
  - Uses `actions/github-script@v7` with least-privilege `issues: write`; thresholds are configurable via `env`.
- **CONTRIBUTING.md** — New "Issue Assignment Activity" section documenting the 14-day nudge and 7-day grace thresholds, added to the Table of Contents.

## Acceptance criteria
- [x] Automated check-in comment posted after the inactivity threshold (14 days).
- [x] Automatic unassignment after a further grace period (7 days) with no response.
- [x] Reasonable, documented thresholds — intentionally generous so slow-but-active contributors aren't pushed out; documented in CONTRIBUTING.md and in workflow comments.

## Verification
Workflow YAML validated with a YAML parser (parses cleanly; `on` schedule/dispatch, `permissions`, `env` thresholds, and `actions/github-script@v7` step confirmed). Note: scheduled workflows run from the default branch, so the behavior takes effect once merged.

Closes #982