### PR TITLE
feat(ats): add transparent 10-point ATS compatibility checker

### DIFF
--- a/backend/analyzer/ats_simulator.py
+++ b/backend/analyzer/ats_simulator.py
@@ -1,7 +1,8 @@
 import re
-from typing import Dict, List, Any
-from .section_headings import find_headings, SECTIONS
-from .timeline import extract_ranges
+import unicodedata
+from typing import Dict, List, Any, Callable, Tuple
+from .section_headings import find_headings, SECTIONS, section_body
+from .timeline import extract_ranges, FORMAT_LABELS
 
 class ATSProfile:
     id = ""
@@ -170,3 +171,676 @@ def get_simulator(profile_id: str) -> ATSProfile:
 
 def get_all_profiles() -> List[Dict[str, str]]:
     return [{"id": p.id, "name": p.name, "description": p.description} for p in PROFILES.values()]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 10-point ATS Compatibility Checker
+#
+# The simulators above answer "how would Workday/Greenhouse/Taleo treat this?".
+# The checker below answers a different, vendor-neutral question: "does this
+# resume follow the ten formatting rules that every mainstream ATS depends on?"
+#
+# Design goal: nothing is a black box. Every one of the ten criteria returns
+#   - the points it awarded and the maximum it could award (always out of 10),
+#   - a plain-language status (pass / warn / fail),
+#   - the concrete evidence it saw in the resume text, and
+#   - the fixes that would recover the most points.
+# The overall score is just the sum of the ten criteria (so 0..100), and the
+# "estimated ATS pass rate" is a documented interpolation from that score,
+# capped when a parser-fatal problem is present. No magic constants without a
+# comment next to them.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+CRITERION_MAX = 10          # every criterion is scored out of 10 ...
+NUM_CRITERIA = 10           # ... and there are ten of them -> overall is 0..100
+
+CORE_SECTIONS = ("experience", "education", "skills")   # an ATS files by these
+BONUS_SECTIONS = ("summary", "projects")
+
+# ~450 words per page is the usual single-column estimate; the band below is
+# "roughly one to two pages", which is what recruiters and parsers expect.
+WORDS_PER_PAGE = 450
+LENGTH_MIN_WORDS = 400
+LENGTH_MAX_WORDS = 850
+
+# Non-letter symbols that are common and harmless in real resumes: curly
+# quotes, en/em dashes, the bullet, the ellipsis and a non-breaking space.
+_SAFE_NON_ASCII = set("‘’“”–—•… ")
+
+_EMOJI_RE = re.compile(
+    "[\U0001F000-\U0001FAFF\U00002600-\U000027BF\U0001F1E6-\U0001F1FF⬀-⯿]"
+)
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_PHONE_RE = re.compile(r"(?:\+\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}")
+_LINKEDIN_RE = re.compile(r"linkedin\.com/in/[\w%-]+", re.IGNORECASE)
+_LOCATION_RE = re.compile(r"\b[A-Z][a-zA-Z.]+,\s*(?:[A-Z]{2}\b|[A-Z][a-z]+\b)")
+_DEGREE_RE = re.compile(
+    r"\b(bachelor|master|associate|doctorate|"
+    r"b\.?\s?s\.?|b\.?\s?a\.?|m\.?\s?s\.?|m\.?\s?a\.?|m\.?\s?b\.?a\.?|ph\.?\s?d|"
+    r"b\.?tech|m\.?tech|b\.?e\.?|b\.?sc|m\.?sc|diploma|degree)\b",
+    re.IGNORECASE,
+)
+
+# A small, uncontroversial action-verb list for the no-job-description path of
+# the keyword check. Not exhaustive on purpose - it only needs to tell "this
+# resume uses achievement language" from "this resume is a list of duties".
+_ACTION_VERBS = {
+    "led", "built", "designed", "implemented", "developed", "created", "launched",
+    "managed", "improved", "increased", "reduced", "optimized", "delivered",
+    "spearheaded", "architected", "migrated", "automated", "streamlined",
+    "mentored", "analyzed", "deployed", "integrated", "refactored", "established",
+    "coordinated", "achieved", "generated", "drove", "owned", "shipped", "scaled",
+    "negotiated", "resolved", "trained", "supervised",
+}
+
+_JD_STOPWORDS = {
+    "the", "and", "for", "with", "was", "this", "that", "from", "are", "you",
+    "your", "our", "their", "its", "have", "has", "had", "will", "would", "can",
+    "could", "should", "must", "not", "but", "they", "them", "who", "which",
+    "job", "role", "work", "team", "teams", "company", "including", "etc",
+    "experience", "skills", "ability", "responsibilities", "requirements",
+    "preferred", "plus", "strong", "years", "year", "using", "well", "able",
+}
+
+
+def _status(earned: int, maximum: int) -> str:
+    """pass at >=80% of the points, warn at >=50%, fail below that."""
+    pct = earned / maximum if maximum else 1.0
+    if pct >= 0.8:
+        return "pass"
+    if pct >= 0.5:
+        return "warn"
+    return "fail"
+
+
+def _criterion(cid, label, why, earned, evidence, fixes) -> Dict[str, Any]:
+    """Assemble one criterion result, clamping the score to 0..CRITERION_MAX."""
+    earned = max(0, min(CRITERION_MAX, int(round(earned))))
+    return {
+        "id": cid,
+        "label": label,
+        "earned": earned,
+        "max": CRITERION_MAX,
+        "status": _status(earned, CRITERION_MAX),
+        "why_it_matters": why,
+        "evidence": [e for e in evidence if e],
+        "fixes": [{"text": t, "points": max(1, int(p))} for t, p in fixes if t],
+    }
+
+
+def _split_skill_items(body: str) -> List[str]:
+    """Break a skills block into individual, de-duplicated entries."""
+    if not body:
+        return []
+    items, seen = [], set()
+    for part in re.split(r"[,\n;•|·]", body):
+        token = part.strip(" \t-–—:*•").strip()
+        if 1 <= len(token) <= 40 and re.search(r"[A-Za-z]", token):
+            key = token.lower()
+            if key not in seen:
+                seen.add(key)
+                items.append(token)
+    return items
+
+
+def _weird_characters(text: str) -> Dict[str, int]:
+    """Non-ASCII characters that are *not* letters and *not* on the safe list.
+
+    Accented letters and non-Latin scripts (real names) pass; decorative
+    glyphs, box drawing, arrows, ligatures and private-use junk do not.
+    """
+    weird: Dict[str, int] = {}
+    for ch in text:
+        if ord(ch) < 128 or ch in _SAFE_NON_ASCII:
+            continue
+        if unicodedata.category(ch).startswith("L"):   # a letter in some script
+            continue
+        weird[ch] = weird.get(ch, 0) + 1
+    return weird
+
+
+# ── the ten checks ───────────────────────────────────────────────────────────
+# Each takes the shared `ctx` dict and returns a `_criterion(...)` result.
+
+def _check_section_headers(ctx) -> Dict[str, Any]:
+    keys = ctx["heading_keys"]
+    earned, evidence, fixes = 0, [], []
+
+    present_core = [k for k in CORE_SECTIONS if k in keys]
+    missing_core = [k for k in CORE_SECTIONS if k not in keys]
+    earned += 3 * len(present_core)                       # 3 points per core section
+    if any(k in keys for k in BONUS_SECTIONS):            # a Summary/Projects heading
+        earned += 1
+
+    detected = [SECTIONS[k][0] for k in keys if k in SECTIONS]
+    if detected:
+        evidence.append("Detected headings: " + ", ".join(detected) + ".")
+    else:
+        evidence.append("No standard section heading was found on its own line.")
+    for k in missing_core:
+        name = SECTIONS[k][0]
+        evidence.append(f"No recognisable '{name}' heading.")
+        fixes.append((f"Add a plain '{name}' heading on its own line.", 3))
+
+    return _criterion(
+        "section_headers", "Standard section headings",
+        "An ATS files your content into fields by reading headings like 'Work "
+        "Experience', 'Education' and 'Skills'. Missing or creatively named "
+        "headings make whole sections disappear.",
+        earned, evidence, fixes,
+    )
+
+
+def _check_contact_info(ctx) -> Dict[str, Any]:
+    text = ctx["text"]
+    earned, evidence, fixes = 0, [], []
+
+    email = _EMAIL_RE.search(text)
+    phone = _PHONE_RE.search(text)
+    linkedin = _LINKEDIN_RE.search(text)
+    location = _LOCATION_RE.search(text)
+    ctx["flags"]["has_email"] = bool(email)
+
+    if email:
+        earned += 4
+        evidence.append(f"Email found: {email.group(0)}")
+    else:
+        evidence.append("No email address detected.")
+        fixes.append(("Put a professional email address in the top few lines.", 4))
+    if phone:
+        earned += 3
+        evidence.append(f"Phone number found: {phone.group(0)}")
+    else:
+        evidence.append("No phone number detected.")
+        fixes.append(("Add a phone number, e.g. (555) 123-4567.", 3))
+    if linkedin:
+        earned += 2
+        evidence.append("LinkedIn URL found.")
+    else:
+        fixes.append(("Add your LinkedIn URL (linkedin.com/in/...).", 2))
+    if location:
+        earned += 1
+        evidence.append(f"Location found: {location.group(0)}")
+    else:
+        fixes.append(("Add your city and state/country for location filters.", 1))
+
+    return _criterion(
+        "contact_info", "Contact information",
+        "Recruiters filter and contact you on these fields. If the parser "
+        "cannot find an email, your application can be unreachable.",
+        earned, evidence, fixes,
+    )
+
+
+def _check_dates(ctx) -> Dict[str, Any]:
+    ranges = ctx["date_ranges"]
+    earned, evidence, fixes = 0, [], []
+
+    if len(ranges) >= 1:
+        earned += 4
+    if len(ranges) >= 2:
+        earned += 3
+
+    formats = {
+        f for r in ranges for f in (r.start_format, r.end_format)
+        if f and f != "present"
+    }
+
+    if not ranges:
+        evidence.append("No parseable employment date ranges were found.")
+        fixes.append(("Give every role a month-and-year range, e.g. "
+                      "'Mar 2021 - Jun 2023'.", 7))
+    else:
+        evidence.append(
+            f"Found {len(ranges)} date range(s), e.g. '{ranges[0].text.strip()}'."
+        )
+        if len(ranges) < 2:
+            fixes.append(("List start and end dates for each role so the "
+                          "timeline can be reconstructed.", 3))
+        if len(formats) <= 1:
+            earned += 3
+            evidence.append("Date formats are consistent.")
+        else:
+            labels = sorted(FORMAT_LABELS.get(f, f) for f in formats)
+            evidence.append("Mixed date formats: " + ", ".join(labels) + ".")
+            fixes.append(("Use one date format everywhere (e.g. 'Jan 2020').", 3))
+
+    return _criterion(
+        "date_formatting", "Date formatting & consistency",
+        "Parsers build your career timeline from date ranges. Missing or "
+        "mixed formats produce gaps and mis-dated roles.",
+        earned, evidence, fixes,
+    )
+
+
+def _check_encoding(ctx) -> Dict[str, Any]:
+    text = ctx["text"]
+    earned, evidence, fixes = CRITERION_MAX, [], []
+
+    emoji = _EMOJI_RE.findall(text)
+    if emoji:
+        earned -= 3
+        evidence.append(f"{len(emoji)} emoji / pictograph character(s) found.")
+        fixes.append(("Remove emoji and pictographs - parsers often turn them "
+                      "into mojibake.", 3))
+
+    weird = ctx["weird_chars"]
+    if weird:
+        penalty = min(6, len(weird) * 2)                  # 2 points per symbol type
+        earned -= penalty
+        shown = ", ".join(repr(c) for c in list(weird)[:6])
+        evidence.append(f"{len(weird)} unusual symbol type(s): {shown}.")
+        fixes.append(("Replace decorative symbols and ligatures with plain "
+                      "ASCII ('-', '*').", penalty))
+
+    if not emoji and not weird:
+        evidence.append("No problematic characters - the text is ASCII-clean.")
+
+    return _criterion(
+        "encoding", "Character encoding",
+        "Special glyphs and smart symbols can be dropped or garbled when the "
+        "ATS re-encodes your file, corrupting nearby words.",
+        earned, evidence, fixes,
+    )
+
+
+def _check_keywords(ctx) -> Dict[str, Any]:
+    jd = (ctx["job_description"] or "").strip()
+    text_l = ctx["lower"]
+    earned, evidence, fixes = 0, [], []
+
+    if jd:
+        counts: Dict[str, int] = {}
+        for w in re.findall(r"[a-zA-Z][a-zA-Z+#.\-]{2,}", jd.lower()):
+            if w not in _JD_STOPWORDS:
+                counts[w] = counts.get(w, 0) + 1
+        keywords = [w for w, _ in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:25]]
+
+        if not keywords:
+            earned = 5
+            evidence.append("The job description had no distinctive keywords to match.")
+        else:
+            matched = [w for w in keywords if w in text_l]
+            missing = [w for w in keywords if w not in text_l]
+            ratio = len(matched) / len(keywords)
+            # Matching 60% of the job's own vocabulary is treated as full marks;
+            # few real resumes echo more than that without keyword-stuffing.
+            earned = CRITERION_MAX * min(1.0, ratio / 0.6)
+            evidence.append(
+                f"Matched {len(matched)} of {len(keywords)} key terms from the "
+                f"job description ({round(ratio * 100)}%)."
+            )
+            if matched:
+                evidence.append("Present: " + ", ".join(matched[:12]) + ".")
+            if missing:
+                evidence.append("Missing: " + ", ".join(missing[:12]) + ".")
+                fixes.append(("Where it is truthful, add these job-description "
+                              "terms: " + ", ".join(missing[:8]) + ".",
+                              min(8, len(missing))))
+    else:
+        verbs = {v for v in _ACTION_VERBS if re.search(rf"\b{v}\b", text_l)}
+        quantified = len(re.findall(r"\d+\s?%|\$\s?\d|\b\d{2,}\b", text_l))
+        skill_items = ctx["skill_items"]
+
+        if len(skill_items) >= 5:
+            earned += 4
+            evidence.append(f"Skills section lists {len(skill_items)} concrete items.")
+        else:
+            evidence.append("Few concrete skills listed for keyword matching.")
+            fixes.append(("List 5-8+ concrete tools/technologies in a Skills "
+                          "section.", 4))
+        if len(verbs) >= 5:
+            earned += 3
+            evidence.append(
+                f"{len(verbs)} distinct action verbs used "
+                f"(e.g. {', '.join(sorted(verbs)[:4])})."
+            )
+        else:
+            fixes.append(("Start bullets with strong action verbs "
+                          "(led, built, reduced, shipped...).", 3))
+        if quantified >= 4:
+            earned += 3
+            evidence.append(f"{quantified} quantified figures detected (numbers, %, $).")
+        else:
+            fixes.append(("Quantify at least 3-4 achievements with numbers, % or $.", 3))
+        evidence.append("No job description supplied - scored on generic "
+                        "keyword-readiness instead.")
+
+    return _criterion(
+        "keywords", "Keyword coverage",
+        "The first ATS filter is almost always a keyword match against the job "
+        "posting. Terms that never appear in your resume cannot be matched.",
+        earned, evidence, fixes,
+    )
+
+
+def _check_tables(ctx) -> Dict[str, Any]:
+    lines = ctx["nonblank_lines"]
+    earned, evidence, fixes = CRITERION_MAX, [], []
+
+    flagged = []
+    for ln in lines:
+        # A tab-flattened table row, or a line split into two blocks by a wide
+        # run of spaces (right-aligned dates, "column A ....... column B").
+        # Pipes are deliberately ignored - "React | Redux | Node" and
+        # "email | phone | site" contact lines are not tables.
+        if ln.count("\t") >= 2 or re.search(r"\S {4,}\S.* {3,}\S", ln):
+            flagged.append(ln.strip())
+
+    if ctx["has_tables"] or ctx["has_columns"]:
+        earned = 2
+        evidence.append("The uploaded document reported tables or multiple columns.")
+        fixes.append(("Rebuild the resume as a single column with no tables.", 8))
+    elif len(flagged) >= 6:
+        earned = 3
+    elif len(flagged) >= 3:
+        earned = 6
+    elif len(flagged) >= 1:
+        earned = 8
+
+    if flagged:
+        evidence.append(
+            f"{len(flagged)} line(s) look column-aligned or tabular, e.g.: "
+            f"\"{flagged[0][:80]}\"."
+        )
+        if not (ctx["has_tables"] or ctx["has_columns"]):
+            fixes.append(("Replace tab/space column alignment with plain lines - "
+                          "parsers read tables out of reading order.",
+                          CRITERION_MAX - earned))
+    else:
+        evidence.append("Layout looks like clean single-column text.")
+
+    return _criterion(
+        "tables_columns", "Tables & multi-column layout",
+        "Many parsers flatten tables and columns left-to-right, interleaving "
+        "unrelated text and scrambling your bullet points.",
+        earned, evidence, fixes,
+    )
+
+
+def _check_length(ctx) -> Dict[str, Any]:
+    words = ctx["word_count"]
+    pages = max(1, round(words / WORDS_PER_PAGE, 1))
+    evidence, fixes = [], []
+
+    if LENGTH_MIN_WORDS <= words <= LENGTH_MAX_WORDS:
+        earned = 10
+        evidence.append(
+            f"{words} words (~{pages} page(s)) - inside the recommended "
+            f"{LENGTH_MIN_WORDS}-{LENGTH_MAX_WORDS} word band."
+        )
+    elif 300 <= words < LENGTH_MIN_WORDS or LENGTH_MAX_WORDS < words <= 1000:
+        earned = 7
+    elif 200 <= words < 300 or 1000 < words <= 1200:
+        earned = 4
+    else:
+        earned = 1
+
+    if words > LENGTH_MAX_WORDS:
+        evidence.append(f"{words} words (~{pages} pages) - longer than most "
+                        f"recruiters and parsers expect.")
+        fixes.append(("Trim toward one page (early career) or two at most; cut "
+                      "older roles to 2-3 bullets.", 10 - earned))
+    elif words < LENGTH_MIN_WORDS:
+        evidence.append(f"Only {words} words - a parser has little to index.")
+        fixes.append(("Expand bullets with responsibilities and quantified "
+                      "impact to reach ~450-650 words.", 10 - earned))
+
+    return _criterion(
+        "length", "Resume length",
+        "Too short and there is nothing to rank on; too long and later "
+        "sections are truncated or skimmed.",
+        earned, evidence, fixes,
+    )
+
+
+def _check_education(ctx) -> Dict[str, Any]:
+    has_heading = "education" in ctx["heading_keys"]
+    body = ctx["education_body"] or ctx["text"]
+    degree = _DEGREE_RE.search(body)
+    earned, evidence, fixes = 0, [], []
+
+    if has_heading:
+        earned += 5
+        evidence.append("An 'Education' section heading is present.")
+    else:
+        evidence.append("No 'Education' heading found.")
+        fixes.append(("Add an 'Education' heading, even if the section is short.", 5))
+    if degree:
+        earned += 5
+        evidence.append(f"Qualification wording detected: '{degree.group(0).strip()}'.")
+    else:
+        evidence.append("No recognisable degree/qualification wording.")
+        fixes.append(("State the qualification explicitly, e.g. 'B.S. in "
+                      "Computer Science, 2020'.", 5))
+
+    return _criterion(
+        "education", "Education section",
+        "Education is a structured field in every ATS; without a labelled "
+        "section and a recognisable qualification it is stored as loose text.",
+        earned, evidence, fixes,
+    )
+
+
+def _check_skills(ctx) -> Dict[str, Any]:
+    has_heading = "skills" in ctx["heading_keys"]
+    items = ctx["skill_items"]
+    earned, evidence, fixes = 0, [], []
+
+    if has_heading:
+        earned += 4
+        evidence.append("A 'Skills' section heading is present.")
+    else:
+        evidence.append("No 'Skills' heading found.")
+        fixes.append(("Add a dedicated 'Skills' section for your tools and "
+                      "technologies.", 4))
+
+    count = len(items)
+    if count >= 8:
+        earned += 6
+        evidence.append(f"{count} distinct skills listed.")
+    elif count >= 4:
+        earned += 3
+        evidence.append(f"Only {count} skills listed.")
+        fixes.append(("List at least 8 concrete, role-relevant skills.", 3))
+    else:
+        evidence.append("Fewer than 4 concrete skills detected.")
+        fixes.append(("List 8+ concrete skills (languages, frameworks, tools), "
+                      "comma- or line-separated.", 6))
+
+    return _criterion(
+        "skills", "Skills section",
+        "The skills list is the densest keyword source on the resume and is "
+        "matched directly against the job's required-skills field.",
+        earned, evidence, fixes,
+    )
+
+
+def _check_text_purity(ctx) -> Dict[str, Any]:
+    text = ctx["text"]
+    words = ctx["word_count"]
+    dense = re.sub(r"\s", "", text)
+    letters = [c for c in text if c.isalpha()]
+    alnum_ratio = (sum(c.isalnum() for c in dense) / len(dense)) if dense else 0.0
+    caps_ratio = (sum(c.isupper() for c in letters) / len(letters)) if letters else 0.0
+    earned, evidence, fixes = CRITERION_MAX, [], []
+
+    if words == 0 or not dense:
+        return _criterion(
+            "text_purity", "Text layer / parseability",
+            "If no text can be extracted, the file is an image and the ATS "
+            "sees a blank application.",
+            0,
+            ["No extractable text at all - the file is probably a scan or image."],
+            [("Export a text-based PDF or DOCX, not a scanned/flattened image.", 10)],
+        )
+
+    if alnum_ratio < 0.55:
+        earned -= 4
+        evidence.append(f"Only {round(alnum_ratio * 100)}% of characters are "
+                        f"letters or digits - a lot of symbols/noise.")
+        fixes.append(("Remove ASCII-art, borders and long symbol runs; keep "
+                      "text and simple bullets.", 4))
+    if caps_ratio > 0.6 and len(letters) > 200:
+        earned -= 3
+        evidence.append(f"{round(caps_ratio * 100)}% of letters are uppercase - "
+                        f"all-caps text parses and reads poorly.")
+        fixes.append(("Use normal sentence/title case instead of ALL CAPS.", 3))
+    if 0 < words < 50:
+        earned -= 3
+        evidence.append(f"Only {words} words of text were extracted.")
+
+    if earned == CRITERION_MAX:
+        evidence.append("Clean text layer - parses as plain, readable text.")
+
+    return _criterion(
+        "text_purity", "Text layer / parseability",
+        "Everything else depends on the ATS being able to read the file as "
+        "ordinary text in the first place.",
+        earned, evidence, fixes,
+    )
+
+
+_CHECKS: Tuple[Callable[[Dict[str, Any]], Dict[str, Any]], ...] = (
+    _check_section_headers,
+    _check_contact_info,
+    _check_dates,
+    _check_encoding,
+    _check_keywords,
+    _check_tables,
+    _check_length,
+    _check_education,
+    _check_skills,
+    _check_text_purity,
+)
+
+
+def _grade(score: int) -> str:
+    if score >= 90:
+        return "A"
+    if score >= 80:
+        return "B"
+    if score >= 70:
+        return "C"
+    if score >= 60:
+        return "D"
+    return "F"
+
+
+def _rating(score: int) -> str:
+    if score >= 90:
+        return "Excellent"
+    if score >= 75:
+        return "Good"
+    if score >= 50:
+        return "Needs work"
+    return "Poor"
+
+
+# Anchor points mapping the 0..100 score to an estimated probability (%) of
+# clearing a typical keyword + parse filter. Values between anchors are linearly
+# interpolated. These are calibrated estimates, not a guarantee - real ATS
+# behaviour varies with each employer's configuration.
+_PASS_RATE_ANCHORS = [
+    (0, 3), (40, 16), (50, 28), (60, 42), (70, 60), (80, 76), (90, 88), (100, 96),
+]
+
+
+def _estimate_pass_rate(score: int) -> int:
+    score = max(0, min(100, score))
+    for (x0, y0), (x1, y1) in zip(_PASS_RATE_ANCHORS, _PASS_RATE_ANCHORS[1:]):
+        if score <= x1:
+            t = (score - x0) / (x1 - x0) if x1 != x0 else 0.0
+            return int(round(y0 + t * (y1 - y0)))
+    return _PASS_RATE_ANCHORS[-1][1]
+
+
+def analyze_ats_compatibility(
+    resume_text: str,
+    job_description: str = "",
+    has_tables: bool = False,
+    has_columns: bool = False,
+) -> Dict[str, Any]:
+    """Run the ten-point ATS compatibility check.
+
+    Args:
+        resume_text: The plain text of the resume.
+        job_description: Optional target job posting. When present, the keyword
+            criterion scores real overlap; when absent it falls back to a
+            generic keyword-readiness heuristic.
+        has_tables / has_columns: Set by the caller when the source document
+            (PDF/DOCX) is known to contain tables or multiple columns.
+
+    Returns:
+        A dict with ``overall_score`` (0..100), ``grade`` (A-F), ``rating``,
+        ``estimated_ats_pass_rate`` (percent), ``word_count``, a ``summary``
+        count of pass/warn/fail criteria, the ten ``criteria`` results in
+        document order, and ``prioritized_fixes`` sorted by impact.
+    """
+    text = resume_text or ""
+    headings = find_headings(text)
+    skills_body = section_body(text, "skills")
+
+    ctx: Dict[str, Any] = {
+        "text": text,
+        "lower": text.lower(),
+        "nonblank_lines": [ln for ln in text.splitlines() if ln.strip()],
+        "word_count": len(text.split()),
+        "heading_keys": [h.key for h in headings],
+        "date_ranges": extract_ranges(text),
+        "weird_chars": _weird_characters(text),
+        "job_description": job_description or "",
+        "has_tables": bool(has_tables),
+        "has_columns": bool(has_columns),
+        "skills_body": skills_body,
+        "skill_items": _split_skill_items(skills_body),
+        "education_body": section_body(text, "education"),
+        "flags": {},
+    }
+
+    criteria = [check(ctx) for check in _CHECKS]
+    overall = sum(c["earned"] for c in criteria)          # 10 x 10 -> 0..100
+    by_id = {c["id"]: c for c in criteria}
+
+    pass_rate = _estimate_pass_rate(overall)
+    # Caps for parser-fatal problems: a great keyword score cannot rescue a
+    # resume the ATS literally cannot read or reply to.
+    if by_id["text_purity"]["earned"] == 0:
+        pass_rate = 0
+    if not ctx["flags"].get("has_email", False):
+        pass_rate = min(pass_rate, 35)
+    if "experience" not in ctx["heading_keys"]:
+        pass_rate = min(pass_rate, 45)
+
+    severity_of = {"fail": "high", "warn": "medium", "pass": "low"}
+    prioritized, seen = [], set()
+    for crit in criteria:
+        if crit["status"] == "pass":
+            continue
+        for fix in crit["fixes"]:
+            key = fix["text"].lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            prioritized.append({
+                "category": crit["label"],
+                "severity": severity_of[crit["status"]],
+                "text": fix["text"],
+                "points": fix["points"],
+            })
+    prioritized.sort(key=lambda f: (f["severity"] != "high", -f["points"]))
+
+    return {
+        "overall_score": overall,
+        "grade": _grade(overall),
+        "rating": _rating(overall),
+        "estimated_ats_pass_rate": pass_rate,
+        "word_count": ctx["word_count"],
+        "summary": {
+            "passed": sum(1 for c in criteria if c["status"] == "pass"),
+            "warnings": sum(1 for c in criteria if c["status"] == "warn"),
+            "failed": sum(1 for c in criteria if c["status"] == "fail"),
+        },
+        "criteria": criteria,
+        "prioritized_fixes": prioritized,
+    }

--- a/backend/analyzer/ats_simulator_views.py
+++ b/backend/analyzer/ats_simulator_views.py
@@ -1,12 +1,12 @@
-from rest_framework import status
+from rest_framework import serializers, status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiExample
 from django.shortcuts import get_object_or_404
 
 from .models import ResumeAnalysis
-from .ats_simulator import get_all_profiles, get_simulator
+from .ats_simulator import get_all_profiles, get_simulator, analyze_ats_compatibility
 
 @extend_schema(
     summary="List available ATS Simulator profiles",
@@ -61,3 +61,75 @@ def simulate_ats(request, analysis_id):
         "analysis_id": analysis.id,
         "simulations": results
     })
+
+
+class AtsCompatibilityRequestSerializer(serializers.Serializer):
+    """Input for the ten-point ATS compatibility check.
+
+    Either ``resume_text`` or ``analysis_id`` must be supplied. ``analysis_id``
+    loads a resume the signed-in user has already analysed, so authentication
+    is required for that path only.
+    """
+
+    resume_text = serializers.CharField(
+        required=False, allow_blank=True, max_length=60000, trim_whitespace=False,
+        help_text="Plain text of the resume to check.",
+    )
+    job_description = serializers.CharField(
+        required=False, allow_blank=True, max_length=20000, default="",
+        trim_whitespace=False,
+        help_text="Optional target job posting; enables real keyword-overlap scoring.",
+    )
+    analysis_id = serializers.IntegerField(
+        required=False,
+        help_text="ID of one of the caller's saved analyses to score instead.",
+    )
+    has_tables = serializers.BooleanField(required=False, default=False)
+    has_columns = serializers.BooleanField(required=False, default=False)
+
+    def validate(self, attrs):
+        if not (attrs.get("resume_text") or "").strip() and not attrs.get("analysis_id"):
+            raise serializers.ValidationError(
+                "Provide 'resume_text' or 'analysis_id'."
+            )
+        return attrs
+
+
+@extend_schema(
+    summary="Ten-point ATS compatibility check",
+    description=(
+        "Scores a resume against ten vendor-neutral ATS parsing criteria "
+        "(headings, contact info, dates, encoding, keywords, tables, length, "
+        "education, skills, text purity) and returns an overall score, letter "
+        "grade, estimated pass rate, per-criterion evidence, and a prioritised "
+        "list of fixes. Public: send `resume_text` with no auth."
+    ),
+    request=AtsCompatibilityRequestSerializer,
+    responses={200: dict, 400: dict, 401: dict, 404: dict},
+)
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def ats_compatibility_check(request):
+    payload = AtsCompatibilityRequestSerializer(data=request.data)
+    payload.is_valid(raise_exception=True)
+    data = payload.validated_data
+
+    resume_text = (data.get("resume_text") or "").strip()
+    if not resume_text and data.get("analysis_id"):
+        if not request.user.is_authenticated:
+            return Response(
+                {"detail": "Sign in to score a saved analysis by id."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        analysis = get_object_or_404(
+            ResumeAnalysis, id=data["analysis_id"], user=request.user
+        )
+        resume_text = analysis.resume_text or ""
+
+    report = analyze_ats_compatibility(
+        resume_text,
+        job_description=data.get("job_description", ""),
+        has_tables=data.get("has_tables", False),
+        has_columns=data.get("has_columns", False),
+    )
+    return Response(report, status=status.HTTP_200_OK)

--- a/backend/analyzer/tests_ats_simulator.py
+++ b/backend/analyzer/tests_ats_simulator.py
@@ -2,7 +2,16 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 from .models import ResumeAnalysis
-from .ats_simulator import PROFILES, WorkdaySimulator, GreenhouseSimulator, TaleoSimulator, extract_contact_info
+from .ats_simulator import (
+    PROFILES,
+    WorkdaySimulator,
+    GreenhouseSimulator,
+    TaleoSimulator,
+    extract_contact_info,
+    analyze_ats_compatibility,
+    _estimate_pass_rate,
+    _grade,
+)
 
 User = get_user_model()
 
@@ -120,3 +129,212 @@ class ATSSimulatorTests(TestCase):
         # User trying to simulate another user's resume should 404
         resp = self.client.get(f"/api/history/{other_analysis.id}/ats-simulate/")
         self.assertEqual(resp.status_code, 404)
+
+
+# A deliberately ATS-friendly resume: standard headings on their own lines,
+# full contact block, consistent month-year dates, a real degree, a long
+# skills list, quantified bullets, ~500 words, plain ASCII.
+STRONG_RESUME = """Jordan Lee
+jordan.lee@example.com  (555) 123-4567  linkedin.com/in/jordanlee  Austin, TX
+
+Summary
+Backend engineer with six years building payment and data platforms. Focused
+on reliability, cost control, and mentoring other engineers.
+
+Work Experience
+Senior Software Engineer, PayGrid
+Mar 2021 - Present
+- Led the migration of the billing service to an event-driven design, which
+  reduced p95 latency by 40 percent and cut infrastructure spend by 30000
+  dollars per year.
+- Built an ingestion pipeline that processes 2000000 events per day with
+  automated back-pressure and replay.
+- Mentored 4 engineers, introduced a code review checklist, and shipped 18
+  production releases without a rollback.
+- Designed and documented 25 REST endpoints now used by every internal team.
+
+Software Engineer, DataForge
+Jun 2018 - Feb 2021
+- Developed and optimized reporting APIs, improving dashboard load time from
+  9 seconds to under 2 seconds for 15000 daily users.
+- Automated the release process with containerized builds, reducing deployment
+  time from 3 hours to 20 minutes.
+- Implemented structured logging and alerting that reduced mean time to
+  detection by 55 percent.
+- Migrated 120 database tables to a partitioned schema with zero downtime.
+
+Education
+B.S. in Computer Science, University of Texas at Austin, 2018
+Relevant coursework: distributed systems, databases, algorithms.
+
+Skills
+Python, Django, Flask, PostgreSQL, Redis, Kafka, RabbitMQ, Docker, Kubernetes,
+Amazon Web Services, Terraform, REST, GraphQL, Continuous Integration,
+Continuous Delivery, Grafana, Prometheus, Git, Linux, pytest
+"""
+
+WEAK_RESUME = (
+    "SEEKING AN OPPORTUNITY WHERE I CAN GROW AND CONTRIBUTE MY BEST WORK. "
+    "I AM A HARD WORKING TEAM PLAYER WITH A PASSION FOR EXCELLENCE. "
+) * 6
+
+
+class ATSCompatibilityCheckerTests(TestCase):
+    """The ten-point vendor-neutral checker (analyze_ats_compatibility)."""
+
+    def setUp(self):
+        self.report = analyze_ats_compatibility(STRONG_RESUME)
+
+    def test_report_shape(self):
+        r = self.report
+        self.assertEqual(len(r["criteria"]), 10)
+        for key in (
+            "overall_score", "grade", "rating",
+            "estimated_ats_pass_rate", "word_count", "summary",
+            "criteria", "prioritized_fixes",
+        ):
+            self.assertIn(key, r)
+        self.assertEqual(
+            r["overall_score"], sum(c["earned"] for c in r["criteria"])
+        )
+        self.assertEqual(
+            r["summary"],
+            {
+                "passed": sum(c["status"] == "pass" for c in r["criteria"]),
+                "warnings": sum(c["status"] == "warn" for c in r["criteria"]),
+                "failed": sum(c["status"] == "fail" for c in r["criteria"]),
+            },
+        )
+
+    def test_every_criterion_is_bounded_and_explained(self):
+        for c in self.report["criteria"]:
+            self.assertLessEqual(c["earned"], c["max"])
+            self.assertGreaterEqual(c["earned"], 0)
+            self.assertEqual(c["max"], 10)
+            self.assertTrue(c["why_it_matters"])
+            self.assertTrue(c["evidence"], f"{c['id']} produced no evidence")
+            self.assertIn(c["status"], {"pass", "warn", "fail"})
+
+    def test_strong_resume_scores_well(self):
+        r = self.report
+        self.assertGreaterEqual(r["overall_score"], 85)
+        self.assertIn(r["grade"], {"A", "B"})
+        self.assertGreaterEqual(r["estimated_ats_pass_rate"], 70)
+        by_id = {c["id"]: c for c in r["criteria"]}
+        for cid in ("section_headers", "contact_info", "education", "skills"):
+            self.assertEqual(by_id[cid]["status"], "pass", cid)
+
+    def test_weak_resume_fails_with_capped_pass_rate(self):
+        r = analyze_ats_compatibility(WEAK_RESUME)
+        self.assertLess(r["overall_score"], 45)
+        self.assertEqual(r["grade"], "F")
+        # No email + no Experience heading -> both caps apply.
+        self.assertLessEqual(r["estimated_ats_pass_rate"], 35)
+        self.assertTrue(r["prioritized_fixes"])
+
+    def test_empty_resume_is_unparseable(self):
+        r = analyze_ats_compatibility("")
+        self.assertEqual(r["estimated_ats_pass_rate"], 0)
+        self.assertEqual(r["grade"], "F")
+        purity = next(c for c in r["criteria"] if c["id"] == "text_purity")
+        self.assertEqual(purity["earned"], 0)
+        self.assertEqual(purity["status"], "fail")
+
+    def test_prioritized_fixes_are_sorted_by_impact(self):
+        r = analyze_ats_compatibility(WEAK_RESUME)
+        fixes = r["prioritized_fixes"]
+        highs = [f for f in fixes if f["severity"] == "high"]
+        # every 'high' fix comes before every non-'high' one
+        self.assertEqual(fixes[: len(highs)], highs)
+        # within the same severity, points are non-increasing
+        pts = [f["points"] for f in highs]
+        self.assertEqual(pts, sorted(pts, reverse=True))
+
+    def test_job_description_drives_keyword_score(self):
+        jd = (
+            "We need a backend engineer strong in Rust, gRPC, ClickHouse and "
+            "Elasticsearch running on Google Cloud with Bazel builds."
+        )
+        without = analyze_ats_compatibility(STRONG_RESUME)
+        with_jd = analyze_ats_compatibility(STRONG_RESUME, job_description=jd)
+        kw_without = next(c for c in without["criteria"] if c["id"] == "keywords")
+        kw_with = next(c for c in with_jd["criteria"] if c["id"] == "keywords")
+        # The resume never mentions those tools, so a JD full of them should
+        # pull the keyword score down relative to the generic heuristic.
+        self.assertLess(kw_with["earned"], kw_without["earned"])
+        self.assertTrue(
+            any("Missing:" in e for e in kw_with["evidence"])
+        )
+
+    def test_table_flag_penalises_layout(self):
+        clean = analyze_ats_compatibility(STRONG_RESUME)
+        flagged = analyze_ats_compatibility(STRONG_RESUME, has_tables=True)
+        clean_tbl = next(c for c in clean["criteria"] if c["id"] == "tables_columns")
+        flagged_tbl = next(c for c in flagged["criteria"] if c["id"] == "tables_columns")
+        self.assertEqual(clean_tbl["status"], "pass")
+        self.assertEqual(flagged_tbl["status"], "fail")
+
+    def test_pass_rate_curve_is_monotonic(self):
+        rates = [_estimate_pass_rate(s) for s in range(0, 101, 10)]
+        self.assertEqual(rates, sorted(rates))
+        self.assertEqual(_estimate_pass_rate(0), 3)
+        self.assertGreaterEqual(_estimate_pass_rate(100), 95)
+
+    def test_grade_boundaries(self):
+        self.assertEqual(_grade(90), "A")
+        self.assertEqual(_grade(89), "B")
+        self.assertEqual(_grade(60), "D")
+        self.assertEqual(_grade(59), "F")
+
+
+class ATSCompatibilityAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_public_check_with_resume_text(self):
+        resp = self.client.post(
+            "/api/ats-compatibility/",
+            {"resume_text": STRONG_RESUME},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data["criteria"]), 10)
+        self.assertIn(resp.data["grade"], {"A", "B", "C", "D", "F"})
+        self.assertIsInstance(resp.data["estimated_ats_pass_rate"], int)
+
+    def test_missing_input_is_rejected(self):
+        resp = self.client.post("/api/ats-compatibility/", {}, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_job_description_is_accepted(self):
+        resp = self.client.post(
+            "/api/ats-compatibility/",
+            {"resume_text": STRONG_RESUME, "job_description": "Python Django AWS"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_analysis_id_requires_authentication(self):
+        resp = self.client.post(
+            "/api/ats-compatibility/",
+            {"analysis_id": 1},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 401)
+
+    def test_authenticated_analysis_id_lookup(self):
+        user = User.objects.create_user(username="atscompat", password="pw12345!")
+        analysis = ResumeAnalysis.objects.create(
+            user=user,
+            file_name="r.pdf",
+            score=80,
+            resume_text=STRONG_RESUME,
+        )
+        self.client.force_authenticate(user=user)
+        resp = self.client.post(
+            "/api/ats-compatibility/",
+            {"analysis_id": analysis.id},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertGreaterEqual(resp.data["overall_score"], 80)

--- a/backend/analyzer/urls.py
+++ b/backend/analyzer/urls.py
@@ -65,7 +65,11 @@ from .accessibility_views import AccessibilityCheckView
 from .cliche_views import ClicheDetectorView
 from .linkedin_views import LinkedInOptimizationView, LinkedInConsistencyView
 from .sanitizer_views import FileMetadataView, SanitizeResumeView
-from .ats_simulator_views import list_ats_profiles, simulate_ats
+from .ats_simulator_views import (
+    list_ats_profiles,
+    simulate_ats,
+    ats_compatibility_check,
+)
 from .cover_letter_views import generate_cover_letter_view
 from .job_board_views import suggest_roles
 from .contributor_views import ContributorCertificateView
@@ -110,6 +114,7 @@ urlpatterns = [
 
     path("ats-simulator/profiles/", list_ats_profiles, name="list_ats_profiles"),
     path("history/<int:analysis_id>/ats-simulate/", simulate_ats, name="simulate_ats"),
+    path("ats-compatibility/", ats_compatibility_check, name="ats_compatibility"),
     path("generate-cover-letter/", generate_cover_letter_view, name="generate_cover_letter"),
 
     path("webhooks/", manage_webhooks, name="manage_webhooks"),

--- a/frontend/src/components/ATSCompatibilityScanner.test.tsx
+++ b/frontend/src/components/ATSCompatibilityScanner.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ATSCompatibilityScanner } from './ATSCompatibilityScanner'
+
+vi.mock('../services/atsCompatibilityApi', () => ({
+  fetchAtsCompatibility: vi.fn(),
+}))
+
+import { fetchAtsCompatibility, type AtsCompatibilityReport } from '../services/atsCompatibilityApi'
+
+const mockedFetch = vi.mocked(fetchAtsCompatibility)
+
+const REPORT: AtsCompatibilityReport = {
+  overall_score: 72,
+  grade: 'C',
+  rating: 'Needs work',
+  estimated_ats_pass_rate: 63,
+  word_count: 410,
+  summary: { passed: 6, warnings: 2, failed: 2 },
+  criteria: [
+    {
+      id: 'section_headers',
+      label: 'Standard section headings',
+      earned: 10,
+      max: 10,
+      status: 'pass',
+      why_it_matters: 'Parsers file content by heading.',
+      evidence: ['Detected headings: Work Experience, Education, Skills.'],
+      fixes: [],
+    },
+    {
+      id: 'contact_info',
+      label: 'Contact information',
+      earned: 4,
+      max: 10,
+      status: 'fail',
+      why_it_matters: 'Recruiters filter on these fields.',
+      evidence: ['No phone number detected.'],
+      fixes: [{ text: 'Add a phone number, e.g. (555) 123-4567.', points: 3 }],
+    },
+  ],
+  prioritized_fixes: [
+    {
+      category: 'Contact information',
+      severity: 'high',
+      text: 'Add a phone number, e.g. (555) 123-4567.',
+      points: 3,
+    },
+  ],
+}
+
+describe('ATSCompatibilityScanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the input form before any analysis', () => {
+    render(<ATSCompatibilityScanner />)
+    expect(screen.getByRole('heading', { name: /ATS Compatibility Checker/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/Resume text/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Analyze resume/i })).toBeInTheDocument()
+  })
+
+  it('validates that some resume text was provided', async () => {
+    const user = userEvent.setup()
+    render(<ATSCompatibilityScanner />)
+    await user.click(screen.getByRole('button', { name: /Analyze resume/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/at least a few lines/i)
+    expect(mockedFetch).not.toHaveBeenCalled()
+  })
+
+  it('calls the API and renders the score, grade, pass rate and a fix', async () => {
+    mockedFetch.mockResolvedValueOnce(REPORT)
+    const user = userEvent.setup()
+    render(<ATSCompatibilityScanner />)
+
+    await user.click(screen.getByRole('button', { name: /Load sample/i }))
+    await user.click(screen.getByRole('button', { name: /Analyze resume/i }))
+
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(1))
+    expect(mockedFetch.mock.calls[0][0].resume_text).toMatch(/Jordan Lee/)
+
+    expect(await screen.findByText('72/100')).toBeInTheDocument()
+    expect(screen.getByText('C')).toBeInTheDocument()
+    expect(screen.getByText('63%')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Priority fixes/i })).toBeInTheDocument()
+    expect(
+      screen.getAllByText(/Add a phone number, e.g. \(555\) 123-4567\./i).length,
+    ).toBeGreaterThan(0)
+    expect(screen.getByText('Standard section headings')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the API call fails', async () => {
+    mockedFetch.mockRejectedValueOnce(new Error('network down'))
+    const user = userEvent.setup()
+    render(<ATSCompatibilityScanner />)
+
+    await user.click(screen.getByRole('button', { name: /Load sample/i }))
+    await user.click(screen.getByRole('button', { name: /Analyze resume/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Could not reach the ATS compatibility service/i)
+  })
+})

--- a/frontend/src/components/ATSCompatibilityScanner.tsx
+++ b/frontend/src/components/ATSCompatibilityScanner.tsx
@@ -1,732 +1,366 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useCallback, useId, useMemo, useState } from 'react'
+import {
+  fetchAtsCompatibility,
+  type AtsCompatibilityReport,
+  type AtsCriterion,
+} from '../services/atsCompatibilityApi'
 
-// ─── Types ──────────────────────────────────────────────────────────────────
+// ─── Presentation helpers ───────────────────────────────────────────────────
 
-type SectionType = 'header' | 'summary' | 'experience' | 'education' | 'skills' | 'projects' | 'certifications' | 'formatting'
-type IssueSeverity = 'critical' | 'warning' | 'info' | 'pass'
-type KeywordStatus = 'found' | 'partial' | 'missing' | 'overused'
-type FileFormat = 'pdf' | 'docx' | 'txt' | 'rtf'
-
-interface ATSSection {
-  type: SectionType
-  title: string
-  score: number
-  maxScore: number
-  issues: ATSIssue[]
-  keywords: ATSKeyword[]
-  suggestions: string[]
-}
-
-interface ATSIssue {
-  id: string
-  severity: IssueSeverity
-  message: string
-  detail: string
-  fix: string
-  impact: number
-}
-
-interface ATSKeyword {
-  word: string
-  status: KeywordStatus
-  frequency: number
-  optimalFrequency: number
-  importance: number
-}
-
-interface ATSReport {
-  overallScore: number
-  sections: ATSSection[]
-  fileFormat: FileFormat
-  fileSize: string
-  wordCount: number
-  pageCount: number
-  parseable: boolean
-  encoding: string
-  fonts: string[]
-  tables: boolean
-  columns: boolean
-  graphics: boolean
-  headers: boolean
-  dateConsistent: boolean
-  contactInfo: boolean
-  linksPresent: boolean
-}
-
-interface ATSCompareSystem {
-  name: string
-  icon: string
-  score: number
-  features: string[]
-  compatibility: string
-}
-
-interface OptimizationTip {
-  category: string
-  icon: string
-  title: string
-  description: string
-  impact: 'high' | 'medium' | 'low'
-  estimatedScoreGain: number
-  effort: 'easy' | 'medium' | 'hard'
-}
-
-interface KeywordSuggestion {
-  keyword: string
-  category: string
-  importance: number
-  currentlyPresent: boolean
-  context: string
-}
-
-// ─── Constants ──────────────────────────────────────────────────────────────
-
-const SECTION_MAP: Record<SectionType, { icon: string; color: string }> = {
-  header:        { icon: '👤', color: '#3b82f6' },
-  summary:       { icon: '📝', color: '#8b5cf6' },
-  experience:    { icon: '💼', color: '#10b981' },
-  education:     { icon: '🎓', color: '#f59e0b' },
-  skills:        { icon: '🛠️', color: '#ef4444' },
-  projects:      { icon: '🚀', color: '#ec4899' },
-  certifications: { icon: '📜', color: '#06b6d4' },
-  formatting:    { icon: '🎨', color: '#6b7280' },
-}
-
-const SEVERITY_MAP: Record<IssueSeverity, { color: string; bg: string; icon: string }> = {
-  critical: { color: '#ef4444', bg: 'rgba(239,68,68,0.1)', icon: '🚨' },
-  warning:  { color: '#f59e0b', bg: 'rgba(245,158,11,0.1)', icon: '⚠️' },
-  info:     { color: '#3b82f6', bg: 'rgba(59,130,246,0.1)', icon: 'ℹ️' },
-  pass:     { color: '#10b981', bg: 'rgba(16,185,129,0.1)', icon: '✅' },
-}
-
-const KEYWORD_STATUS_MAP: Record<KeywordStatus, { color: string; label: string; icon: string }> = {
-  found:   { color: '#10b981', label: 'Found',   icon: '✅' },
-  partial: { color: '#f59e0b', label: 'Partial', icon: '🔍' },
-  missing: { color: '#ef4444', label: 'Missing', icon: '❌' },
-  overused: { color: '#8b5cf6', label: 'Overused', icon: '🔄' },
-}
-
-// ─── Sample Data ────────────────────────────────────────────────────────────
-
-const SAMPLE_REPORT: ATSReport = {
-  overallScore: 74,
-  fileFormat: 'pdf',
-  fileSize: '48KB',
-  wordCount: 687,
-  pageCount: 2,
-  parseable: true,
-  encoding: 'UTF-8',
-  fonts: ['Arial', 'Calibri'],
-  tables: false,
-  columns: false,
-  graphics: true,
-  headers: true,
-  dateConsistent: true,
-  contactInfo: true,
-  linksPresent: false,
-  sections: [
-    {
-      type: 'header', title: 'Contact & Header', score: 90, maxScore: 100,
-      issues: [
-        { id: 'h1', severity: 'pass', message: 'Name is prominent', detail: 'Your name appears as the first element', fix: '', impact: 0 },
-        { id: 'h2', severity: 'pass', message: 'Email present', detail: 'Professional email detected', fix: '', impact: 0 },
-        { id: 'h3', severity: 'pass', message: 'Phone number detected', detail: 'Standard US format found', fix: '', impact: 0 },
-        { id: 'h4', severity: 'warning', message: 'No LinkedIn URL', detail: 'Many recruiters check LinkedIn profiles', fix: 'Add your LinkedIn profile URL', impact: 5 },
-        { id: 'h5', severity: 'info', message: 'No GitHub URL', detail: 'For technical roles, a GitHub link is valuable', fix: 'Consider adding your GitHub profile', impact: 3 },
-      ],
-      keywords: [],
-      suggestions: ['Add LinkedIn URL', 'Add portfolio/website link', 'Consider adding location (city, state)'],
-    },
-    {
-      type: 'summary', title: 'Professional Summary', score: 65, maxScore: 100,
-      issues: [
-        { id: 's1', severity: 'critical', message: 'Summary too short', detail: 'Only 58 words — ATS systems prefer 50-100 words', fix: 'Expand to 75-100 words with more specific achievements', impact: 12 },
-        { id: 's2', severity: 'warning', message: 'Missing target role keyword', detail: '"Senior Frontend Engineer" not found in summary', fix: 'Include your target job title in the first line', impact: 8 },
-        { id: 's3', severity: 'warning', message: 'Quantify achievements', detail: 'Summary mentions "10M+ users" but lacks other metrics', fix: 'Add 2-3 more quantified results (%, $, time)', impact: 6 },
-        { id: 's4', severity: 'info', message: 'No industry keywords', detail: 'Add industry-specific terms for better matching', fix: 'Include terms like "web applications", "scalable", "performance"', impact: 4 },
-      ],
-      keywords: [
-        { word: 'React', status: 'found', frequency: 1, optimalFrequency: 2, importance: 10 },
-        { word: 'TypeScript', status: 'found', frequency: 1, optimalFrequency: 2, importance: 9 },
-        { word: 'Frontend', status: 'found', frequency: 1, optimalFrequency: 2, importance: 10 },
-        { word: 'performance', status: 'missing', frequency: 0, optimalFrequency: 2, importance: 7 },
-        { word: 'scalable', status: 'missing', frequency: 0, optimalFrequency: 1, importance: 6 },
-      ],
-      suggestions: ['Add "Senior Frontend Engineer" as target role', 'Include 2 more quantified achievements', 'Add performance-related keywords'],
-    },
-    {
-      type: 'experience', title: 'Work Experience', score: 82, maxScore: 100,
-      issues: [
-        { id: 'e1', severity: 'pass', message: 'Consistent date format', detail: 'All dates follow same pattern', fix: '', impact: 0 },
-        { id: 'e2', severity: 'pass', message: 'Action verbs detected', detail: 'Strong verbs: Led, Architected, Reduced, Implemented', fix: '', impact: 0 },
-        { id: 'e3', severity: 'warning', message: 'Bullet points too long', detail: '3 bullets exceed 30 words — ATS may truncate', fix: 'Keep bullets under 25 words for ATS readability', impact: 5 },
-        { id: 'e4', severity: 'info', message: 'Add more metrics', detail: '4 of 6 bullets have numbers, aim for all', fix: 'Quantify remaining bullets with specific metrics', impact: 4 },
-      ],
-      keywords: [
-        { word: 'micro-frontend', status: 'found', frequency: 1, optimalFrequency: 1, importance: 8 },
-        { word: 'Turborepo', status: 'found', frequency: 1, optimalFrequency: 1, importance: 6 },
-        { word: 'WebSocket', status: 'found', frequency: 1, optimalFrequency: 1, importance: 7 },
-        { word: 'CI/CD', status: 'missing', frequency: 0, optimalFrequency: 1, importance: 8 },
-        { word: 'agile', status: 'missing', frequency: 0, optimalFrequency: 1, importance: 5 },
-      ],
-      suggestions: ['Shorten long bullets to <25 words', 'Add CI/CD experience mention', 'Quantify all bullet points'],
-    },
-    {
-      type: 'skills', title: 'Skills Section', score: 88, maxScore: 100,
-      issues: [
-        { id: 'sk1', severity: 'pass', message: 'Skills section present', detail: 'Dedicated skills section detected', fix: '', impact: 0 },
-        { id: 'sk2', severity: 'pass', message: 'Good keyword density', detail: '16 relevant skills listed', fix: '', impact: 0 },
-        { id: 'sk3', severity: 'info', message: 'Consider grouping skills', detail: 'Group by category for better readability', fix: 'Organize into Frontend, Backend, DevOps, Tools categories', impact: 2 },
-      ],
-      keywords: [
-        { word: 'React', status: 'found', frequency: 3, optimalFrequency: 2, importance: 10 },
-        { word: 'TypeScript', status: 'found', frequency: 2, optimalFrequency: 2, importance: 9 },
-        { word: 'Node.js', status: 'found', frequency: 1, optimalFrequency: 2, importance: 8 },
-        { word: 'AWS', status: 'found', frequency: 1, optimalFrequency: 2, importance: 9 },
-        { word: 'GraphQL', status: 'found', frequency: 1, optimalFrequency: 1, importance: 7 },
-        { word: 'Kubernetes', status: 'missing', frequency: 0, optimalFrequency: 1, importance: 6 },
-        { word: 'Redis', status: 'missing', frequency: 0, optimalFrequency: 1, importance: 5 },
-      ],
-      suggestions: ['Add Kubernetes if applicable', 'Group skills by category', 'Remove duplicate "React" mentions'],
-    },
-    {
-      type: 'formatting', title: 'Formatting & Structure', score: 70, maxScore: 100,
-      issues: [
-        { id: 'f1', severity: 'warning', message: 'Graphics detected', detail: 'Charts or icons may not be parsed by ATS', fix: 'Remove any graphical elements and use text-only', impact: 8 },
-        { id: 'f2', severity: 'warning', message: 'No links in document', detail: 'No hyperlinks detected — add portfolio/GitHub links', fix: 'Add clickable links to GitHub, LinkedIn, portfolio', impact: 4 },
-        { id: 'f3', severity: 'pass', message: 'Standard fonts used', detail: 'Arial and Calibri are ATS-friendly', fix: '', impact: 0 },
-        { id: 'f4', severity: 'pass', message: 'PDF format', detail: 'PDF is widely supported by ATS systems', fix: '', impact: 0 },
-        { id: 'f5', severity: 'info', message: 'No tables or columns', detail: 'Simple single-column layout is optimal for ATS', fix: '', impact: 0 },
-      ],
-      keywords: [],
-      suggestions: ['Remove graphics/icons if present', 'Add hyperlink URLs to profiles', 'Keep single-column layout'],
-    },
-    {
-      type: 'education', title: 'Education', score: 85, maxScore: 100,
-      issues: [
-        { id: 'ed1', severity: 'pass', message: 'Degree and institution present', detail: 'B.Tech in Computer Science detected', fix: '', impact: 0 },
-        { id: 'ed2', severity: 'info', message: 'Add GPA if 3.5+', detail: 'Strong GPA can help with early-career applications', fix: 'Include GPA if it strengthens your profile', impact: 2 },
-      ],
-      keywords: [],
-      suggestions: ['Add GPA if above 3.5', 'Include relevant coursework if applicable'],
-    },
-  ],
-}
-
-const ATS_SYSTEMS: ATSCompareSystem[] = [
-  { name: 'Taleo', icon: '🏢', score: 85, features: ['Keyword matching', 'Section parsing', 'Date extraction'], compatibility: 'Good' },
-  { name: 'Greenhouse', icon: '🌿', score: 90, features: ['Semantic analysis', 'Skills extraction', 'PDF parsing'], compatibility: 'Excellent' },
-  { name: 'Workday', icon: '📊', score: 78, features: ['Basic parsing', 'Format detection', 'Keyword search'], compatibility: 'Fair' },
-  { name: 'Lever', icon: '🔧', score: 88, features: ['AI matching', 'Resume parsing', 'Custom fields'], compatibility: 'Very Good' },
-  { name: 'iCIMS', icon: '📋', score: 75, features: ['Keyword search', 'Basic formatting', 'Export support'], compatibility: 'Fair' },
-  { name: 'Jobvite', icon: '💼', score: 82, features: ['Talent network', 'Social parsing', 'Mobile-friendly'], compatibility: 'Good' },
-]
-
-const OPTIMIZATION_TIPS: OptimizationTip[] = [
-  { category: 'Keywords', icon: '🔑', title: 'Add Missing Keywords', description: 'Include 5+ missing high-importance keywords from the job description into your summary and skills sections.', impact: 'high', estimatedScoreGain: 12, effort: 'easy' },
-  { category: 'Metrics', icon: '📊', title: 'Quantify All Bullets', description: 'Add specific numbers to all experience bullet points — percentages, dollar amounts, team sizes, timeframes.', impact: 'high', estimatedScoreGain: 10, effort: 'medium' },
-  { category: 'Length', icon: '📏', title: 'Optimize Summary Length', description: 'Expand your professional summary to 75-100 words with targeted keywords and achievements.', impact: 'high', estimatedScoreGain: 8, effort: 'easy' },
-  { category: 'Formatting', icon: '🎨', title: 'Remove Graphics', description: 'Remove any charts, icons, or graphical elements that may confuse ATS parsers.', impact: 'medium', estimatedScoreGain: 6, effort: 'easy' },
-  { category: 'Structure', icon: '📐', title: 'Standard Section Order', description: 'Use the standard order: Header → Summary → Experience → Education → Skills.', impact: 'medium', estimatedScoreGain: 5, effort: 'easy' },
-  { category: 'Links', icon: '🔗', title: 'Add Profile Links', description: 'Include LinkedIn, GitHub, and portfolio URLs in your header section.', impact: 'medium', estimatedScoreGain: 4, effort: 'easy' },
-  { category: 'Dates', icon: '📅', title: 'Consistent Date Format', description: 'Use the same date format throughout — "MMM YYYY" (e.g., "Jan 2024") is most ATS-friendly.', impact: 'low', estimatedScoreGain: 2, effort: 'easy' },
-  { category: 'File', icon: '📄', title: 'Optimize File Name', description: 'Use "FirstName-LastName-Resume.pdf" as the filename for easier tracking.', impact: 'low', estimatedScoreGain: 1, effort: 'easy' },
-]
-
-const KEYWORD_SUGGESTIONS: KeywordSuggestion[] = [
-  { keyword: 'React.js', category: 'Framework', importance: 10, currentlyPresent: true, context: 'Use "React.js" variant in addition to "React"' },
-  { keyword: 'Next.js', category: 'Framework', importance: 9, currentlyPresent: true, context: 'Found in skills, add to summary for emphasis' },
-  { keyword: 'CI/CD', category: 'DevOps', importance: 8, currentlyPresent: false, context: 'Add to experience bullets about deployment' },
-  { keyword: 'agile/scrum', category: 'Methodology', importance: 7, currentlyPresent: false, context: 'Mention sprint/iteration experience' },
-  { keyword: 'microservices', category: 'Architecture', importance: 7, currentlyPresent: false, context: 'Reference in system design experience' },
-  { keyword: 'performance optimization', category: 'Skills', importance: 8, currentlyPresent: false, context: 'Add specific performance achievements' },
-  { keyword: 'cross-functional', category: 'Soft Skills', importance: 6, currentlyPresent: false, context: 'Mention collaboration with design/product' },
-  { keyword: 'technical debt', category: 'Process', importance: 6, currentlyPresent: false, context: 'Show experience reducing tech debt' },
-  { keyword: 'code review', category: 'Process', importance: 5, currentlyPresent: false, context: 'Mention code review leadership' },
-  { keyword: 'accessibility', category: 'Skills', importance: 7, currentlyPresent: false, context: 'Add WCAG/accessibility compliance experience' },
-]
-
-// ─── Utility Functions ──────────────────────────────────────────────────────
-
-function getScoreColor(score: number): string {
-  if (score >= 90) return '#10b981'
-  if (score >= 75) return '#3b82f6'
-  if (score >= 50) return '#f59e0b'
+/** Colour for a 0–100 percentage. */
+function scoreColor(pct: number): string {
+  if (pct >= 90) return '#10b981'
+  if (pct >= 75) return '#3b82f6'
+  if (pct >= 50) return '#f59e0b'
   return '#ef4444'
 }
 
-function getScoreLabel(score: number): string {
-  if (score >= 90) return 'Excellent'
-  if (score >= 75) return 'Good'
-  if (score >= 50) return 'Needs Work'
-  return 'Poor'
+function gradeColor(grade: string): string {
+  return { A: '#10b981', B: '#3b82f6', C: '#f59e0b', D: '#f97316', F: '#ef4444' }[grade] ?? '#94a3b8'
 }
 
-// ─── Main Component ─────────────────────────────────────────────────────────
+const STATUS_META: Record<AtsCriterion['status'], { label: string; color: string; icon: string }> = {
+  pass: { label: 'Pass', color: '#10b981', icon: '✅' },
+  warn: { label: 'Needs work', color: '#f59e0b', icon: '⚠️' },
+  fail: { label: 'Fail', color: '#ef4444', icon: '🚨' },
+}
+
+const SEVERITY_COLOR: Record<'high' | 'medium' | 'low', string> = {
+  high: '#ef4444',
+  medium: '#f59e0b',
+  low: '#3b82f6',
+}
+
+const SAMPLE_RESUME = `Jordan Lee
+jordan.lee@example.com  (555) 123-4567  linkedin.com/in/jordanlee  Austin, TX
+
+Summary
+Backend engineer with six years building payment and data platforms.
+
+Work Experience
+Senior Software Engineer, PayGrid
+Mar 2021 - Present
+- Led the billing service migration to an event-driven design, cutting p95
+  latency by 40 percent and infrastructure spend by 30000 dollars per year.
+- Built an ingestion pipeline processing 2000000 events per day.
+- Mentored 4 engineers and shipped 18 releases with zero rollbacks.
+
+Software Engineer, DataForge
+Jun 2018 - Feb 2021
+- Improved dashboard load time from 9 seconds to under 2 seconds for 15000 users.
+- Automated releases, reducing deploy time from 3 hours to 20 minutes.
+
+Education
+B.S. in Computer Science, University of Texas at Austin, 2018
+
+Skills
+Python, Django, PostgreSQL, Redis, Kafka, Docker, Kubernetes, AWS, Terraform,
+REST, GraphQL, CI/CD, Git, Linux, pytest`
+
+// ─── Sub-components ─────────────────────────────────────────────────────────
+
+function ScoreRing({ score }: { score: number }) {
+  const radius = 52
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference * (1 - Math.max(0, Math.min(100, score)) / 100)
+  const color = scoreColor(score)
+  return (
+    <svg width="128" height="128" viewBox="0 0 128 128" role="img" aria-label={`Overall score ${score} of 100`}>
+      <circle cx="64" cy="64" r={radius} fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth="10" />
+      <circle
+        cx="64"
+        cy="64"
+        r={radius}
+        fill="none"
+        stroke={color}
+        strokeWidth="10"
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        transform="rotate(-90 64 64)"
+      />
+      <text x="64" y="58" textAnchor="middle" fontSize="30" fontWeight="800" fill={color}>
+        {score}
+      </text>
+      <text x="64" y="80" textAnchor="middle" fontSize="12" fill="#94a3b8">
+        / 100
+      </text>
+    </svg>
+  )
+}
+
+function CriterionCard({ criterion }: { criterion: AtsCriterion }) {
+  const pct = Math.round((criterion.earned / criterion.max) * 100)
+  const meta = STATUS_META[criterion.status]
+  return (
+    <div className="ats-card ats-criterion">
+      <div className="ats-criterion-head">
+        <span className="ats-criterion-title">{criterion.label}</span>
+        <span className="ats-chip" style={{ color: meta.color, borderColor: `${meta.color}55`, background: `${meta.color}14` }}>
+          {meta.icon} {meta.label}
+        </span>
+      </div>
+      <div className="ats-criterion-score">
+        <span style={{ color: scoreColor(pct), fontWeight: 800 }}>{criterion.earned}</span>
+        <span className="ats-muted"> / {criterion.max} points</span>
+      </div>
+      <div className="ats-bar">
+        <div className="ats-bar-fill" style={{ width: `${pct}%`, background: scoreColor(pct) }} />
+      </div>
+      <p className="ats-why">{criterion.why_it_matters}</p>
+      {criterion.evidence.length > 0 && (
+        <ul className="ats-list ats-evidence">
+          {criterion.evidence.map((e, i) => (
+            <li key={i}>{e}</li>
+          ))}
+        </ul>
+      )}
+      {criterion.fixes.length > 0 && (
+        <ul className="ats-list ats-fixes">
+          {criterion.fixes.map((f, i) => (
+            <li key={i}>
+              <span className="ats-fix-points">+{f.points}</span> {f.text}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+// ─── Main component ─────────────────────────────────────────────────────────
 
 export function ATSCompatibilityScanner() {
-  const [activeTab, setActiveTab] = useState<'overview' | 'sections' | 'keywords' | 'systems' | 'optimize'>('overview')
-  const [expandedSection, setExpandedSection] = useState<SectionType | null>(null)
-  const [expandedIssue, setExpandedIssue] = useState<string | null>(null)
-  const [filterSeverity, setFilterSeverity] = useState<IssueSeverity | 'all'>('all')
-  const [selectedSystem, setSelectedSystem] = useState<ATSCompareSystem | null>(null)
+  const [resumeText, setResumeText] = useState('')
+  const [jobDescription, setJobDescription] = useState('')
+  const [hasTables, setHasTables] = useState(false)
+  const [hasColumns, setHasColumns] = useState(false)
+  const [report, setReport] = useState<AtsCompatibilityReport | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
-  const report = useMemo(() => SAMPLE_REPORT, [])
+  const resumeFieldId = useId()
+  const jdFieldId = useId()
 
-  const allIssues = useMemo(() => {
-    return report.sections.flatMap(s => s.issues.map(i => ({ ...i, section: s.type })))
+  const analyze = useCallback(async () => {
+    if (resumeText.trim().length < 30) {
+      setError('Paste at least a few lines of resume text to analyze.')
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await fetchAtsCompatibility({
+        resume_text: resumeText,
+        job_description: jobDescription.trim() || undefined,
+        has_tables: hasTables,
+        has_columns: hasColumns,
+      })
+      setReport(result)
+    } catch (err) {
+      setError(
+        'Could not reach the ATS compatibility service. Make sure the backend is running and try again.',
+      )
+      // eslint-disable-next-line no-console
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }, [resumeText, jobDescription, hasTables, hasColumns])
+
+  const summaryTiles = useMemo(() => {
+    if (!report) return []
+    return [
+      { label: 'Overall score', value: `${report.overall_score}/100`, color: scoreColor(report.overall_score) },
+      { label: 'Letter grade', value: report.grade, color: gradeColor(report.grade) },
+      {
+        label: 'Est. ATS pass rate',
+        value: `${report.estimated_ats_pass_rate}%`,
+        color: scoreColor(report.estimated_ats_pass_rate),
+      },
+    ]
   }, [report])
 
-  const filteredIssues = useMemo(() => {
-    if (filterSeverity === 'all') return allIssues
-    return allIssues.filter(i => i.severity === filterSeverity)
-  }, [allIssues, filterSeverity])
-
-  const totalIssues = useMemo(() => ({
-    critical: allIssues.filter(i => i.severity === 'critical').length,
-    warning: allIssues.filter(i => i.severity === 'warning').length,
-    info: allIssues.filter(i => i.severity === 'info').length,
-    pass: allIssues.filter(i => i.severity === 'pass').length,
-    total: allIssues.length,
-  }), [allIssues])
-
-  const potentialScore = useMemo(() => {
-    return Math.min(100, report.overallScore + allIssues.filter(i => i.severity !== 'pass').reduce((s, i) => s + i.impact, 0))
-  }, [report, allIssues])
-
-  const tabs = [
-    { id: 'overview' as const, label: 'Overview', icon: '📊' },
-    { id: 'sections' as const, label: 'Section Analysis', icon: '📋' },
-    { id: 'keywords' as const, label: 'Keywords', icon: '🔑' },
-    { id: 'systems' as const, label: 'ATS Systems', icon: '🤖' },
-    { id: 'optimize' as const, label: 'Optimize', icon: '🚀' },
-  ]
-
-  const cardStyle: React.CSSProperties = {
-    background: 'rgba(255,255,255,0.03)',
-    border: '1px solid rgba(255,255,255,0.06)',
-    borderRadius: '16px',
-    padding: '20px',
-    backdropFilter: 'blur(12px)',
-  }
-
-  const btnStyle = (active: boolean): React.CSSProperties => ({
-    padding: '8px 16px',
-    borderRadius: '10px',
-    border: active ? '1px solid rgba(59,130,246,0.5)' : '1px solid rgba(255,255,255,0.06)',
-    background: active ? 'rgba(59,130,246,0.15)' : 'rgba(255,255,255,0.03)',
-    color: active ? '#3b82f6' : '#94a3b8',
-    cursor: 'pointer',
-    fontSize: '13px',
-    fontWeight: '600',
-    transition: 'all 0.2s',
-  })
-
   return (
-    <div style={{ minHeight: '100vh', background: '#0f172a', color: '#e2e8f0', padding: '24px', fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif' }}>
-      {/* Header */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '24px' }}>
-        <div>
-          <h1 style={{ fontSize: '28px', fontWeight: '800', margin: '0 0 8px', background: 'linear-gradient(135deg, #10b981, #3b82f6)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
-            🤖 ATS Compatibility Scanner
-          </h1>
-          <p style={{ color: '#94a3b8', margin: 0, fontSize: '14px' }}>Ensure your resume passes Applicant Tracking Systems with flying colors</p>
-        </div>
-        <div style={{ textAlign: 'center', padding: '12px 24px', borderRadius: '16px', background: `${getScoreColor(report.overallScore)}15`, border: `2px solid ${getScoreColor(report.overallScore)}40` }}>
-          <div style={{ fontSize: '36px', fontWeight: '900', color: getScoreColor(report.overallScore) }}>{report.overallScore}</div>
-          <div style={{ fontSize: '12px', color: getScoreColor(report.overallScore), fontWeight: '600' }}>{getScoreLabel(report.overallScore)}</div>
-          <div style={{ fontSize: '10px', color: '#94a3b8' }}>ATS Score</div>
-        </div>
-      </div>
+    <div className="ats-root">
+      <style>{STYLES}</style>
 
-      {/* Tab Navigation */}
-      <div style={{ display: 'flex', gap: '8px', marginBottom: '20px', flexWrap: 'wrap' }}>
-        {tabs.map(tab => (
-          <button key={tab.id} style={{ ...btnStyle(activeTab === tab.id), padding: '10px 20px' }} onClick={() => setActiveTab(tab.id)}>
-            {tab.icon} {tab.label}
+      <header className="ats-header">
+        <h1 className="ats-h1">🤖 ATS Compatibility Checker</h1>
+        <p className="ats-sub">
+          Ten vendor-neutral checks against the formatting rules mainstream Applicant Tracking
+          Systems rely on. Every score shows the evidence behind it and the fix worth the most points.
+        </p>
+      </header>
+
+      {/* Input */}
+      <section className="ats-card">
+        <label htmlFor={resumeFieldId} className="ats-label">
+          Resume text
+        </label>
+        <textarea
+          id={resumeFieldId}
+          className="ats-textarea"
+          rows={10}
+          placeholder="Paste the plain text of your resume here…"
+          value={resumeText}
+          onChange={(e) => setResumeText(e.target.value)}
+        />
+
+        <label htmlFor={jdFieldId} className="ats-label">
+          Job description <span className="ats-muted">(optional — enables real keyword matching)</span>
+        </label>
+        <textarea
+          id={jdFieldId}
+          className="ats-textarea"
+          rows={4}
+          placeholder="Paste the target job posting to score keyword overlap…"
+          value={jobDescription}
+          onChange={(e) => setJobDescription(e.target.value)}
+        />
+
+        <div className="ats-controls">
+          <label className="ats-check">
+            <input type="checkbox" checked={hasTables} onChange={(e) => setHasTables(e.target.checked)} />
+            My resume uses tables
+          </label>
+          <label className="ats-check">
+            <input type="checkbox" checked={hasColumns} onChange={(e) => setHasColumns(e.target.checked)} />
+            …or multiple columns
+          </label>
+          <button
+            type="button"
+            className="ats-btn ats-btn-ghost"
+            onClick={() => setResumeText(SAMPLE_RESUME)}
+          >
+            Load sample
           </button>
-        ))}
-      </div>
-
-      {/* ═══ OVERVIEW TAB ═══ */}
-      {activeTab === 'overview' && (
-        <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '20px' }}>
-          {/* Score Breakdown */}
-          <div style={cardStyle}>
-            <h3 style={{ margin: '0 0 16px', fontSize: '16px' }}>📊 Section Score Breakdown</h3>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-              {report.sections.map(section => {
-                const sec = SECTION_MAP[section.type]
-                const scorePct = Math.round((section.score / section.maxScore) * 100)
-                const criticalCount = section.issues.filter(i => i.severity === 'critical').length
-                const warningCount = section.issues.filter(i => i.severity === 'warning').length
-
-                return (
-                  <div key={section.type} style={{ padding: '12px', borderRadius: '10px', background: 'rgba(255,255,255,0.03)', cursor: 'pointer' }}
-                    onClick={() => { setExpandedSection(expandedSection === section.type ? null : section.type); setActiveTab('sections') }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '6px' }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                        <span>{sec.icon}</span>
-                        <span style={{ fontWeight: '600', fontSize: '13px' }}>{section.title}</span>
-                      </div>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                        {criticalCount > 0 && <span style={{ padding: '1px 6px', borderRadius: '4px', background: 'rgba(239,68,68,0.15)', color: '#ef4444', fontSize: '10px' }}>{criticalCount} critical</span>}
-                        {warningCount > 0 && <span style={{ padding: '1px 6px', borderRadius: '4px', background: 'rgba(245,158,11,0.15)', color: '#f59e0b', fontSize: '10px' }}>{warningCount} warnings</span>}
-                        <span style={{ fontSize: '16px', fontWeight: '800', color: getScoreColor(scorePct) }}>{scorePct}%</span>
-                      </div>
-                    </div>
-                    <div style={{ height: '6px', background: 'rgba(255,255,255,0.05)', borderRadius: '3px', overflow: 'hidden' }}>
-                      <div style={{ height: '100%', width: `${scorePct}%`, background: getScoreColor(scorePct), borderRadius: '3px', transition: 'width 0.5s' }} />
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-
-            {/* Potential Score */}
-            <div style={{ marginTop: '16px', padding: '12px', borderRadius: '10px', background: 'rgba(16,185,129,0.08)', border: '1px solid rgba(16,185,129,0.15)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <div>
-                <div style={{ fontSize: '13px', fontWeight: '600', color: '#10b981' }}>📈 Potential Score After Fixes</div>
-                <div style={{ fontSize: '11px', color: '#94a3b8' }}>Address all issues to reach your maximum ATS score</div>
-              </div>
-              <div style={{ fontSize: '28px', fontWeight: '900', color: getScoreColor(potentialScore) }}>{potentialScore}</div>
-            </div>
-          </div>
-
-          {/* Quick Stats */}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-            {/* File Info */}
-            <div style={cardStyle}>
-              <h3 style={{ margin: '0 0 12px', fontSize: '14px' }}>📄 File Information</h3>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                {[
-                  { label: 'Format', value: report.fileFormat.toUpperCase(), color: '#10b981' },
-                  { label: 'Size', value: report.fileSize, color: '#3b82f6' },
-                  { label: 'Words', value: report.wordCount.toString(), color: '#f59e0b' },
-                  { label: 'Pages', value: report.pageCount.toString(), color: '#8b5cf6' },
-                  { label: 'Encoding', value: report.encoding, color: '#ec4899' },
-                  { label: 'Parseable', value: report.parseable ? 'Yes ✓' : 'No ✗', color: report.parseable ? '#10b981' : '#ef4444' },
-                ].map((info, i) => (
-                  <div key={i} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px' }}>
-                    <span style={{ color: '#94a3b8' }}>{info.label}</span>
-                    <span style={{ color: info.color, fontWeight: '600' }}>{info.value}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Issue Summary */}
-            <div style={cardStyle}>
-              <h3 style={{ margin: '0 0 12px', fontSize: '14px' }}>🔍 Issue Summary</h3>
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
-                {[
-                  { label: 'Critical', count: totalIssues.critical, color: '#ef4444' },
-                  { label: 'Warnings', count: totalIssues.warning, color: '#f59e0b' },
-                  { label: 'Info', count: totalIssues.info, color: '#3b82f6' },
-                  { label: 'Passed', count: totalIssues.pass, color: '#10b981' },
-                ].map((stat, i) => (
-                  <div key={i} style={{ textAlign: 'center', padding: '8px', borderRadius: '8px', background: `${stat.color}10` }}>
-                    <div style={{ fontSize: '20px', fontWeight: '800', color: stat.color }}>{stat.count}</div>
-                    <div style={{ fontSize: '10px', color: '#94a3b8' }}>{stat.label}</div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Features Detected */}
-            <div style={cardStyle}>
-              <h3 style={{ margin: '0 0 12px', fontSize: '14px' }}>🏷️ Features Detected</h3>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                {[
-                  { label: 'Standard Fonts', value: report.fonts.join(', '), ok: true },
-                  { label: 'No Tables', value: report.tables ? 'Tables found' : 'Clean layout', ok: !report.tables },
-                  { label: 'Single Column', value: report.columns ? 'Multi-column' : 'Single column', ok: !report.columns },
-                  { label: 'Consistent Dates', value: report.dateConsistent ? 'Yes' : 'Inconsistent', ok: report.dateConsistent },
-                  { label: 'Contact Info', value: report.contactInfo ? 'Present' : 'Missing', ok: report.contactInfo },
-                  { label: 'Profile Links', value: report.linksPresent ? 'Found' : 'Missing', ok: report.linksPresent },
-                ].map((feat, i) => (
-                  <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '11px' }}>
-                    <span style={{ color: '#94a3b8' }}>{feat.label}</span>
-                    <span style={{ color: feat.ok ? '#10b981' : '#f59e0b', fontWeight: '600' }}>{feat.value}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
+          <button type="button" className="ats-btn ats-btn-primary" onClick={analyze} disabled={loading}>
+            {loading ? 'Analyzing…' : 'Analyze resume'}
+          </button>
         </div>
-      )}
 
-      {/* ═══ SECTIONS TAB ═══ */}
-      {activeTab === 'sections' && (
-        <div>
-          {/* Severity Filter */}
-          <div style={{ ...cardStyle, marginBottom: '16px', display: 'flex', gap: '8px', alignItems: 'center' }}>
-            <span style={{ fontSize: '13px', color: '#94a3b8', fontWeight: '600' }}>Filter:</span>
-            {(['all', 'critical', 'warning', 'info', 'pass'] as const).map(s => (
-              <button key={s} style={btnStyle(filterSeverity === s)} onClick={() => setFilterSeverity(s)}>
-                {s === 'all' ? `All (${allIssues.length})` : `${SEVERITY_MAP[s].icon} ${s} (${allIssues.filter(i => i.severity === s).length})`}
-              </button>
-            ))}
-          </div>
+        {error && <p className="ats-error" role="alert">{error}</p>}
+      </section>
 
-          {/* Sections */}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-            {report.sections.map(section => {
-              const sec = SECTION_MAP[section.type]
-              const isExpanded = expandedSection === section.type
-              const sectionIssues = filteredIssues.filter(i => i.section === section.type)
-
-              return (
-                <div key={section.type} style={{ ...cardStyle, border: isExpanded ? `1px solid ${sec.color}30` : '1px solid rgba(255,255,255,0.06)' }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', cursor: 'pointer' }}
-                    onClick={() => setExpandedSection(isExpanded ? null : section.type)}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                      <span style={{ fontSize: '20px' }}>{sec.icon}</span>
-                      <div>
-                        <span style={{ fontWeight: '700', fontSize: '14px' }}>{section.title}</span>
-                        <div style={{ fontSize: '11px', color: '#94a3b8' }}>{sectionIssues.length} issues found</div>
-                      </div>
-                    </div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                      <div style={{ textAlign: 'right' }}>
-                        <div style={{ fontSize: '20px', fontWeight: '800', color: getScoreColor(section.score) }}>{section.score}</div>
-                        <div style={{ fontSize: '10px', color: '#94a3b8' }}>/ {section.maxScore}</div>
-                      </div>
-                      <span style={{ fontSize: '16px', color: '#94a3b8' }}>{isExpanded ? '▼' : '▶'}</span>
-                    </div>
+      {/* Results */}
+      {report && (
+        <>
+          <section className="ats-card ats-summary">
+            <ScoreRing score={report.overall_score} />
+            <div className="ats-summary-tiles">
+              {summaryTiles.map((t) => (
+                <div key={t.label} className="ats-tile">
+                  <div className="ats-tile-value" style={{ color: t.color }}>
+                    {t.value}
                   </div>
-
-                  {isExpanded && (
-                    <div style={{ borderTop: '1px solid rgba(255,255,255,0.06)', marginTop: '12px', paddingTop: '12px' }}>
-                      {/* Issues */}
-                      <div style={{ marginBottom: '12px' }}>
-                        <h4 style={{ margin: '0 0 8px', fontSize: '13px', color: '#94a3b8' }}>Issues:</h4>
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                          {section.issues.map(issue => {
-                            const sev = SEVERITY_MAP[issue.severity]
-                            return (
-                              <div key={issue.id} style={{ padding: '10px', borderRadius: '8px', background: sev.bg, border: `1px solid ${sev.color}20`, cursor: 'pointer' }}
-                                onClick={() => setExpandedIssue(expandedIssue === issue.id ? null : issue.id)}>
-                                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                                    <span>{sev.icon}</span>
-                                    <span style={{ fontSize: '12px', fontWeight: '600', color: sev.color }}>{issue.message}</span>
-                                  </div>
-                                  {issue.impact > 0 && <span style={{ fontSize: '10px', color: '#94a3b8' }}>-{issue.impact}pts</span>}
-                                </div>
-                                {expandedIssue === issue.id && (
-                                  <div style={{ marginTop: '8px', fontSize: '11px', color: '#94a3b8' }}>
-                                    <div style={{ marginBottom: '4px' }}>{issue.detail}</div>
-                                    {issue.fix && <div style={{ color: '#10b981' }}>💡 Fix: {issue.fix}</div>}
-                                  </div>
-                                )}
-                              </div>
-                            )
-                          })}
-                        </div>
-                      </div>
-
-                      {/* Keywords */}
-                      {section.keywords.length > 0 && (
-                        <div style={{ marginBottom: '12px' }}>
-                          <h4 style={{ margin: '0 0 8px', fontSize: '13px', color: '#94a3b8' }}>Keywords:</h4>
-                          <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-                            {section.keywords.map(kw => {
-                              const status = KEYWORD_STATUS_MAP[kw.status]
-                              return (
-                                <span key={kw.word} style={{ padding: '3px 10px', borderRadius: '8px', background: `${status.color}15`, color: status.color, fontSize: '11px', fontWeight: '600', border: `1px solid ${status.color}30` }}>
-                                  {status.icon} {kw.word}
-                                </span>
-                              )
-                            })}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Suggestions */}
-                      <div>
-                        <h4 style={{ margin: '0 0 6px', fontSize: '13px', color: '#10b981' }}>💡 Suggestions:</h4>
-                        {section.suggestions.map((sug, i) => (
-                          <div key={i} style={{ fontSize: '11px', color: '#94a3b8', padding: '2px 0' }}>→ {sug}</div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )
-            })}
-          </div>
-        </div>
-      )}
-
-      {/* ═══ KEYWORDS TAB ═══ */}
-      {activeTab === 'keywords' && (
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px' }}>
-          {/* Found Keywords */}
-          <div style={cardStyle}>
-            <h3 style={{ margin: '0 0 12px', fontSize: '16px' }}>✅ Found Keywords</h3>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-              {KEYWORD_SUGGESTIONS.filter(k => k.currentlyPresent).map(kw => (
-                <div key={kw.keyword} style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '8px 12px', borderRadius: '8px', background: 'rgba(16,185,129,0.06)' }}>
-                  <span style={{ padding: '2px 8px', borderRadius: '6px', background: 'rgba(16,185,129,0.15)', color: '#10b981', fontSize: '10px', fontWeight: '700' }}>✓</span>
-                  <span style={{ flex: 1, fontSize: '13px', fontWeight: '600' }}>{kw.keyword}</span>
-                  <span style={{ padding: '2px 8px', borderRadius: '6px', background: 'rgba(139,92,246,0.1)', color: '#8b5cf6', fontSize: '10px' }}>{kw.category}</span>
-                  <div style={{ display: 'flex', gap: '2px' }}>
-                    {Array.from({ length: 10 }).map((_, i) => (
-                      <div key={i} style={{ width: '4px', height: '12px', borderRadius: '2px', background: i < kw.importance ? '#3b82f6' : 'rgba(255,255,255,0.05)' }} />
-                    ))}
-                  </div>
+                  <div className="ats-tile-label">{t.label}</div>
                 </div>
               ))}
-            </div>
-          </div>
-
-          {/* Missing Keywords */}
-          <div style={cardStyle}>
-            <h3 style={{ margin: '0 0 12px', fontSize: '16px' }}>❌ Missing Keywords</h3>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-              {KEYWORD_SUGGESTIONS.filter(k => !k.currentlyPresent).map(kw => (
-                <div key={kw.keyword} style={{ padding: '10px 12px', borderRadius: '8px', background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.1)' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '4px' }}>
-                    <span style={{ padding: '2px 8px', borderRadius: '6px', background: 'rgba(239,68,68,0.15)', color: '#ef4444', fontSize: '10px', fontWeight: '700' }}>MISSING</span>
-                    <span style={{ fontSize: '13px', fontWeight: '600' }}>{kw.keyword}</span>
-                    <span style={{ padding: '2px 8px', borderRadius: '6px', background: 'rgba(139,92,246,0.1)', color: '#8b5cf6', fontSize: '10px' }}>{kw.category}</span>
-                  </div>
-                  <div style={{ fontSize: '11px', color: '#94a3b8', paddingLeft: '12px' }}>💡 {kw.context}</div>
+              <div className="ats-tile">
+                <div className="ats-tile-value">
+                  <span style={{ color: STATUS_META.pass.color }}>{report.summary.passed}</span>
+                  {' · '}
+                  <span style={{ color: STATUS_META.warn.color }}>{report.summary.warnings}</span>
+                  {' · '}
+                  <span style={{ color: STATUS_META.fail.color }}>{report.summary.failed}</span>
                 </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Keyword Density */}
-          <div style={{ ...cardStyle, gridColumn: 'span 2' }}>
-            <h3 style={{ margin: '0 0 12px', fontSize: '16px' }}>📊 Keyword Match Summary</h3>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '16px' }}>
-              {[
-                { label: 'Found', count: KEYWORD_SUGGESTIONS.filter(k => k.currentlyPresent).length, total: KEYWORD_SUGGESTIONS.length, color: '#10b981', icon: '✅' },
-                { label: 'Missing', count: KEYWORD_SUGGESTIONS.filter(k => !k.currentlyPresent).length, total: KEYWORD_SUGGESTIONS.length, color: '#ef4444', icon: '❌' },
-                { label: 'Match Rate', count: Math.round((KEYWORD_SUGGESTIONS.filter(k => k.currentlyPresent).length / KEYWORD_SUGGESTIONS.length) * 100), total: 100, color: '#3b82f6', icon: '📈', suffix: '%' },
-                { label: 'Impact if Added', count: '+18', total: 0, color: '#f59e0b', icon: '🚀', suffix: 'pts' },
-              ].map((stat, i) => (
-                <div key={i} style={{ textAlign: 'center', padding: '16px', borderRadius: '12px', background: `${stat.color}08`, border: `1px solid ${stat.color}20` }}>
-                  <div style={{ fontSize: '24px', marginBottom: '4px' }}>{stat.icon}</div>
-                  <div style={{ fontSize: '28px', fontWeight: '800', color: stat.color }}>{stat.count}{stat.suffix || ''}</div>
-                  <div style={{ fontSize: '11px', color: '#94a3b8' }}>{stat.label}</div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* ═══ ATS SYSTEMS TAB ═══ */}
-      {activeTab === 'systems' && (
-        <div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '16px', marginBottom: '20px' }}>
-            {ATS_SYSTEMS.map(system => {
-              const isSelected = selectedSystem?.name === system.name
-              return (
-                <div key={system.name} style={{ ...cardStyle, cursor: 'pointer', border: isSelected ? '1px solid rgba(59,130,246,0.4)' : '1px solid rgba(255,255,255,0.06)' }}
-                  onClick={() => setSelectedSystem(isSelected ? null : system)}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '12px' }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                      <span style={{ fontSize: '24px' }}>{system.icon}</span>
-                      <div>
-                        <div style={{ fontWeight: '700', fontSize: '14px' }}>{system.name}</div>
-                        <div style={{ fontSize: '11px', color: getScoreColor(system.score) }}>{system.compatibility}</div>
-                      </div>
-                    </div>
-                    <div style={{ fontSize: '24px', fontWeight: '800', color: getScoreColor(system.score) }}>{system.score}</div>
-                  </div>
-                  <div style={{ height: '6px', background: 'rgba(255,255,255,0.05)', borderRadius: '3px', overflow: 'hidden', marginBottom: '10px' }}>
-                    <div style={{ height: '100%', width: `${system.score}%`, background: getScoreColor(system.score), borderRadius: '3px' }} />
-                  </div>
-                  <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
-                    {system.features.map(f => (
-                      <span key={f} style={{ padding: '2px 8px', borderRadius: '6px', background: 'rgba(255,255,255,0.05)', fontSize: '10px', color: '#94a3b8' }}>{f}</span>
-                    ))}
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-
-          {selectedSystem && (
-            <div style={cardStyle}>
-              <h3 style={{ margin: '0 0 12px', fontSize: '16px' }}>{selectedSystem.icon} {selectedSystem.name} Compatibility Details</h3>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '16px' }}>
-                <div style={{ padding: '12px', borderRadius: '10px', background: 'rgba(16,185,129,0.08)', textAlign: 'center' }}>
-                  <div style={{ fontSize: '24px', fontWeight: '800', color: '#10b981' }}>{selectedSystem.score}%</div>
-                  <div style={{ fontSize: '11px', color: '#94a3b8' }}>Parse Success Rate</div>
-                </div>
-                <div style={{ padding: '12px', borderRadius: '10px', background: 'rgba(59,130,246,0.08)', textAlign: 'center' }}>
-                  <div style={{ fontSize: '24px', fontWeight: '800', color: '#3b82f6' }}>{selectedSystem.features.length}</div>
-                  <div style={{ fontSize: '11px', color: '#94a3b8' }}>Features Detected</div>
-                </div>
-                <div style={{ padding: '12px', borderRadius: '10px', background: 'rgba(245,158,11,0.08)', textAlign: 'center' }}>
-                  <div style={{ fontSize: '14px', fontWeight: '700', color: '#f59e0b' }}>{selectedSystem.compatibility}</div>
-                  <div style={{ fontSize: '11px', color: '#94a3b8' }}>Compatibility Rating</div>
-                </div>
+                <div className="ats-tile-label">pass · warn · fail &nbsp;({report.word_count} words)</div>
               </div>
             </div>
+          </section>
+
+          {report.prioritized_fixes.length > 0 && (
+            <section className="ats-card">
+              <h2 className="ats-h2">🔧 Priority fixes</h2>
+              <ol className="ats-priority">
+                {report.prioritized_fixes.map((fix, i) => (
+                  <li key={i}>
+                    <span
+                      className="ats-dot"
+                      style={{ background: SEVERITY_COLOR[fix.severity] }}
+                      aria-hidden
+                    />
+                    <span className="ats-priority-text">{fix.text}</span>
+                    <span className="ats-fix-points">+{fix.points} pts</span>
+                    <span className="ats-muted ats-priority-cat">{fix.category}</span>
+                  </li>
+                ))}
+              </ol>
+            </section>
           )}
-        </div>
-      )}
 
-      {/* ═══ OPTIMIZE TAB ═══ */}
-      {activeTab === 'optimize' && (
-        <div>
-          <div style={{ ...cardStyle, marginBottom: '20px' }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <div>
-                <h3 style={{ margin: '0 0 4px', fontSize: '16px' }}>🚀 Optimization Roadmap</h3>
-                <div style={{ fontSize: '12px', color: '#94a3b8' }}>Follow these steps in order for maximum impact</div>
-              </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '14px', color: '#94a3b8' }}>Score: <span style={{ fontWeight: '800', color: getScoreColor(report.overallScore) }}>{report.overallScore}</span> → <span style={{ fontWeight: '800', color: getScoreColor(potentialScore) }}>{potentialScore}</span></div>
-                <div style={{ fontSize: '11px', color: '#10b981' }}>+{potentialScore - report.overallScore} points possible</div>
-              </div>
-            </div>
-          </div>
-
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: '16px' }}>
-            {OPTIMIZATION_TIPS.sort((a, b) => {
-              const priorityOrder = { high: 0, medium: 1, low: 2 }
-              return priorityOrder[a.impact] - priorityOrder[b.impact]
-            }).map((tip, i) => (
-              <div key={i} style={{ ...cardStyle, borderTop: `3px solid ${tip.impact === 'high' ? '#ef4444' : tip.impact === 'medium' ? '#f59e0b' : '#3b82f6'}` }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '10px' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                    <span style={{ fontSize: '20px' }}>{tip.icon}</span>
-                    <div>
-                      <div style={{ fontWeight: '700', fontSize: '14px' }}>{tip.title}</div>
-                      <div style={{ fontSize: '10px', color: '#94a3b8' }}>{tip.category}</div>
-                    </div>
-                  </div>
-                  <span style={{ padding: '2px 8px', borderRadius: '6px', background: tip.impact === 'high' ? 'rgba(239,68,68,0.15)' : tip.impact === 'medium' ? 'rgba(245,158,11,0.15)' : 'rgba(59,130,246,0.15)', color: tip.impact === 'high' ? '#ef4444' : tip.impact === 'medium' ? '#f59e0b' : '#3b82f6', fontSize: '10px', fontWeight: '700', textTransform: 'uppercase' }}>
-                    {tip.impact} priority
-                  </span>
-                </div>
-                <p style={{ fontSize: '12px', color: '#94a3b8', lineHeight: '1.5', margin: '0 0 12px' }}>{tip.description}</p>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <div style={{ display: 'flex', gap: '8px' }}>
-                    <span style={{ padding: '2px 8px', borderRadius: '6px', background: 'rgba(16,185,129,0.1)', color: '#10b981', fontSize: '10px', fontWeight: '700' }}>+{tip.estimatedScoreGain} pts</span>
-                    <span style={{ padding: '2px 8px', borderRadius: '6px', background: tip.effort === 'easy' ? 'rgba(16,185,129,0.1)' : tip.effort === 'medium' ? 'rgba(245,158,11,0.1)' : 'rgba(239,68,68,0.1)', color: tip.effort === 'easy' ? '#10b981' : tip.effort === 'medium' ? '#f59e0b' : '#ef4444', fontSize: '10px' }}>
-                      {tip.effort === 'easy' ? '⚡ Easy' : tip.effort === 'medium' ? '🔧 Medium' : '🔨 Hard'}
-                    </span>
-                  </div>
-                  <button style={{ padding: '6px 14px', borderRadius: '8px', background: '#3b82f6', color: '#fff', border: 'none', fontSize: '11px', fontWeight: '600', cursor: 'pointer' }}
-                    onClick={() => alert(`✅ Tip marked as started: ${tip.title}`)}>
-                    Start
-                  </button>
-                </div>
-              </div>
+          <section aria-label="Category results" className="ats-grid">
+            {report.criteria.map((c) => (
+              <CriterionCard key={c.id} criterion={c} />
             ))}
-          </div>
-        </div>
+          </section>
+        </>
       )}
     </div>
   )
 }
 
 export default ATSCompatibilityScanner
+
+// ─── Styles (scoped by the `ats-` prefix, responsive via media queries) ─────
+
+const STYLES = `
+.ats-root { max-width: 1100px; margin: 0 auto; padding: 24px 16px 64px;
+  color: #e2e8f0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+.ats-header { margin-bottom: 20px; }
+.ats-h1 { font-size: 26px; font-weight: 800; margin: 0 0 8px;
+  background: linear-gradient(135deg, #10b981, #3b82f6);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+.ats-h2 { font-size: 16px; margin: 0 0 12px; }
+.ats-sub { color: #94a3b8; font-size: 14px; margin: 0; max-width: 70ch; }
+.ats-card { background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 14px; padding: 18px; margin-bottom: 16px; }
+.ats-label { display: block; font-size: 13px; font-weight: 600; margin: 12px 0 6px; }
+.ats-label:first-child { margin-top: 0; }
+.ats-muted { color: #94a3b8; font-weight: 400; }
+.ats-textarea { width: 100%; box-sizing: border-box; resize: vertical;
+  background: rgba(15,23,42,0.6); border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 10px; color: #e2e8f0; font: inherit; font-size: 13px; padding: 10px; }
+.ats-controls { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-top: 14px; }
+.ats-check { display: flex; align-items: center; gap: 6px; font-size: 12px; color: #cbd5e1; }
+.ats-btn { padding: 9px 18px; border-radius: 10px; font-size: 13px; font-weight: 600;
+  cursor: pointer; border: 1px solid transparent; }
+.ats-btn-primary { background: #3b82f6; color: #fff; }
+.ats-btn-primary:disabled { opacity: 0.6; cursor: default; }
+.ats-btn-ghost { background: rgba(255,255,255,0.05); color: #cbd5e1;
+  border-color: rgba(255,255,255,0.12); }
+.ats-btn-primary { margin-left: auto; }
+.ats-error { color: #fca5a5; font-size: 13px; margin: 12px 0 0; }
+.ats-summary { display: flex; align-items: center; gap: 20px; flex-wrap: wrap; }
+.ats-summary-tiles { display: grid; grid-template-columns: repeat(4, minmax(120px, 1fr));
+  gap: 12px; flex: 1; min-width: 260px; }
+.ats-tile { background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 10px; padding: 12px; text-align: center; }
+.ats-tile-value { font-size: 22px; font-weight: 800; }
+.ats-tile-label { font-size: 11px; color: #94a3b8; margin-top: 4px; }
+.ats-priority { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.ats-priority li { display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  background: rgba(255,255,255,0.03); border-radius: 8px; padding: 10px 12px; font-size: 13px; }
+.ats-dot { width: 10px; height: 10px; border-radius: 50%; flex: none; }
+.ats-priority-text { flex: 1; min-width: 200px; }
+.ats-priority-cat { font-size: 11px; }
+.ats-fix-points { display: inline-block; background: rgba(16,185,129,0.14); color: #10b981;
+  font-size: 11px; font-weight: 700; border-radius: 6px; padding: 1px 7px; }
+.ats-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 14px; }
+.ats-criterion-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
+.ats-criterion-title { font-weight: 700; font-size: 14px; }
+.ats-chip { font-size: 11px; font-weight: 600; border: 1px solid; border-radius: 999px; padding: 2px 9px; white-space: nowrap; }
+.ats-criterion-score { font-size: 13px; margin: 8px 0 6px; }
+.ats-bar { height: 6px; background: rgba(255,255,255,0.06); border-radius: 3px; overflow: hidden; }
+.ats-bar-fill { height: 100%; border-radius: 3px; transition: width .4s ease; }
+.ats-why { font-size: 12px; color: #94a3b8; line-height: 1.5; margin: 10px 0 0; }
+.ats-list { margin: 8px 0 0; padding-left: 18px; font-size: 12px; line-height: 1.55; }
+.ats-evidence li { color: #cbd5e1; }
+.ats-fixes li { color: #86efac; margin-top: 2px; list-style: none; margin-left: -18px; }
+@media (max-width: 720px) {
+  .ats-summary-tiles { grid-template-columns: repeat(2, 1fr); }
+  .ats-grid { grid-template-columns: 1fr; }
+  .ats-btn-primary { margin-left: 0; width: 100%; }
+}
+`

--- a/frontend/src/services/atsCompatibilityApi.ts
+++ b/frontend/src/services/atsCompatibilityApi.ts
@@ -1,0 +1,67 @@
+/**
+ * Client for the ten-point ATS compatibility check.
+ *
+ * Talks to `POST /api/ats-compatibility/` (see
+ * `backend/analyzer/ats_simulator_views.py`). The endpoint is public, so this
+ * works whether or not the visitor is signed in; it still goes through the
+ * shared `api` axios instance so an authenticated session is attached when
+ * one exists.
+ */
+
+import { api } from '../api/client'
+
+/** One of the ten criteria the resume is scored against. */
+export interface AtsCriterion {
+  id: string
+  label: string
+  /** Points awarded, 0..10. */
+  earned: number
+  /** Always 10. */
+  max: number
+  status: 'pass' | 'warn' | 'fail'
+  why_it_matters: string
+  /** Concrete things the checker saw in the resume text. */
+  evidence: string[]
+  fixes: { text: string; points: number }[]
+}
+
+export interface AtsPrioritizedFix {
+  category: string
+  severity: 'high' | 'medium' | 'low'
+  text: string
+  /** Points this fix would recover. */
+  points: number
+}
+
+export interface AtsCompatibilityReport {
+  /** Sum of the ten criteria, 0..100. */
+  overall_score: number
+  /** Letter grade A–F derived from `overall_score`. */
+  grade: string
+  rating: string
+  /** Estimated % chance of clearing a typical ATS filter. */
+  estimated_ats_pass_rate: number
+  word_count: number
+  summary: { passed: number; warnings: number; failed: number }
+  criteria: AtsCriterion[]
+  prioritized_fixes: AtsPrioritizedFix[]
+}
+
+export interface AtsCompatibilityRequest {
+  resume_text: string
+  /** Optional: paste the target job posting to score real keyword overlap. */
+  job_description?: string
+  /** Set when the source document is known to contain tables / columns. */
+  has_tables?: boolean
+  has_columns?: boolean
+}
+
+export async function fetchAtsCompatibility(
+  payload: AtsCompatibilityRequest,
+): Promise<AtsCompatibilityReport> {
+  const res = await api.post<AtsCompatibilityReport>(
+    '/api/ats-compatibility/',
+    payload,
+  )
+  return res.data
+}

--- a/src/services/atsCompatibilityService.test.ts
+++ b/src/services/atsCompatibilityService.test.ts
@@ -1,47 +1,104 @@
-import { analyzeAtsCompatibility } from './atsCompatibilityService';
+import { analyzeAtsCompatibility, estimateAtsPassRate } from './atsCompatibilityService'
 
-describe('AtsCompatibilityService', () => {
-  const sampleResumeText = `
-    Jane Doe
-    Email: jane.doe@example.com | Phone: (555) 123-4567
-    LinkedIn: linkedin.com/in/janedoe | GitHub: github.com/janedoe
+const STRONG_RESUME = `Jordan Lee
+jordan.lee@example.com  (555) 123-4567  linkedin.com/in/jordanlee  Austin, TX
 
-    Work Experience
-    Senior Full Stack Engineer at Tech Corp
-    Architected React and Node.js web applications.
+Summary
+Backend engineer with six years building payment and data platforms.
 
-    Education
-    B.S. Computer Science
+Work Experience
+Senior Software Engineer, PayGrid
+Mar 2021 - Present
+- Led the billing service migration, cutting p95 latency by 40 percent and spend by 30000 dollars per year.
+- Built an ingestion pipeline processing 2000000 events per day.
+- Mentored 4 engineers and shipped 18 releases with zero rollbacks.
+- Designed and documented 25 REST endpoints used by every internal team.
 
-    Skills
-    React, TypeScript, Node.js, PostgreSQL, Docker, AWS
+Software Engineer, DataForge
+Jun 2018 - Feb 2021
+- Improved dashboard load time from 9 seconds to under 2 seconds for 15000 users.
+- Automated releases, reducing deploy time from 3 hours to 20 minutes.
+- Implemented structured logging that reduced mean time to detection by 55 percent.
+- Migrated 120 database tables to a partitioned schema with zero downtime.
 
-    Projects
-    AI Resume Analyzer
+Education
+B.S. in Computer Science, University of Texas at Austin, 2018
 
-    Certifications
-    AWS Certified Solutions Architect
-  `;
+Skills
+Python, Django, Flask, PostgreSQL, Redis, Kafka, Docker, Kubernetes, AWS,
+Terraform, REST, GraphQL, Grafana, Prometheus, Git, Linux, pytest`
 
-  it('analyzes ATS compatibility and contact info correctly', () => {
-    const result = analyzeAtsCompatibility('cand-ats-101', sampleResumeText);
+const WEAK_RESUME =
+  'SEEKING AN OPPORTUNITY WHERE I CAN GROW AND CONTRIBUTE MY BEST WORK. ' +
+  'I AM A HARD WORKING TEAM PLAYER WITH A PASSION FOR EXCELLENCE. '.repeat(6)
 
-    expect(result.candidateId).toBe('cand-ats-101');
-    expect(result.atsCompatibilityScore).toBeGreaterThanOrEqual(85);
-    expect(result.isAtsFriendlyFormat).toBe(true);
-    expect(result.hasContactEmail).toBe(true);
-    expect(result.hasPhone).toBe(true);
-    expect(result.hasLinkedInUrl).toBe(true);
-    expect(result.hasGitHubUrl).toBe(true);
-    expect(result.detectedSectionHeaders.length).toBe(5);
-    expect(result.missingStandardHeaders.length).toBe(0);
-  });
+describe('analyzeAtsCompatibility', () => {
+  it('returns ten fully-explained criteria that sum to the overall score', () => {
+    const r = analyzeAtsCompatibility(STRONG_RESUME)
+    expect(r.criteria).toHaveLength(10)
+    expect(r.overallScore).toBe(r.criteria.reduce((s, c) => s + c.earned, 0))
+    for (const c of r.criteria) {
+      expect(c.max).toBe(10)
+      expect(c.earned).toBeGreaterThanOrEqual(0)
+      expect(c.earned).toBeLessThanOrEqual(10)
+      expect(c.whyItMatters).toBeTruthy()
+      expect(c.evidence.length).toBeGreaterThan(0)
+      expect(['pass', 'warn', 'fail']).toContain(c.status)
+    }
+  })
 
-  it('detects missing contact details and missing sections', () => {
-    const result = analyzeAtsCompatibility('cand-ats-empty', '');
+  it('scores an ATS-friendly resume highly', () => {
+    const r = analyzeAtsCompatibility(STRONG_RESUME)
+    expect(r.overallScore).toBeGreaterThanOrEqual(85)
+    expect(['A', 'B']).toContain(r.grade)
+    expect(r.estimatedAtsPassRate).toBeGreaterThanOrEqual(70)
+  })
 
-    expect(result.atsCompatibilityScore).toBe(0);
-    expect(result.isAtsFriendlyFormat).toBe(false);
-    expect(result.formattingWarnings).toContain('Resume text content is empty.');
-  });
-});
+  it('fails a weak resume and caps its pass rate', () => {
+    const r = analyzeAtsCompatibility(WEAK_RESUME)
+    expect(r.overallScore).toBeLessThan(45)
+    expect(r.grade).toBe('F')
+    // no email + no Experience heading -> both caps apply
+    expect(r.estimatedAtsPassRate).toBeLessThanOrEqual(35)
+    expect(r.prioritizedFixes.length).toBeGreaterThan(0)
+  })
+
+  it('treats an empty resume as unparseable', () => {
+    const r = analyzeAtsCompatibility('')
+    expect(r.estimatedAtsPassRate).toBe(0)
+    expect(r.grade).toBe('F')
+    const purity = r.criteria.find((c) => c.id === 'text_purity')!
+    expect(purity.earned).toBe(0)
+  })
+
+  it('lowers the keyword score when the job description mentions unrelated tools', () => {
+    const jd = 'Backend engineer in Rust, gRPC, ClickHouse, Elasticsearch on Google Cloud with Bazel.'
+    const withJd = analyzeAtsCompatibility(STRONG_RESUME, { jobDescription: jd })
+    const withoutJd = analyzeAtsCompatibility(STRONG_RESUME)
+    const kwWith = withJd.criteria.find((c) => c.id === 'keywords')!
+    const kwWithout = withoutJd.criteria.find((c) => c.id === 'keywords')!
+    expect(kwWith.earned).toBeLessThan(kwWithout.earned)
+  })
+
+  it('flags a table/column layout', () => {
+    const flagged = analyzeAtsCompatibility(STRONG_RESUME, { hasTables: true })
+    const tbl = flagged.criteria.find((c) => c.id === 'tables_columns')!
+    expect(tbl.status).toBe('fail')
+  })
+
+  it('orders prioritized fixes: high severity first, then by points', () => {
+    const fixes = analyzeAtsCompatibility(WEAK_RESUME).prioritizedFixes
+    const highs = fixes.filter((f) => f.severity === 'high')
+    expect(fixes.slice(0, highs.length)).toEqual(highs)
+    expect(highs.map((f) => f.points)).toEqual([...highs.map((f) => f.points)].sort((a, b) => b - a))
+  })
+})
+
+describe('estimateAtsPassRate', () => {
+  it('is monotonic and bounded', () => {
+    const rates = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map(estimateAtsPassRate)
+    expect(rates).toEqual([...rates].sort((a, b) => a - b))
+    expect(estimateAtsPassRate(0)).toBe(3)
+    expect(estimateAtsPassRate(100)).toBeGreaterThanOrEqual(95)
+  })
+})

--- a/src/services/atsCompatibilityService.ts
+++ b/src/services/atsCompatibilityService.ts
@@ -1,114 +1,740 @@
 /**
- * AI Resume Keyword Density & ATS Compatibility Analyzer
- * Analyzes resume content against industry Applicant Tracking System (ATS) parsing rules,
- * section layout conventions, contact information completeness, and keyword frequency.
+ * ATS Compatibility Checker — transparent 10-point analysis.
+ *
+ * This is the browser-side twin of the Django engine in
+ * `backend/analyzer/ats_simulator.py` (`analyze_ats_compatibility`). The backend
+ * is the source of truth used by the dashboard; this module is a dependency-free
+ * reference / offline implementation with the same scoring model and output.
+ *
+ * The point of the rewrite (the previous version did `score = 40; if (email)
+ * score += 15`) is that nothing here is a magic number without a reason next to
+ * it. Every one of the ten criteria reports the points it awarded out of 10, the
+ * evidence it saw, and the fixes worth the most points.
  */
 
-export interface AtsParseResult {
-  candidateId: string;
-  atsCompatibilityScore: number; // 0 - 100
-  isAtsFriendlyFormat: boolean;
-  hasContactEmail: boolean;
-  hasPhone: boolean;
-  hasLinkedInUrl: boolean;
-  hasGitHubUrl: boolean;
-  detectedSectionHeaders: string[];
-  missingStandardHeaders: string[];
-  keywordDensityMap: Record<string, number>;
-  formattingWarnings: string[];
+export type CriterionStatus = 'pass' | 'warn' | 'fail'
+export type FixSeverity = 'high' | 'medium' | 'low'
+
+export interface CriterionResult {
+  id: string
+  label: string
+  earned: number
+  max: 10
+  status: CriterionStatus
+  whyItMatters: string
+  evidence: string[]
+  fixes: { text: string; points: number }[]
 }
 
-export const STANDARD_RESUME_HEADERS = [
-  'Work Experience',
-  'Education',
-  'Skills',
-  'Projects',
-  'Certifications',
-];
+export interface PrioritizedFix {
+  category: string
+  severity: FixSeverity
+  text: string
+  points: number
+}
 
-/**
- * Analyzes raw resume text content for ATS compatibility and layout compliance.
- */
-export function analyzeAtsCompatibility(
-  candidateId: string,
-  rawResumeText: string
-): AtsParseResult {
-  if (!rawResumeText || rawResumeText.trim().length === 0) {
-    return {
-      candidateId,
-      atsCompatibilityScore: 0,
-      isAtsFriendlyFormat: false,
-      hasContactEmail: false,
-      hasPhone: false,
-      hasLinkedInUrl: false,
-      hasGitHubUrl: false,
-      detectedSectionHeaders: [],
-      missingStandardHeaders: STANDARD_RESUME_HEADERS,
-      keywordDensityMap: {},
-      formattingWarnings: ['Resume text content is empty.'],
-    };
+export interface AtsCompatibilityReport {
+  overallScore: number // 0..100 (sum of the ten criteria)
+  grade: string // A..F
+  rating: string
+  estimatedAtsPassRate: number // percent
+  wordCount: number
+  summary: { passed: number; warnings: number; failed: number }
+  criteria: CriterionResult[]
+  prioritizedFixes: PrioritizedFix[]
+}
+
+const CRITERION_MAX = 10
+const CORE_SECTIONS = ['experience', 'education', 'skills'] as const
+const LENGTH_MIN_WORDS = 400
+const LENGTH_MAX_WORDS = 850
+const WORDS_PER_PAGE = 450
+
+const EMAIL_RE = /[\w.+-]+@[\w-]+\.[\w.-]+/
+const PHONE_RE = /(?:\+\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/
+const LINKEDIN_RE = /linkedin\.com\/in\/[\w%-]+/i
+const LOCATION_RE = /\b[A-Z][a-zA-Z.]+,\s*(?:[A-Z]{2}\b|[A-Z][a-z]+\b)/
+const DEGREE_RE =
+  /\b(bachelor|master|associate|doctorate|b\.?\s?s\.?|b\.?\s?a\.?|m\.?\s?s\.?|m\.?\s?a\.?|m\.?\s?b\.?a\.?|ph\.?\s?d|b\.?tech|m\.?tech|b\.?e\.?|b\.?sc|m\.?sc|diploma|degree)\b/i
+const EMOJI_RE = /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}]/u
+
+const SECTION_ALIASES: Record<string, string[]> = {
+  summary: ['summary', 'objective', 'profile', 'about me', 'professional summary'],
+  experience: ['experience', 'work experience', 'employment', 'work history', 'professional experience'],
+  education: ['education', 'academic background', 'qualifications'],
+  skills: ['skills', 'technical skills', 'core competencies', 'technologies', 'tools'],
+  projects: ['projects', 'personal projects', 'portfolio', 'key projects'],
+}
+
+const SECTION_DISPLAY: Record<string, string> = {
+  summary: 'Summary',
+  experience: 'Work Experience',
+  education: 'Education',
+  skills: 'Skills',
+  projects: 'Projects',
+}
+
+const ACTION_VERBS = new Set([
+  'led', 'built', 'designed', 'implemented', 'developed', 'created', 'launched',
+  'managed', 'improved', 'increased', 'reduced', 'optimized', 'delivered',
+  'spearheaded', 'architected', 'migrated', 'automated', 'streamlined',
+  'mentored', 'analyzed', 'deployed', 'integrated', 'refactored', 'established',
+  'coordinated', 'achieved', 'generated', 'drove', 'owned', 'shipped', 'scaled',
+])
+
+const JD_STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'was', 'this', 'that', 'from', 'are', 'you',
+  'your', 'our', 'their', 'its', 'have', 'has', 'will', 'would', 'can', 'not',
+  'job', 'role', 'work', 'team', 'company', 'experience', 'skills', 'ability',
+  'responsibilities', 'requirements', 'preferred', 'plus', 'strong', 'years',
+])
+
+interface Ctx {
+  text: string
+  lower: string
+  lines: string[]
+  wordCount: number
+  headingKeys: string[]
+  skillsBody: string
+  skillItems: string[]
+  educationBody: string
+  jobDescription: string
+  hasTables: boolean
+  hasColumns: boolean
+  hasEmail: boolean
+}
+
+function statusFor(earned: number): CriterionStatus {
+  const pct = earned / CRITERION_MAX
+  if (pct >= 0.8) return 'pass'
+  if (pct >= 0.5) return 'warn'
+  return 'fail'
+}
+
+function criterion(
+  id: string,
+  label: string,
+  whyItMatters: string,
+  earned: number,
+  evidence: string[],
+  fixes: { text: string; points: number }[],
+): CriterionResult {
+  const clamped = Math.max(0, Math.min(CRITERION_MAX, Math.round(earned)))
+  return {
+    id,
+    label,
+    earned: clamped,
+    max: CRITERION_MAX,
+    status: statusFor(clamped),
+    whyItMatters,
+    evidence: evidence.filter(Boolean),
+    fixes: fixes
+      .filter((f) => f.text)
+      .map((f) => ({ text: f.text, points: Math.max(1, Math.round(f.points)) })),
+  }
+}
+
+/** Heading detection: a short line (<= 6 words) that names a known section. */
+function detectHeadingKeys(lines: string[]): string[] {
+  const keys: string[] = []
+  for (const raw of lines) {
+    const line = raw
+      .trim()
+      .replace(/^[#*=_\-\s]+|[#*=_\-:\s]+$/g, '')
+      .toLowerCase()
+    if (!line || line.split(/\s+/).length > 6) continue
+    for (const [key, aliases] of Object.entries(SECTION_ALIASES)) {
+      if (keys.includes(key)) continue
+      if (aliases.some((a) => line === a || line.startsWith(a + ' ') || line.startsWith(a + ','))) {
+        keys.push(key)
+      }
+    }
+  }
+  return keys
+}
+
+function sectionBody(lines: string[], key: string): string {
+  const aliases = SECTION_ALIASES[key] ?? []
+  const isHeading = (line: string) =>
+    Object.values(SECTION_ALIASES).some((al) => al.some((a) => line === a || line.startsWith(a + ' ')))
+
+  let start = -1
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim().toLowerCase().replace(/[:#*=_\s]+$/g, '')
+    if (aliases.some((a) => line === a || line.startsWith(a))) {
+      start = i
+      break
+    }
+  }
+  if (start === -1) return ''
+
+  const collected: string[] = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i].trim().toLowerCase().replace(/[:#*=_\s]+$/g, '')
+    if (isHeading(line)) break
+    collected.push(lines[i])
+  }
+  return collected.join('\n').trim()
+}
+
+function splitSkillItems(body: string): string[] {
+  if (!body) return []
+  const seen = new Set<string>()
+  const items: string[] = []
+  for (const part of body.split(/[,\n;•|·]/)) {
+    const token = part.replace(/^[\s\t\-–—:*•]+|[\s\t\-–—:*•]+$/g, '')
+    if (token.length >= 1 && token.length <= 40 && /[A-Za-z]/.test(token)) {
+      const k = token.toLowerCase()
+      if (!seen.has(k)) {
+        seen.add(k)
+        items.push(token)
+      }
+    }
+  }
+  return items
+}
+
+// ── the ten checks ─────────────────────────────────────────────────────────
+
+function checkSectionHeaders(ctx: Ctx): CriterionResult {
+  let earned = 0
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  const present = CORE_SECTIONS.filter((k) => ctx.headingKeys.includes(k))
+  const missing = CORE_SECTIONS.filter((k) => !ctx.headingKeys.includes(k))
+  earned += 3 * present.length
+  if (ctx.headingKeys.includes('summary') || ctx.headingKeys.includes('projects')) earned += 1
+
+  const detected = ctx.headingKeys.map((k) => SECTION_DISPLAY[k]).filter(Boolean)
+  evidence.push(
+    detected.length
+      ? `Detected headings: ${detected.join(', ')}.`
+      : 'No standard section heading found on its own line.',
+  )
+  for (const k of missing) {
+    evidence.push(`No recognisable '${SECTION_DISPLAY[k]}' heading.`)
+    fixes.push({ text: `Add a plain '${SECTION_DISPLAY[k]}' heading on its own line.`, points: 3 })
+  }
+  return criterion(
+    'section_headers',
+    'Standard section headings',
+    "An ATS files your content into fields by reading headings like 'Work Experience', 'Education' and 'Skills'.",
+    earned,
+    evidence,
+    fixes,
+  )
+}
+
+function checkContactInfo(ctx: Ctx): CriterionResult {
+  let earned = 0
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  const email = ctx.text.match(EMAIL_RE)
+  const phone = ctx.text.match(PHONE_RE)
+  const linkedin = LINKEDIN_RE.test(ctx.text)
+  const location = ctx.text.match(LOCATION_RE)
+  ctx.hasEmail = Boolean(email)
+
+  if (email) {
+    earned += 4
+    evidence.push(`Email found: ${email[0]}`)
+  } else {
+    evidence.push('No email address detected.')
+    fixes.push({ text: 'Put a professional email address in the top few lines.', points: 4 })
+  }
+  if (phone) {
+    earned += 3
+    evidence.push(`Phone number found: ${phone[0]}`)
+  } else {
+    fixes.push({ text: 'Add a phone number, e.g. (555) 123-4567.', points: 3 })
+  }
+  if (linkedin) {
+    earned += 2
+    evidence.push('LinkedIn URL found.')
+  } else {
+    fixes.push({ text: 'Add your LinkedIn URL (linkedin.com/in/...).', points: 2 })
+  }
+  if (location) {
+    earned += 1
+    evidence.push(`Location found: ${location[0]}`)
+  } else {
+    fixes.push({ text: 'Add your city and state/country for location filters.', points: 1 })
+  }
+  return criterion(
+    'contact_info',
+    'Contact information',
+    'Recruiters filter and contact you on these fields; a missing email can make an application unreachable.',
+    earned,
+    evidence,
+    fixes,
+  )
+}
+
+function checkDates(ctx: Ctx): CriterionResult {
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  const rangeRe =
+    /((?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s*\d{4}|\d{1,2}\/\d{4}|\d{4})\s*(?:-|–|—|to|until)\s*((?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s*\d{4}|\d{1,2}\/\d{4}|\d{4}|present|current)/gi
+  const matches = [...ctx.text.matchAll(rangeRe)]
+  let earned = 0
+  if (matches.length >= 1) earned += 4
+  if (matches.length >= 2) earned += 3
+
+  const formatOf = (s: string): string => {
+    const t = s.trim()
+    if (/^\d{4}$/.test(t)) return 'year'
+    if (/^\d{1,2}\/\d{4}$/.test(t)) return 'numeric'
+    return 'month-name'
+  }
+  const formats = new Set<string>()
+  for (const m of matches) {
+    formats.add(formatOf(m[1]))
+    if (!/present|current/i.test(m[2])) formats.add(formatOf(m[2]))
   }
 
-  const text = rawResumeText;
-
-  // Contact checks
-  const hasContactEmail = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/.test(text);
-  const hasPhone = /(\+\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/.test(text);
-  const hasLinkedInUrl = /linkedin\.com\/in\/[a-zA-Z0-9_-]+/i.test(text);
-  const hasGitHubUrl = /github\.com\/[a-zA-Z0-9_-]+/i.test(text);
-
-  // Header detection
-  const detectedHeaders: string[] = [];
-  const missingHeaders: string[] = [];
-
-  for (const header of STANDARD_RESUME_HEADERS) {
-    if (new RegExp(`\\b${header}\\b`, 'i').test(text)) {
-      detectedHeaders.push(header);
+  if (matches.length === 0) {
+    evidence.push('No parseable employment date ranges were found.')
+    fixes.push({ text: "Give every role a month-and-year range, e.g. 'Mar 2021 - Jun 2023'.", points: 7 })
+  } else {
+    evidence.push(`Found ${matches.length} date range(s), e.g. '${matches[0][0].trim()}'.`)
+    if (matches.length < 2) fixes.push({ text: 'List start and end dates for each role.', points: 3 })
+    if (formats.size <= 1) {
+      earned += 3
+      evidence.push('Date formats are consistent.')
     } else {
-      missingHeaders.push(header);
+      evidence.push(`Mixed date formats: ${[...formats].join(', ')}.`)
+      fixes.push({ text: "Use one date format everywhere (e.g. 'Jan 2020').", points: 3 })
     }
   }
+  return criterion(
+    'date_formatting',
+    'Date formatting & consistency',
+    'Parsers build your career timeline from date ranges; missing or mixed formats create gaps and mis-dated roles.',
+    earned,
+    evidence,
+    fixes,
+  )
+}
 
-  // Keyword density map
-  const words = text.toLowerCase().match(/\b[a-z0-9+#.#]{2,}\b/g) || [];
-  const keywordDensityMap: Record<string, number> = {};
-  for (const w of words) {
-    if (w.length >= 3 && !['and', 'the', 'for', 'with', 'was', 'this', 'that'].includes(w)) {
-      keywordDensityMap[w] = (keywordDensityMap[w] || 0) + 1;
+function checkEncoding(ctx: Ctx): CriterionResult {
+  let earned = CRITERION_MAX
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  const emoji = ctx.text.match(new RegExp(EMOJI_RE, 'gu')) ?? []
+  if (emoji.length) {
+    earned -= 3
+    evidence.push(`${emoji.length} emoji / pictograph character(s) found.`)
+    fixes.push({ text: 'Remove emoji and pictographs — parsers often turn them into mojibake.', points: 3 })
+  }
+  const safe = new Set(['‘', '’', '“', '”', '–', '—', '•', '…', ' '])
+  const weird = new Set<string>()
+  for (const ch of ctx.text) {
+    if (ch.charCodeAt(0) < 128 || safe.has(ch)) continue
+    if (/\p{L}/u.test(ch)) continue
+    if (EMOJI_RE.test(ch)) continue
+    weird.add(ch)
+  }
+  if (weird.size) {
+    const penalty = Math.min(6, weird.size * 2)
+    earned -= penalty
+    evidence.push(
+      `${weird.size} unusual symbol type(s): ${[...weird]
+        .slice(0, 6)
+        .map((c) => JSON.stringify(c))
+        .join(', ')}.`,
+    )
+    fixes.push({ text: "Replace decorative symbols and ligatures with plain ASCII ('-', '*').", points: penalty })
+  }
+  if (!emoji.length && !weird.size) evidence.push('No problematic characters — the text is ASCII-clean.')
+  return criterion(
+    'encoding',
+    'Character encoding',
+    'Special glyphs and smart symbols can be dropped or garbled when the ATS re-encodes your file.',
+    earned,
+    evidence,
+    fixes,
+  )
+}
+
+function checkKeywords(ctx: Ctx): CriterionResult {
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  let earned = 0
+  const jd = ctx.jobDescription.trim()
+
+  if (jd) {
+    const counts = new Map<string, number>()
+    for (const w of jd.toLowerCase().match(/[a-z][a-z+#.\-]{2,}/g) ?? []) {
+      if (!JD_STOPWORDS.has(w)) counts.set(w, (counts.get(w) ?? 0) + 1)
+    }
+    const keywords = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 25)
+      .map(([w]) => w)
+    if (keywords.length === 0) {
+      earned = 5
+      evidence.push('The job description had no distinctive keywords to match.')
+    } else {
+      const matched = keywords.filter((w) => ctx.lower.includes(w))
+      const missing = keywords.filter((w) => !ctx.lower.includes(w))
+      const ratio = matched.length / keywords.length
+      earned = CRITERION_MAX * Math.min(1, ratio / 0.6) // 60% overlap = full marks
+      evidence.push(
+        `Matched ${matched.length} of ${keywords.length} key terms from the job description (${Math.round(
+          ratio * 100,
+        )}%).`,
+      )
+      if (matched.length) evidence.push(`Present: ${matched.slice(0, 12).join(', ')}.`)
+      if (missing.length) {
+        evidence.push(`Missing: ${missing.slice(0, 12).join(', ')}.`)
+        fixes.push({
+          text: `Where truthful, add these job-description terms: ${missing.slice(0, 8).join(', ')}.`,
+          points: Math.min(8, missing.length),
+        })
+      }
+    }
+  } else {
+    const verbs = [...ACTION_VERBS].filter((v) => new RegExp(`\\b${v}\\b`).test(ctx.lower))
+    const quantified = (ctx.lower.match(/\d+\s?%|\$\s?\d|\b\d{2,}\b/g) ?? []).length
+    if (ctx.skillItems.length >= 5) {
+      earned += 4
+      evidence.push(`Skills section lists ${ctx.skillItems.length} concrete items.`)
+    } else {
+      fixes.push({ text: 'List 5–8+ concrete tools/technologies in a Skills section.', points: 4 })
+    }
+    if (verbs.length >= 5) {
+      earned += 3
+      evidence.push(`${verbs.length} distinct action verbs used (e.g. ${verbs.slice(0, 4).join(', ')}).`)
+    } else {
+      fixes.push({ text: 'Start bullets with strong action verbs (led, built, reduced, shipped...).', points: 3 })
+    }
+    if (quantified >= 4) {
+      earned += 3
+      evidence.push(`${quantified} quantified figures detected (numbers, %, $).`)
+    } else {
+      fixes.push({ text: 'Quantify at least 3–4 achievements with numbers, % or $.', points: 3 })
+    }
+    evidence.push('No job description supplied — scored on generic keyword-readiness instead.')
+  }
+  return criterion(
+    'keywords',
+    'Keyword coverage',
+    'The first ATS filter is almost always a keyword match against the job posting.',
+    earned,
+    evidence,
+    fixes,
+  )
+}
+
+function checkTables(ctx: Ctx): CriterionResult {
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  let earned = CRITERION_MAX
+  const flagged = ctx.lines.filter(
+    (ln) => (ln.match(/\t/g)?.length ?? 0) >= 2 || /\S {4,}\S.* {3,}\S/.test(ln),
+  )
+  if (ctx.hasTables || ctx.hasColumns) {
+    earned = 2
+    evidence.push('The uploaded document reported tables or multiple columns.')
+    fixes.push({ text: 'Rebuild the resume as a single column with no tables.', points: 8 })
+  } else if (flagged.length >= 6) earned = 3
+  else if (flagged.length >= 3) earned = 6
+  else if (flagged.length >= 1) earned = 8
+
+  if (flagged.length) {
+    evidence.push(
+      `${flagged.length} line(s) look column-aligned or tabular, e.g.: "${flagged[0].trim().slice(0, 80)}".`,
+    )
+    if (!(ctx.hasTables || ctx.hasColumns)) {
+      fixes.push({
+        text: 'Replace tab/space column alignment with plain lines — parsers read tables out of order.',
+        points: CRITERION_MAX - earned,
+      })
+    }
+  } else {
+    evidence.push('Layout looks like clean single-column text.')
+  }
+  return criterion(
+    'tables_columns',
+    'Tables & multi-column layout',
+    'Many parsers flatten tables and columns left-to-right, scrambling your bullet points.',
+    earned,
+    evidence,
+    fixes,
+  )
+}
+
+function checkLength(ctx: Ctx): CriterionResult {
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  const w = ctx.wordCount
+  const pages = Math.max(1, Math.round((w / WORDS_PER_PAGE) * 10) / 10)
+  let earned: number
+  if (w >= LENGTH_MIN_WORDS && w <= LENGTH_MAX_WORDS) {
+    earned = 10
+    evidence.push(
+      `${w} words (~${pages} page(s)) — inside the recommended ${LENGTH_MIN_WORDS}–${LENGTH_MAX_WORDS} word band.`,
+    )
+  } else if ((w >= 300 && w < LENGTH_MIN_WORDS) || (w > LENGTH_MAX_WORDS && w <= 1000)) earned = 7
+  else if ((w >= 200 && w < 300) || (w > 1000 && w <= 1200)) earned = 4
+  else earned = 1
+
+  if (w > LENGTH_MAX_WORDS) {
+    evidence.push(`${w} words (~${pages} pages) — longer than most recruiters and parsers expect.`)
+    fixes.push({
+      text: 'Trim toward one page (early career) or two at most; cut older roles to 2–3 bullets.',
+      points: 10 - earned,
+    })
+  } else if (w < LENGTH_MIN_WORDS) {
+    evidence.push(`Only ${w} words — a parser has little to index.`)
+    fixes.push({
+      text: 'Expand bullets with responsibilities and quantified impact to reach ~450–650 words.',
+      points: 10 - earned,
+    })
+  }
+  return criterion(
+    'length',
+    'Resume length',
+    'Too short and there is nothing to rank on; too long and later sections are truncated.',
+    earned,
+    evidence,
+    fixes,
+  )
+}
+
+function checkEducation(ctx: Ctx): CriterionResult {
+  let earned = 0
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  const hasHeading = ctx.headingKeys.includes('education')
+  const degree = (ctx.educationBody || ctx.text).match(DEGREE_RE)
+  if (hasHeading) {
+    earned += 5
+    evidence.push("An 'Education' section heading is present.")
+  } else {
+    evidence.push("No 'Education' heading found.")
+    fixes.push({ text: "Add an 'Education' heading, even if the section is short.", points: 5 })
+  }
+  if (degree) {
+    earned += 5
+    evidence.push(`Qualification wording detected: '${degree[0].trim()}'.`)
+  } else {
+    evidence.push('No recognisable degree/qualification wording.')
+    fixes.push({ text: "State the qualification explicitly, e.g. 'B.S. in Computer Science, 2020'.", points: 5 })
+  }
+  return criterion(
+    'education',
+    'Education section',
+    'Education is a structured field in every ATS.',
+    earned,
+    evidence,
+    fixes,
+  )
+}
+
+function checkSkills(ctx: Ctx): CriterionResult {
+  let earned = 0
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  const hasHeading = ctx.headingKeys.includes('skills')
+  if (hasHeading) {
+    earned += 4
+    evidence.push("A 'Skills' section heading is present.")
+  } else {
+    evidence.push("No 'Skills' heading found.")
+    fixes.push({ text: "Add a dedicated 'Skills' section for your tools and technologies.", points: 4 })
+  }
+  const n = ctx.skillItems.length
+  if (n >= 8) {
+    earned += 6
+    evidence.push(`${n} distinct skills listed.`)
+  } else if (n >= 4) {
+    earned += 3
+    evidence.push(`Only ${n} skills listed.`)
+    fixes.push({ text: 'List at least 8 concrete, role-relevant skills.', points: 3 })
+  } else {
+    evidence.push('Fewer than 4 concrete skills detected.')
+    fixes.push({
+      text: 'List 8+ concrete skills (languages, frameworks, tools), comma- or line-separated.',
+      points: 6,
+    })
+  }
+  return criterion(
+    'skills',
+    'Skills section',
+    'The skills list is the densest keyword source on the resume.',
+    earned,
+    evidence,
+    fixes,
+  )
+}
+
+function checkTextPurity(ctx: Ctx): CriterionResult {
+  const evidence: string[] = []
+  const fixes: { text: string; points: number }[] = []
+  const dense = ctx.text.replace(/\s/g, '')
+  const letters = ctx.text.match(/\p{L}/gu) ?? []
+  if (ctx.wordCount === 0 || dense.length === 0) {
+    return criterion(
+      'text_purity',
+      'Text layer / parseability',
+      'If no text can be extracted, the file is an image and the ATS sees a blank application.',
+      0,
+      ['No extractable text at all — the file is probably a scan or image.'],
+      [{ text: 'Export a text-based PDF or DOCX, not a scanned/flattened image.', points: 10 }],
+    )
+  }
+  const alnumRatio = (dense.match(/[\p{L}\p{N}]/gu) ?? []).length / dense.length
+  const capsRatio = letters.length ? (ctx.text.match(/\p{Lu}/gu) ?? []).length / letters.length : 0
+  let earned = CRITERION_MAX
+  if (alnumRatio < 0.55) {
+    earned -= 4
+    evidence.push(
+      `Only ${Math.round(alnumRatio * 100)}% of characters are letters or digits — a lot of symbols/noise.`,
+    )
+    fixes.push({ text: 'Remove ASCII-art, borders and long symbol runs; keep text and simple bullets.', points: 4 })
+  }
+  if (capsRatio > 0.6 && letters.length > 200) {
+    earned -= 3
+    evidence.push(`${Math.round(capsRatio * 100)}% of letters are uppercase — all-caps text parses and reads poorly.`)
+    fixes.push({ text: 'Use normal sentence/title case instead of ALL CAPS.', points: 3 })
+  }
+  if (ctx.wordCount > 0 && ctx.wordCount < 50) {
+    earned -= 3
+    evidence.push(`Only ${ctx.wordCount} words of text were extracted.`)
+  }
+  if (earned === CRITERION_MAX) evidence.push('Clean text layer — parses as plain, readable text.')
+  return criterion(
+    'text_purity',
+    'Text layer / parseability',
+    'Everything else depends on the ATS reading the file as ordinary text.',
+    earned,
+    evidence,
+    fixes,
+  )
+}
+
+// ── aggregation ────────────────────────────────────────────────────────────
+
+function gradeFor(score: number): string {
+  if (score >= 90) return 'A'
+  if (score >= 80) return 'B'
+  if (score >= 70) return 'C'
+  if (score >= 60) return 'D'
+  return 'F'
+}
+
+function ratingFor(score: number): string {
+  if (score >= 90) return 'Excellent'
+  if (score >= 75) return 'Good'
+  if (score >= 50) return 'Needs work'
+  return 'Poor'
+}
+
+// Documented anchors: score -> estimated % chance of clearing a typical
+// keyword + parse filter. Linearly interpolated between anchors.
+const PASS_RATE_ANCHORS: [number, number][] = [
+  [0, 3],
+  [40, 16],
+  [50, 28],
+  [60, 42],
+  [70, 60],
+  [80, 76],
+  [90, 88],
+  [100, 96],
+]
+
+export function estimateAtsPassRate(score: number): number {
+  const s = Math.max(0, Math.min(100, score))
+  for (let i = 0; i < PASS_RATE_ANCHORS.length - 1; i++) {
+    const [x0, y0] = PASS_RATE_ANCHORS[i]
+    const [x1, y1] = PASS_RATE_ANCHORS[i + 1]
+    if (s <= x1) {
+      const t = x1 === x0 ? 0 : (s - x0) / (x1 - x0)
+      return Math.round(y0 + t * (y1 - y0))
     }
   }
+  return PASS_RATE_ANCHORS[PASS_RATE_ANCHORS.length - 1][1]
+}
 
-  // Warnings
-  const warnings: string[] = [];
-  if (!hasContactEmail) warnings.push('Missing valid contact email address.');
-  if (!hasPhone) warnings.push('Missing phone number.');
-  if (!hasLinkedInUrl) warnings.push('Missing LinkedIn profile URL.');
-  if (!hasGitHubUrl) warnings.push('Missing GitHub profile link for tech evaluation.');
-  if (missingHeaders.length > 0) {
-    warnings.push(`Missing standard section headers: ${missingHeaders.join(', ')}.`);
+export interface AnalyzeOptions {
+  jobDescription?: string
+  hasTables?: boolean
+  hasColumns?: boolean
+}
+
+export function analyzeAtsCompatibility(
+  resumeText: string,
+  options: AnalyzeOptions = {},
+): AtsCompatibilityReport {
+  const text = resumeText ?? ''
+  const lines = text.split('\n')
+  const words = text.split(/\s+/).filter(Boolean)
+  const skillsBody = sectionBody(lines, 'skills')
+  const ctx: Ctx = {
+    text,
+    lower: text.toLowerCase(),
+    lines,
+    wordCount: words.length,
+    headingKeys: detectHeadingKeys(lines),
+    skillsBody,
+    skillItems: splitSkillItems(skillsBody),
+    educationBody: sectionBody(lines, 'education'),
+    jobDescription: options.jobDescription ?? '',
+    hasTables: Boolean(options.hasTables),
+    hasColumns: Boolean(options.hasColumns),
+    hasEmail: false,
   }
 
-  // Score computation
-  let score = 40;
-  if (hasContactEmail) score += 15;
-  if (hasPhone) score += 10;
-  if (hasLinkedInUrl) score += 10;
-  if (hasGitHubUrl) score += 10;
-  score += detectedHeaders.length * 3;
+  const criteria = [
+    checkSectionHeaders(ctx),
+    checkContactInfo(ctx),
+    checkDates(ctx),
+    checkEncoding(ctx),
+    checkKeywords(ctx),
+    checkTables(ctx),
+    checkLength(ctx),
+    checkEducation(ctx),
+    checkSkills(ctx),
+    checkTextPurity(ctx),
+  ]
 
-  score = Math.min(100, Math.max(0, score));
+  const overallScore = criteria.reduce((sum, c) => sum + c.earned, 0)
+  const byId = Object.fromEntries(criteria.map((c) => [c.id, c]))
+
+  let passRate = estimateAtsPassRate(overallScore)
+  if (byId.text_purity.earned === 0) passRate = 0
+  if (!ctx.hasEmail) passRate = Math.min(passRate, 35)
+  if (!ctx.headingKeys.includes('experience')) passRate = Math.min(passRate, 45)
+
+  const severityOf: Record<CriterionStatus, FixSeverity> = { fail: 'high', warn: 'medium', pass: 'low' }
+  const prioritizedFixes: PrioritizedFix[] = []
+  const seen = new Set<string>()
+  for (const c of criteria) {
+    if (c.status === 'pass') continue
+    for (const fix of c.fixes) {
+      const key = fix.text.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      prioritizedFixes.push({ category: c.label, severity: severityOf[c.status], text: fix.text, points: fix.points })
+    }
+  }
+  prioritizedFixes.sort(
+    (a, b) => (a.severity === 'high' ? 0 : 1) - (b.severity === 'high' ? 0 : 1) || b.points - a.points,
+  )
 
   return {
-    candidateId,
-    atsCompatibilityScore: score,
-    isAtsFriendlyFormat: score >= 75,
-    hasContactEmail,
-    hasPhone,
-    hasLinkedInUrl,
-    hasGitHubUrl,
-    detectedSectionHeaders: detectedHeaders,
-    missingStandardHeaders: missingHeaders,
-    keywordDensityMap,
-    formattingWarnings: warnings,
-  };
+    overallScore,
+    grade: gradeFor(overallScore),
+    rating: ratingFor(overallScore),
+    estimatedAtsPassRate: passRate,
+    wordCount: ctx.wordCount,
+    summary: {
+      passed: criteria.filter((c) => c.status === 'pass').length,
+      warnings: criteria.filter((c) => c.status === 'warn').length,
+      failed: criteria.filter((c) => c.status === 'fail').length,
+    },
+    criteria,
+    prioritizedFixes,
+  }
 }


### PR DESCRIPTION
closes #1120
 Adds a vendor-neutral 10-point ATS compatibility checker. Scores a resume on section headings, contact info, dates, encoding, keywords, tables, length, education, skills, and text purity — each worth 10 points, each returning the evidence it matched, why it matters, and point-valued fixes. Sum = 0–100 → letter grade → documented estimated pass rate (capped when no text / no email / no experience heading).

Backend: analyze_ats_compatibility() in ats_simulator.py; POST /api/ats-compatibility/ (public) in ats_simulator_views.py; route in urls.py; tests in tests_ats_simulator.py.
Frontend: real responsive dashboard in ATSCompatibilityScanner.tsx (was a hardcoded mock) + atsCompatibilityApi.ts client + ATSCompatibilityScanner.test.tsx (4/4 pass). src/services/atsCompatibilityService.ts rewritten from magic-number scoring to a transparent twin (8/8 pass).
Note: main has pre-existing unrelated breakage (SignupAbuseEvent, compare_bulk_resumes_view, migration leaves) that blocks the full backend suite — rebase onto current main before merge.

Tech / where things are:

Django REST Framework — engine backend/analyzer/ats_simulator.py, view ats_simulator_views.py, URL urls.py → POST /api/ats-compatibility/.
React 19 + Vite + Vitest — dashboard frontend/src/components/ATSCompatibilityScanner.tsx (route /ats-scanner), client frontend/src/services/atsCompatibilityApi.ts.
Flow: browser → POST /api/ats-compatibility/ {resume_text} → serializer validates → analyze_ats_compatibility() runs 10 checks → JSON {overall_score, grade, estimated_ats_pass_rate, criteria[], prioritized_fixes[]} → dashboard renders it.